### PR TITLE
Preserve types in RSSA to Machine translation of bogus operands.

### DIFF
--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2013 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -441,8 +441,16 @@ let
       end
       fun bogusOp (t: Type.t): M.Operand.t =
          case Type.deReal t of
-            NONE => M.Operand.Word (WordX.fromIntInf
-                                    (0, WordSize.fromBits (Type.width t)))
+            NONE => let
+                       val bogusWord =
+                          M.Operand.Word
+                          (WordX.zero
+                           (WordSize.fromBits (Type.width t)))
+                    in
+                       case Type.deWord t of
+                          NONE => M.Operand.Cast (bogusWord, t)
+                        | SOME _ => bogusWord
+                    end
           | SOME s => globalReal (RealX.zero s)
       fun constOperand (c: Const.t): M.Operand.t =
          let


### PR DESCRIPTION
An RSSA Offset operand with a non-location base is translated to a
dummy Machine Offset; in particular, to a zero Word of the appropriate
size.  However, this can lead to a Machine program with a statement
like the following:
    SP(24): Objptr (opt_3)  = 0x0
Although this only arises in dead-code, a codegen that targets a
language with a static type system (like an in-progress LLVM codegen)
may dislike the treatment of a word as a pointer.

When introducing a bogus operand, use a Cast operand to preserve the
expected type of the operand.
