### PR TITLE
mlnlffigen no longer terminates because of structs

### DIFF
--- a/mlnlffigen/ast-to-spec.sml
+++ b/mlnlffigen/ast-to-spec.sml
@@ -23,6 +23,7 @@ structure AstToSpec = struct
     exception VoidType
     exception Ellipsis
     exception Duplicate of string
+    exception SkipFunction of string
 
     fun bug m = raise Fail ("AstToSpec: bug: " ^ m)
     fun err m = raise Fail ("AstToSpec: error: " ^ m)
@@ -195,6 +196,14 @@ structure AstToSpec = struct
 
         and valty_nonvoid C t = valty C t
             handle VoidType => err "void variable type"
+
+        and fun_valty_nonvoid C t =
+            case valty_nonvoid C t of
+                Spec.STRUCT tag =>
+                    raise SkipFunction "struct argument/return type not supported"
+              | Spec.UNION tag =>
+                    raise SkipFunction "union argument/return type not supported"
+              | ty => ty
 
         and typeref (tid, otherwise, C) =
             case Tidtab.find (tidtab, tid) of
@@ -373,11 +382,11 @@ structure AstToSpec = struct
         and cft C (res, args) =
             { res = case getCoreType res of
                         A.Void => NONE
-                      | _ => SOME (valty_nonvoid C res),
+                      | _ => SOME (fun_valty_nonvoid C res),
               args = case args of
                          [(arg, _)] => (case getCoreType arg of
                                        A.Void => []
-                                     | _ => [valty_nonvoid C arg])
+                                     | _ => [fun_valty_nonvoid C arg])
                        | _ => let fun build [] = []
                                     | build [(x, _)] =
                                       ([valty_nonvoid C x]
@@ -387,7 +396,7 @@ structure AstToSpec = struct
                                                     \ignoring the ellipsis\n");
                                                    []))
                                     | build ((x, _) :: xs) =
-                                      valty_nonvoid C x :: build xs
+                                      fun_valty_nonvoid C x :: build xs
                               in
                                   build args
                               end }
@@ -415,6 +424,8 @@ structure AstToSpec = struct
                                                 spec = cft tl_context fs,
                                                 argnames = anlo })
                         | NONE => bug "function without function type")
+                     handle SkipFunction reason =>
+                         warnLoc (reason ^ "; skipping function\n")
                  in
                  case #stClass f of
                      A.EXTERN => doit ()

--- a/mlnlffigen/ast-to-spec.sml
+++ b/mlnlffigen/ast-to-spec.sml
@@ -200,9 +200,9 @@ structure AstToSpec = struct
         and fun_valty_nonvoid C t =
             case valty_nonvoid C t of
                 Spec.STRUCT tag =>
-                    raise SkipFunction "struct argument/return type not supported"
+                    raise SkipFunction "struct argument not supported"
               | Spec.UNION tag =>
-                    raise SkipFunction "union argument/return type not supported"
+                    raise SkipFunction "union argument not supported"
               | ty => ty
 
         and typeref (tid, otherwise, C) =
@@ -382,7 +382,7 @@ structure AstToSpec = struct
         and cft C (res, args) =
             { res = case getCoreType res of
                         A.Void => NONE
-                      | _ => SOME (fun_valty_nonvoid C res),
+                      | _ => SOME (valty_nonvoid C res),
               args = case args of
                          [(arg, _)] => (case getCoreType arg of
                                        A.Void => []

--- a/mlnlffigen/ast-to-spec.sml
+++ b/mlnlffigen/ast-to-spec.sml
@@ -389,7 +389,7 @@ structure AstToSpec = struct
                                      | _ => [fun_valty_nonvoid C arg])
                        | _ => let fun build [] = []
                                     | build [(x, _)] =
-                                      ([valty_nonvoid C x]
+                                      ([fun_valty_nonvoid C x]
                                        handle Ellipsis =>
                                               (warnLoc
                                                    ("varargs not supported; \


### PR DESCRIPTION
I replaced calls to `valty_nonvoid` in the `cft` function with a new function `fun_valty_nonvoid` that pattern matches on the result of `valty_nonvoid` and raises an exception if it's `Spec.STRUCT` or `Spec.UNION`. This aborts the assignment to the `gfuns` list in line 421. The exception handler uses the same `warnLoc` function used to warn about varargs.

Tested it on Ubuntu 14.10 64-bit using libsdl2's headers. *SDL_joystick.h* and *SDL_gamecontroller.h* are the ones with struct arguments/return values.