### PR TITLE
mingw32: <winsock2.h> should be included before <windows.h>

### DIFF
--- a/runtime/platform/mingw.h
+++ b/runtime/platform/mingw.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include <unistd.h>
+#include <winsock2.h>
 #include <windows.h>
 
 #include <dirent.h>
@@ -23,7 +24,6 @@
 #include <lm.h>
 #include <process.h>
 //#include <psapi.h>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 #include <psapi.h>
 


### PR DESCRIPTION
- `<windows.h>` might include `<winsock.h>`
- `<winsock.h>` and `<winsock2.h>` are incompatible. Including `<winsock2.h>` can prevent `<winsock.h>` from being included.

This does not (currently) affect the mingw32 build (though it will generate lots of warnings), but breaks MinGW build.
