### PR TITLE
Update post-processing of generated front-end files.

### DIFF
--- a/mlton/front-end/Makefile
+++ b/mlton/front-end/Makefile
@@ -1,4 +1,4 @@
-## Copyright (C) 2009,2014 Matthew Fluet.
+## Copyright (C) 2009,2014-2015 Matthew Fluet.
  # Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
@@ -40,15 +40,21 @@ clean:
 	../../bin/clean
 
 %.lex.sml: %.lex
-	rm -f $@
+	rm -f $<.*
 	$(MLLEX) $<
-	sed -i -e 's/val s = List.map f (List.rev (tl (List.rev s)))/val s = Pervasive.List.map f (Pervasive.List.rev (tl (Pervasive.List.rev s)))/' $<.sml
-	sed -i -e 's/in Vector.fromList(List.map g/in Vector.fromList(Pervasive.List.map g/' $<.sml
-	chmod -w $@
+	mv $<.sml $<.sml.in
+	sed -e 's/val s = List.map f (List.rev (tl (List.rev s)))/val s = Pervasive.List.map f (Pervasive.List.rev (tl (Pervasive.List.rev s)))/' $<.sml.in > $<.sml
+	mv $<.sml $<.sml.in
+	sed -e 's/in Vector.fromList(List.map g/in Vector.fromList(Pervasive.List.map g/' $<.sml.in > $<.sml
+	rm -f $<.sml.in
+	chmod -w $<.*
 
 %.grm.sig %.grm.sml: %.grm
 	rm -f $<.*
 	$(MLYACC) $<
-	sed -i -e 's/in f 0 handle General.Subscript => ()/in f 0 handle Pervasive.General.Subscript => ()/' $<.sml
-	sed -i -e 's/in Array.fromList(List.map actionRowLookUp actionRowNumbers)/in Array.fromList(Pervasive.List.map actionRowLookUp actionRowNumbers)/' $<.sml
+	mv $<.sml $<.sml.in
+	sed -e 's/in f 0 handle General.Subscript => ()/in f 0 handle Pervasive.General.Subscript => ()/' $<.sml.in > $<.sml
+	mv $<.sml $<.sml.in
+	sed -e 's/in Array.fromList(List.map actionRowLookUp actionRowNumbers)/in Array.fromList(Pervasive.List.map actionRowLookUp actionRowNumbers)/' $<.sml.in > $<.sml
+	rm -f $<.sml.in
 	chmod -w $<.*


### PR DESCRIPTION
Commit 4055a88 added post-processing with sed of generated front-end
files to support recent versions of SML/NJ's ml-lex and ml-yacc that
generate long identifiers rather than unqualified (top-level
environment) identifiers.

Unfortunately, GNU sed (e.g., linux) and BSD sed (e.g., darwin) differ
in the treatment of the "-i" (in place extension) command line flag,
which can lead one or the other to leave a backup file that dirties
the working tree.

Use "mv" and temporary files to eliminate the need for in place
editing.