### PR TITLE
Updates to _import attributes for C function kinds.

### DIFF
--- a/doc/changelog
+++ b/doc/changelog
@@ -1,5 +1,10 @@
 Here are the changes from version 20130715 to version YYYYMMDD.
 
+* 2015-06-08
+  - Added "reentrant" attribute to _import.  An _import-ed C function
+    that (directly or indirectly) calls an _export-ed SML function
+    should be attributed "reentrant".
+
 * 2014-11-21
    - Fixed bug in MLton.IntInf.fromRep that could yield values that
      violate the IntInf representation invariants.
@@ -9,6 +14,12 @@ Here are the changes from version 20130715 to version YYYYMMDD.
    - Reorganized runtime support for IntInf operations so that
      programs that do not use IntInf compile to executables with no
      residual dependency on GMP.
+
+* 2014-10-24
+  - Added "pure" and "impure" attributes to _import.  An unattributed
+    _import is treated as "impure".  A "pure" _import may be subject
+    to more aggressive optimizations (common subexpression
+    elimination, dead-code elimiation).
 
 * 2014-07-01
    - Merged Brian Leibig's llvm code generator.

--- a/doc/examples/ffi/export.sml
+++ b/doc/examples/ffi/export.sml
@@ -3,25 +3,25 @@ val _ = e (fn (i, r, _) =>
            (print (concat ["i = ", Int.toString i,
                            "  r = ", Real.toString r, "\n"])
             ; #"g"))
-val g = _import "g" public: unit -> unit;
+val g = _import "g" public reentrant: unit -> unit;
 val _ = g ()
 val _ = g ()
 
 val e = _export "f2": (Word8.word -> word array) -> unit;
 val _ = e (fn w =>
            Array.tabulate (10, fn _ => Word.fromLargeWord (Word8.toLargeWord w)))
-val g2 = _import "g2" public: unit -> word array;
+val g2 = _import "g2" public reentrant: unit -> word array;
 val a = g2 ()
 val _ = print (concat ["0wx", Word.toString (Array.sub (a, 0)), "\n"])
 
 val e = _export "f3": (unit -> unit) -> unit;
 val _ = e (fn () => print "hello\n");
-val g3 = _import "g3" public: unit -> unit;
+val g3 = _import "g3" public reentrant: unit -> unit;
 val _ = g3 ()
 
 (* This example demonstrates mutual recursion between C and SML. *)
 val e = _export "f4": (int -> unit) -> unit;
-val g4 = _import "g4" public: int -> unit;
+val g4 = _import "g4" public reentrant: int -> unit;
 val _ = e (fn i => if i = 0 then () else g4 (i - 1))
 val _ = g4 13
 
@@ -31,4 +31,3 @@ val g5 = _import "g5" public: unit -> unit;
 val _ = g5 ()
 
 val _ = print "success\n"
-

--- a/doc/examples/ffi/test_quot.sml
+++ b/doc/examples/ffi/test_quot.sml
@@ -1,11 +1,11 @@
 (* By default _import is external *)
-val c_quot = _import "c_quot" private: Int8.int * Int8.int -> Int8.int;
+val c_quot = _import "c_quot" private pure: Int8.int * Int8.int -> Int8.int;
 
 (* By default _export is public *)
 val sml_quot = _export "sml_quot": (Int8.int * Int8.int -> Int8.int) -> unit;
 val _ = sml_quot Int8.quot
 
-val call_sml_quot = _import "call_sml_quot" public: unit -> unit;
+val call_sml_quot = _import "call_sml_quot" public reentrant: unit -> unit;
 
 val x : Int8.int = ~1
 val y : Int8.int = 10

--- a/doc/guide/src/CallingFromCToSML.adoc
+++ b/doc/guide/src/CallingFromCToSML.adoc
@@ -49,6 +49,9 @@ Suppose that `export.sml` is
 sys::[./bin/InclGitFile.py mlton master doc/examples/ffi/export.sml]
 ----
 
+Note that the the `reentrant` attribute is used for `_import`-ing the
+C functions that will call the `_export`-ed SML functions.
+
 Create the header file with `-export-header`.
 ----
 % mlton -default-ann 'allowFFI true'    \

--- a/doc/guide/src/CallingFromSMLToC.adoc
+++ b/doc/guide/src/CallingFromSMLToC.adoc
@@ -25,11 +25,7 @@ _import "C function name" attr... : cFuncTy;
 The type and the semicolon are not optional.
 
 The function name is followed by a (possibly empty) sequence of
-attributes, analogous to C `__attribute__` specifiers.  For now, the
-only attributes supported are `cdecl` and `stdcall`.  These specify
-the calling convention of the C function on Cygwin/Windows, and are
-ignored on all other platforms.  The default is `cdecl`.  You must use
-`stdcall` in order to correctly call Windows API functions.
+attributes, analogous to C `__attribute__` specifiers.
 
 
 == Example ==

--- a/doc/guide/src/ForeignFunctionInterfaceSyntax.adoc
+++ b/doc/guide/src/ForeignFunctionInterfaceSyntax.adoc
@@ -77,8 +77,11 @@ details.
 
 * `cdecl` : call with the `cdecl` calling convention (default).
 * `external` : import with external symbol scope (see <:LibrarySupport:>) (default).
+* `impure`: assert that the function depends upon state and/or performs side effects (default).
 * `private` : import with private symbol scope (see <:LibrarySupport:>).
 * `public` : import with public symbol scope (see <:LibrarySupport:>).
+* `pure`: assert that the function does not depend upon state or perform any side effects; such functions are subject to various optimizations (e.g., <:CommonSubexp:>, <:RemoveUnused:>)
+* `reentrant`: assert that the function (directly or indirectly) calls an `_export`-ed SML function.
 * `stdcall` : call with the `stdcall` calling convention (ignored except on Cygwin and MinGW).
 
 
@@ -92,6 +95,9 @@ function through a C function pointer.
 `attr...` denotes a (possibly empty) sequence of attributes.  The following attributes are recognized:
 
 * `cdecl` : call with the `cdecl` calling convention (default).
+* `impure`: assert that the function depends upon state and/or performs side effects (default).
+* `pure`: assert that the function does not depend upon state or perform any side effects; such functions are subject to various optimizations (e.g., <:CommonSubexp:>, <:RemoveUnused:>)
+* `reentrant`: assert that the function (directly or indirectly) calls an `_export`-ed SML function.
 * `stdcall` : call with the `stdcall` calling convention (ignored except on Cygwin and MinGW).
 
 See

--- a/mlton/ast/ast-core.fun
+++ b/mlton/ast/ast-core.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2012 Matthew Fluet.
+(* Copyright (C) 2009,2012,2015 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -220,7 +220,7 @@ structure PrimKind =
    struct
       structure ImportExportAttribute =
          struct
-            datatype t = Cdecl | External | Impure | Private | Public | Pure | Runtime | Stdcall
+            datatype t = Cdecl | External | Impure | Private | Public | Pure | Reentrant | Runtime | Stdcall
 
             val toString: t -> string =
                fn Cdecl => "cdecl"
@@ -229,6 +229,7 @@ structure PrimKind =
                 | Private => "private"
                 | Public => "public"
                 | Pure => "pure"
+                | Reentrant => "reentrant"
                 | Runtime => "runtime"
                 | Stdcall => "stdcall"
 

--- a/mlton/ast/ast-core.sig
+++ b/mlton/ast/ast-core.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2012 Matthew Fluet.
+(* Copyright (C) 2009,2012,2015 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -81,7 +81,7 @@ signature AST_CORE =
          sig
             structure ImportExportAttribute:
                sig
-                  datatype t = Cdecl | External | Impure | Private | Public | Pure | Runtime | Stdcall
+                  datatype t = Cdecl | External | Impure | Private | Public | Pure | Reentrant | Runtime | Stdcall
 
                   val layout: t -> Layout.t
                end

--- a/mlton/atoms/c-function.fun
+++ b/mlton/atoms/c-function.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 2003-2007 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2015 Matthew Fluet.
+ * Copyright (C) 2003-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -43,6 +44,9 @@ structure Kind =
                                     modifiesFrontier = true,
                                     readsStackTop = true,
                                     writesStackTop = true}
+      val pure = Pure
+      val impure = Impure
+      val reentrant = runtimeDefault
 
       fun layout k =
          case k of

--- a/mlton/atoms/c-function.sig
+++ b/mlton/atoms/c-function.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2015 Matthew Fluet.
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -43,6 +43,9 @@ signature C_FUNCTION =
                            readsStackTop: bool,
                            writesStackTop: bool}
 
+            val impure: t
+            val pure: t
+            val reentrant: t
             val runtimeDefault: t
 
             val layout: t -> Layout.t

--- a/mlton/elaborate/elaborate-core.fun
+++ b/mlton/elaborate/elaborate-core.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012 Matthew Fluet.
+(* Copyright (C) 2009-2012,2015 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -932,6 +932,7 @@ val isIEAttributeKind =
    fn ImportExportAttribute.Impure => true
     | ImportExportAttribute.Pure => true
     | ImportExportAttribute.Runtime => true
+    | ImportExportAttribute.Reentrant => true
     | _ => false
 
 fun parseIEAttributesKind (attributes: ImportExportAttribute.t list)
@@ -940,9 +941,10 @@ fun parseIEAttributesKind (attributes: ImportExportAttribute.t list)
       [] => SOME CKind.Impure
     | [a] =>
          (case a of
-             ImportExportAttribute.Impure => SOME CKind.Impure
-           | ImportExportAttribute.Pure => SOME CKind.Pure
+             ImportExportAttribute.Impure => SOME CKind.impure
+           | ImportExportAttribute.Pure => SOME CKind.pure
            | ImportExportAttribute.Runtime => SOME CKind.runtimeDefault
+           | ImportExportAttribute.Reentrant => SOME CKind.reentrant
            | _ => NONE)
     | _ => NONE
 

--- a/mlton/front-end/ml.grm
+++ b/mlton/front-end/ml.grm
@@ -1053,6 +1053,7 @@ ieattributes
           | "private" => PrimKind.ImportExportAttribute.Private :: ieattributes
           | "public" => PrimKind.ImportExportAttribute.Public :: ieattributes
           | "pure" => PrimKind.ImportExportAttribute.Pure :: ieattributes
+          | "reentrant" => PrimKind.ImportExportAttribute.Reentrant :: ieattributes
           | "runtime" => PrimKind.ImportExportAttribute.Runtime :: ieattributes
           | "stdcall" => PrimKind.ImportExportAttribute.Stdcall :: ieattributes
           | _ => (error (reg (idleft, idright), concat ["invalid attribute: ", id])


### PR DESCRIPTION
Two updates to `_import` attributes for C function kinds:
 * Introduce a `reentrant` `_import` attribute for `_import`-ed C functions that call `_export`-ed SML functions.
 * Document the `pure`, `impure`, and `reentrant` `_import` attributes.

Fixes MLton/mlton#88 and MLton/mlton#89.