### PR TITLE
Detect "ppc64" for `uname -m` as "powerpc64" architecture.

### DIFF
--- a/bin/platform
+++ b/bin/platform
@@ -112,6 +112,9 @@ mips*)
 powerpc64)
 	HOST_ARCH=powerpc64
 ;;
+ppc64)
+        HOST_ARCH=powerpc64
+;;
 powerpc)
         HOST_ARCH=powerpc
 ;;


### PR DESCRIPTION
Fixes #5.
