### PR TITLE
Fixed the MLton guide's example for Lazy.

### DIFF
--- a/doc/guide/txt/Lazy.txt
+++ b/doc/guide/txt/Lazy.txt
@@ -29,18 +29,23 @@ structure Lazy: LAZY =
    struct
       fun lazy (th: unit -> 'a): unit -> 'a =
          let
-            val r: 'a option ref = ref NONE
+            datatype 'a lazy_result = Unevaluated of (unit -> 'a)
+                                    | Evaluated of 'a
+                                    | Failed of exn
+            
+            val r = ref (Unevaluated th)
          in
             fn () =>
-            case !r of
-               NONE =>
-                  let
-                     val a = th ()
-                     val () = r := SOME a
-                  in
-                     a
-                  end
-             | SOME a => a
+               case !r of
+                   Unevaluated th => let
+                                       val a  = th ()
+                                           handle x => (r := Failed x; raise x)
+                                       val () =         r := Evaluated a
+                                     in
+                                       a
+                                     end
+                 | Evaluated a => a
+                 | Failed x    => raise x
          end
    end
 ----


### PR DESCRIPTION
MLton would otherwise leak memory for the original example, since the thunk parameter (`th`)
is unnecessarily held in the returned function's closure after evaluation.

Additionally, if the `th` parameter raises an exception, the returned function only
raises that same exception from that point on, rather than re-running `th`.
