### PR TITLE
Replace '__gmp_const' with 'const'

### DIFF
--- a/runtime/gc/int-inf.c
+++ b/runtime/gc/int-inf.c
@@ -181,8 +181,8 @@ objptr finiIntInfRes (GC_state s, __mpz_struct *res, size_t bytes) {
 
 static inline objptr binary (objptr lhs, objptr rhs, size_t bytes,
                              void(*binop)(__mpz_struct *resmpz,
-                                          __gmp_const __mpz_struct *lhsspace,
-                                          __gmp_const __mpz_struct *rhsspace)) {
+                                          const __mpz_struct *lhsspace,
+                                          const __mpz_struct *rhsspace)) {
   __mpz_struct lhsmpz, rhsmpz, resmpz;
   mp_limb_t lhsspace[LIMBS_PER_OBJPTR + 1], rhsspace[LIMBS_PER_OBJPTR + 1];
 
@@ -258,7 +258,7 @@ objptr IntInf_xorb (objptr lhs, objptr rhs, size_t bytes) {
 
 static objptr unary (objptr arg, size_t bytes,
                      void(*unop)(__mpz_struct *resmpz,
-                                 __gmp_const __mpz_struct *argspace)) {
+                                 const __mpz_struct *argspace)) {
   __mpz_struct argmpz, resmpz;
  mp_limb_t argspace[LIMBS_PER_OBJPTR + 1];
 
@@ -284,7 +284,7 @@ objptr IntInf_notb (objptr arg, size_t bytes) {
 
 static objptr shary (objptr arg, Word32_t shift, size_t bytes,
                      void(*shop)(__mpz_struct *resmpz,
-                                 __gmp_const __mpz_struct *argspace,
+                                 const __mpz_struct *argspace,
                                  unsigned long shift))
 {
   __mpz_struct argmpz, resmpz;


### PR DESCRIPTION
The __gmp_const macro was added to GMP as a workaround for C compilers
which didn't support the const keyword.  GMP 5.1 removed support for
pre-ANSI C compilers, so the __gmp_const workaround was removed at the
same time.

This change replaces all uses of '__gmp_const' with uses of the 'const'
keyword directly, since MLton already expects C99 support from the system
C compiler.

This should fix the build errors for systems using GMP >= 5.1, as reported in https://github.com/MLton/mlton/issues/3.

Tested on amd64-freebsd (with GMP 5.1.1) and x86-linux (with GMP 5.0.2).
