### PR TITLE
Deterministic builds

### DIFF
--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2014 Matthew Fluet.
+(* Copyright (C) 2009,2014-2015 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -409,9 +409,15 @@ fun outputDeclarations
                case !Control.align of
                   Control.Align4 => 4
                 | Control.Align8 => 8
-            val magic = C.word (case Random.useed () of
-                                   NONE => String.hash (!Control.inputFile)
-                                 | SOME w => w)
+            val magic =
+               let
+                  val version = String.hash Version.banner
+                  val random = Random.word ()
+               in
+                  Word.orb
+                  (Word.<< (version, Word.fromInt (Word.wordSize - 11)),
+                   Word.>> (random, Word.fromInt 11))
+               end
             val profile =
                case !Control.profile of
                   Control.ProfileNone => "PROFILE_NONE"
@@ -429,7 +435,7 @@ fun outputDeclarations
                            | Control.LibArchive => "MLtonLibrary"
                            | Control.Library => "MLtonLibrary",
                           [C.int align,
-                           magic,
+                           C.word magic,
                            C.bytes maxFrameSize,
                            C.bool (!Control.markCards),
                            profile,

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -411,12 +411,12 @@ fun outputDeclarations
                 | Control.Align8 => 8
             val magic =
                let
-                  val version = String.hash Version.banner
+                  val version = String.hash Version.version
                   val random = Random.word ()
                in
                   Word.orb
-                  (Word.<< (version, Word.fromInt (Word.wordSize - 11)),
-                   Word.>> (random, Word.fromInt 11))
+                  (Word.<< (version, Word.fromInt (Word.wordSize - 8)),
+                   Word.>> (random, Word.fromInt 8))
                end
             val profile =
                case !Control.profile of

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010-2011,2013-2014 Matthew Fluet.
+(* Copyright (C) 2010-2011,2013-2015 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -1272,7 +1272,7 @@ fun commandLine (args: string list): unit =
                      val _ =
                         atMLtons :=
                         Vector.fromList
-                        (maybeOut "" :: tokenize (rev ("--" :: (!runtimeArgs))))
+                        (tokenize (rev ("--" :: (!runtimeArgs))))
                      (* The -Wa,--gstabs says to pass the --gstabs option to the
                       * assembler. This tells the assembler to generate stabs
                       * debugging information for each assembler line.

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009,2012 Matthew Fluet.
+/* Copyright (C) 2009,2012,2015 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -71,11 +71,11 @@ bad:
 /*                             GC_init                              */
 /* ---------------------------------------------------------------- */
 
-int processAtMLton (GC_state s, int argc, char **argv,
+int processAtMLton (GC_state s, int start, int argc, char **argv,
                     char **worldFile) {
   int i;
 
-  i = 1;
+  i = start;
   while (s->controls.mayProcessAtMLton
          and i < argc
          and (0 == strcmp (argv [i], "@MLton"))) {
@@ -337,8 +337,8 @@ int GC_init (GC_state s, int argc, char **argv) {
 
   unless (isAligned (s->sysvals.pageSize, CARD_SIZE))
     die ("Page size must be a multiple of card size.");
-  processAtMLton (s, s->atMLtonsLength, s->atMLtons, &worldFile);
-  res = processAtMLton (s, argc, argv, &worldFile);
+  processAtMLton (s, 0, s->atMLtonsLength, s->atMLtons, &worldFile);
+  res = processAtMLton (s, 1, argc, argv, &worldFile);
   if (s->controls.fixedHeap > 0 and s->controls.maxHeap > 0)
     die ("Cannot use both fixed-heap and max-heap.");
   unless (s->controls.ratios.markCompact <= s->controls.ratios.copy

--- a/runtime/gc/init.h
+++ b/runtime/gc/init.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
+/* Copyright (C) 2015 Matthew Fluet.
+ * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -8,7 +9,7 @@
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-static int processAtMLton (GC_state s, int argc,
+static int processAtMLton (GC_state s, int start, int argc,
                            char **argv, char **worldFile);
 
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */


### PR DESCRIPTION
For a given compiler and input program (and compile-time options), deterministically build executable by:
 * Eliminating output executable name from compile-time specified "@MLton" arguments.
 * Deterministically generating magic constant.

Closes MLton/mlton#50.
