### PR TITLE
Make sure that temp file names don't already exist

### DIFF
--- a/lib/stubs/mlton-stubs/mlton.sml
+++ b/lib/stubs/mlton-stubs/mlton.sml
@@ -18,7 +18,11 @@ functor MkIO (S : sig
       fun mkstemps {prefix, suffix} =
          let
             val name = concat [prefix, MLtonRandom.alphaNumString 6, suffix]
-         in (name, openOut name)
+         in
+            (* Make sure the temporary file name doesn't already exist. *)
+            if OS.FileSys.access (name, [])
+                then mkstemps {prefix = prefix, suffix = suffix}
+                else (name, openOut name)
          end
       fun mkstemp s = mkstemps {prefix = s, suffix = ""}
       fun newIn _ = raise Fail "IO.newIn"


### PR DESCRIPTION
When running a build of MLton that uses the mlton-stubs library,
generated file names weren't checked to see if they already existed.
This only affected the first build of MLton, so the error would manifest
when generating c and assembly files.  In particular, it could happen if
you were building the tools in parallel or building two versions of
MLton from seperate directories at the same time.

Furthermore, the mlton-stubs library uses a hard-coded seed for the
random number generator, so the temorary files had the exact same names
between all running instances of MLton.  So when running parallel
builds, the instance that finished first would delete portions of the
other instances' temporary files and those builds would fail.
