### PR TITLE
Update the broken links in the guide, standardml.org -> sml-family.org

### DIFF
--- a/doc/guide/src/BasisLibrary.adoc
+++ b/doc/guide/src/BasisLibrary.adoc
@@ -6,11 +6,11 @@ The <:StandardML:Standard ML> Basis Library is a collection of modules
 dealing with basic types, input/output, OS interfaces, and simple
 datatypes.  It is intended as a portable library usable across all
 implementations of SML.  For the official online version of the Basis
-Library specification, see http://www.standardml.org/Basis.
+Library specification, see http://www.sml-family.org/Basis.
 <!Cite(GansnerReppy04, The Standard ML Basis Library)> is a book
 version that includes all of the online version and more.  For a
 reverse chronological list of changes to the specification, see
-http://www.standardml.org/Basis/history.html.
+http://www.sml-family.org/Basis/history.html.
 
 MLton implements all of the required portions of the Basis Library.
 MLton also implements many of the optional structures.  You can obtain

--- a/doc/guide/src/Bugs20051202.adoc
+++ b/doc/guide/src/Bugs20051202.adoc
@@ -5,7 +5,7 @@ Here are the known bugs in <:Release20051202:MLton 20051202>, listed
 in reverse chronological order of date reported.
 
 * <!Anchor(bug16)>
-Bug in the http://www.standardml.org/Basis/real.html#SIG:REAL.fmt:VAL[++Real__<N>__.fmt++], http://www.standardml.org/Basis/real.html#SIG:REAL.fromString:VAL[++Real__<N>__.fromString++], http://www.standardml.org/Basis/real.html#SIG:REAL.scan:VAL[++Real__<N>__.scan++], and http://www.standardml.org/Basis/real.html#SIG:REAL.toString:VAL[++Real__<N>__.toString++] functions of the <:BasisLibrary:Basis Library> implementation.  These functions were using `TO_NEAREST` semantics, but should obey the current rounding mode.  (Only ++Real__<N>__.fmt StringCvt.EXACT++, ++Real__<N>__.fromDecimal++, and ++Real__<N>__.toDecimal++ are specified to override the current rounding mode with `TO_NEAREST` semantics.)
+Bug in the http://www.sml-family.org/Basis/real.html#SIG:REAL.fmt:VAL[++Real__<N>__.fmt++], http://www.sml-family.org/Basis/real.html#SIG:REAL.fromString:VAL[++Real__<N>__.fromString++], http://www.sml-family.org/Basis/real.html#SIG:REAL.scan:VAL[++Real__<N>__.scan++], and http://www.sml-family.org/Basis/real.html#SIG:REAL.toString:VAL[++Real__<N>__.toString++] functions of the <:BasisLibrary:Basis Library> implementation.  These functions were using `TO_NEAREST` semantics, but should obey the current rounding mode.  (Only ++Real__<N>__.fmt StringCvt.EXACT++, ++Real__<N>__.fromDecimal++, and ++Real__<N>__.toDecimal++ are specified to override the current rounding mode with `TO_NEAREST` semantics.)
 +
 Thanks to Sean McLaughlin for the bug report.
 +
@@ -19,19 +19,19 @@ Thanks to Sean McLaughlin for the bug report.
 Fixed by revision <!ViewSVNRev(5794)>.
 
 * <!Anchor(bug14)>
-Bug in the http://www.standardml.org/Basis/real.html#SIG:REAL.toInt:VAL[++Real32.toInt++] function of the <:BasisLibrary:Basis Library> implementation could lead incorrect results when applied to a `Real32.real` value numerically close to `valOf(Int.maxInt)`.
+Bug in the http://www.sml-family.org/Basis/real.html#SIG:REAL.toInt:VAL[++Real32.toInt++] function of the <:BasisLibrary:Basis Library> implementation could lead incorrect results when applied to a `Real32.real` value numerically close to `valOf(Int.maxInt)`.
 +
 Fixed by revision <!ViewSVNRev(5764)>.
 
 * <!Anchor(bug13)>
-The http://www.standardml.org/Basis/socket.html[++Socket++] structure of the <:BasisLibrary:Basis Library> implementation used `andb` rather than `orb` to unmarshal socket options (for ++Socket.Ctl.get__<OPT>__++ functions).
+The http://www.sml-family.org/Basis/socket.html[++Socket++] structure of the <:BasisLibrary:Basis Library> implementation used `andb` rather than `orb` to unmarshal socket options (for ++Socket.Ctl.get__<OPT>__++ functions).
 +
 Thanks to Anders Petersson for the bug report and patch.
 +
 Fixed by revision <!ViewSVNRev(5735)>.
 
 * <!Anchor(bug12)>
-Bug in the http://www.standardml.org/Basis/date.html[++Date++] structure of the <:BasisLibrary:Basis Library> implementation yielded some functions that would erroneously raise `Date` when applied to a year before 1900.
+Bug in the http://www.sml-family.org/Basis/date.html[++Date++] structure of the <:BasisLibrary:Basis Library> implementation yielded some functions that would erroneously raise `Date` when applied to a year before 1900.
 +
 Thanks to Joe Hurd for the bug report.
 +
@@ -45,7 +45,7 @@ Thanks to Vesa Karvonen for the bug report.
 Fixed by revision <!ViewSVNRev(5731)>.
 
 * <!Anchor(bug10)>
-The http://www.standardml.org/Basis/pack-float.html#SIG:PACK_REAL.toBytes:VAL[++PackReal__<N>__.toBytes++] function in the <:BasisLibrary:Basis Library> implementation incorrectly shared (and mutated) the result vector.
+The http://www.sml-family.org/Basis/pack-float.html#SIG:PACK_REAL.toBytes:VAL[++PackReal__<N>__.toBytes++] function in the <:BasisLibrary:Basis Library> implementation incorrectly shared (and mutated) the result vector.
 +
 Thanks to Eric McCorkle for the bug report and patch.
 +
@@ -57,7 +57,7 @@ Bug in elaboration of FFI forms.  Using a unary FFI types (e.g., `array`, `ref`,
 Fixed by revision <!ViewSVNRev(4890)>.
 
 * <!Anchor(bug08)>
-The http://www.standardml.org/Basis/mono-vector.html[++MONO_VECTOR++] signature of the <:BasisLibrary:Basis Library> implementation incorrectly omits the specification of `find`.
+The http://www.sml-family.org/Basis/mono-vector.html[++MONO_VECTOR++] signature of the <:BasisLibrary:Basis Library> implementation incorrectly omits the specification of `find`.
 +
 Fixed by revision <!ViewSVNRev(4707)>.
 
@@ -81,7 +81,7 @@ The native codegen's implementation of the C-calling convention failed to widen 
 Fixed by revision <!ViewSVNRev(4631)>.
 
 * <!Anchor(bug04)>
-The http://www.standardml.org/Basis/pack-float.html[++PACK_REAL++] structures of the <:BasisLibrary:Basis Library> implementation used byte, rather than element, indexing.
+The http://www.sml-family.org/Basis/pack-float.html[++PACK_REAL++] structures of the <:BasisLibrary:Basis Library> implementation used byte, rather than element, indexing.
 +
 Fixed by revision <!ViewSVNRev(4411)>.
 

--- a/doc/guide/src/Bugs20070826.adoc
+++ b/doc/guide/src/Bugs20070826.adoc
@@ -100,14 +100,14 @@ Thanks to Florian Weimer for the bug report.
 Fixed by revision <!ViewSVNRev(6347)>.
 
 * <!Anchor(bug10)>
-Bug in the http://www.standardml.org/Basis/imperative-io.html#SIG:IMPERATIVE_IO.canInput:VAL[`IMPERATIVE_IO.canInput`] function of the <:BasisLibrary:Basis Library> implementation.
+Bug in the http://www.sml-family.org/Basis/imperative-io.html#SIG:IMPERATIVE_IO.canInput:VAL[`IMPERATIVE_IO.canInput`] function of the <:BasisLibrary:Basis Library> implementation.
 +
 Thanks to Ville Laurikari for the bug report.
 +
 Fixed by revision <!ViewSVNRev(6261)>.
 
 * <!Anchor(bug09)>
-Bug in algebraic simplification of real primitives.  http://www.standardml.org/Basis/real.html#SIG:REAL.\|@LTE\|:VAL[++REAL__<N>__.\<=(x, x)++] is `false` when `x` is NaN.
+Bug in algebraic simplification of real primitives.  http://www.sml-family.org/Basis/real.html#SIG:REAL.\|@LTE\|:VAL[++REAL__<N>__.\<=(x, x)++] is `false` when `x` is NaN.
 +
 Fixed by revision <!ViewSVNRev(6242)>.
 

--- a/doc/guide/src/Features.adoc
+++ b/doc/guide/src/Features.adoc
@@ -65,7 +65,7 @@ a bug.  For a list of known bugs, see <:UnresolvedBugs:>.
 * A complete implementation of the <:BasisLibrary:Basis Library>.
 +
 MLton's implementation matches latest <:BasisLibrary:Basis Library>
-http://www.standardml.org/Basis[specification], and includes a
+http://www.sml-family.org/Basis[specification], and includes a
 complete implementation of all the required modules, as well as many
 of the optional modules.
 

--- a/doc/guide/src/MLKit.adoc
+++ b/doc/guide/src/MLKit.adoc
@@ -8,7 +8,7 @@ MLKit supports:
 
 * <:DefinitionOfStandardML:SML'97>
 ** including most of the latest <:BasisLibrary:Basis Library>
-http://www.standardml.org/Basis[specification],
+http://www.sml-family.org/Basis[specification],
 * <:MLBasis:ML Basis> files
 ** and separate compilation,
 * <:Regions:Region-Based Memory Management>

--- a/doc/guide/src/Overloading.adoc
+++ b/doc/guide/src/Overloading.adoc
@@ -36,7 +36,7 @@ types.
 
 == Also see ==
 
- * http://www.standardml.org/Basis/top-level-chapter.html[discussion of overloading in the Basis Library]
+ * http://www.sml-family.org/Basis/top-level-chapter.html[discussion of overloading in the Basis Library]
 
 == Examples ==
 

--- a/doc/guide/src/PolymorphicEquality.adoc
+++ b/doc/guide/src/PolymorphicEquality.adoc
@@ -33,7 +33,7 @@ The one ground type that can not be compared is `real`.  So,
 reals for equality, but beware that this has different algebraic
 properties than polymorphic equality.
 
-See http://standardml.org/Basis/real.html for a discussion of why
+See http://sml-family.org/Basis/real.html for a discussion of why
 `real` is not an equality type.
 
 

--- a/doc/guide/src/Poplog.adoc
+++ b/doc/guide/src/Poplog.adoc
@@ -8,7 +8,7 @@ languages, including <:StandardML:Standard ML>.
 While POPLOG is actively developed, the <:ML:> support predates
 <:DefinitionOfStandardML:SML'97>, and there is no support for the
 <:BasisLibrary:Basis Library>
-http://www.standardml.org/Basis[specification].
+http://www.sml-family.org/Basis[specification].
 
 == Also see ==
 

--- a/doc/guide/src/References.adoc
+++ b/doc/guide/src/References.adoc
@@ -313,7 +313,7 @@ ____
 An introduction and overview of the <:BasisLibrary:Basis Library>,
 followed by a detailed description of each module.  The module
 descriptions are also available
-http://www.standardml.org/Basis[online].
+http://www.sml-family.org/Basis[online].
 ____
 
  * <!Anchor(GrossmanEtAl02)>

--- a/doc/guide/src/ReturnStatement.adoc
+++ b/doc/guide/src/ReturnStatement.adoc
@@ -9,17 +9,17 @@ to translate uses of `return` to SML.
 == Conditional iterator function ==
 
 A conditional iterator function, such as
-http://www.standardml.org/Basis/list.html#SIG:LIST.find:VAL[`List.find`],
-http://www.standardml.org/Basis/list.html#SIG:LIST.exists:VAL[`List.exists`],
+http://www.sml-family.org/Basis/list.html#SIG:LIST.find:VAL[`List.find`],
+http://www.sml-family.org/Basis/list.html#SIG:LIST.exists:VAL[`List.exists`],
 or
-http://www.standardml.org/Basis/list.html#SIG:LIST.all:VAL[`List.all`]
+http://www.sml-family.org/Basis/list.html#SIG:LIST.all:VAL[`List.all`]
 is probably what you want in most cases.  Unfortunately, it might be
 the case that the particular conditional iteration pattern that you
 want isn't provided for your data structure.  Usually the best
 alternative in such a case is to implement the desired iteration
 pattern as a higher-order function.  For example, to implement a
 `find` function for arrays (which already exists as
-http://www.standardml.org/Basis/array.html#SIG:ARRAY.findi:VAL[`Array.find`])
+http://www.sml-family.org/Basis/array.html#SIG:ARRAY.findi:VAL[`Array.find`])
 one could write
 
 [source,sml]

--- a/doc/guide/src/SMLNJDeviations.adoc
+++ b/doc/guide/src/SMLNJDeviations.adoc
@@ -336,7 +336,7 @@ These structures are allowed by the Definition.
 == Deviations from the Basis Library Specification ==
 
 Here are some deviations of SML/NJ from the <:BasisLibrary:Basis Library>
-http://www.standardml.org/Basis[specification].
+http://www.sml-family.org/Basis[specification].
 
 * SML/NJ exposes the equality of the `vector` type in structures such
 as `Word8Vector` that abstractly match `MONO_VECTOR`, which says

--- a/doc/guide/src/StaticSum.adoc
+++ b/doc/guide/src/StaticSum.adoc
@@ -143,7 +143,7 @@ In some situations it would seem useful to define functions whose
 result type would depend on some of the arguments.  Traditionally such
 functions have been thought to be impossible in SML and the solution
 has been to define multiple functions.  For example, the
-http://www.standardml.org/Basis/socket.html[`Socket` structure] of the
+http://www.sml-family.org/Basis/socket.html[`Socket` structure] of the
 Basis library defines 16 `send` and 16 `recv` functions.  In contrast,
 the Net structure
 (<!ViewGitFile(mltonlib,master,com/sweeks/basic/unstable/net.sig)>) of the


### PR DESCRIPTION
Don't really know what the story is here (admit I'm curious) but standardml.org appears to have gone away and been resurrected somehow as sml-family.org, so currently a lot of links are broken.
