### PR TITLE
Changes to type equalities and equality status in Basis Library.

### DIFF
--- a/basis-library/arrays-and-vectors/mono-array.fun
+++ b/basis-library/arrays-and-vectors/mono-array.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2015 Matthew Fluet.
+ * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -7,21 +8,21 @@
  *)
 
 functor MonoArray (type elem
-                   structure V: MONO_VECTOR_EXTRA
+                   structure MV: MONO_VECTOR_EXTRA
                      where type elem = elem
                        and type vector = elem Vector.vector
                        and type MonoVectorSlice.slice = elem VectorSlice.slice
                   ): MONO_ARRAY_EXTRA 
                      where type elem = elem
-                       and type vector = V.vector
-                       and type vector_slice = V.MonoVectorSlice.slice =
+                       and type vector = MV.vector
+                       and type vector_slice = MV.MonoVectorSlice.slice =
    struct
       open Array
 
-      type elem = V.elem
+      type elem = MV.elem
       type array = elem array
-      type vector = V.vector
-      type vector_slice = V.MonoVectorSlice.slice
+      type vector = MV.vector
+      type vector_slice = MV.MonoVectorSlice.slice
 
       val fromPoly = fn a => a
       val toPoly = fn a => a

--- a/basis-library/arrays-and-vectors/mono-array2.fun
+++ b/basis-library/arrays-and-vectors/mono-array2.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2015 Matthew Fluet.
+ * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -7,12 +8,12 @@
  *)
 
 functor MonoArray2 (type elem
-                    structure V: MONO_VECTOR
+                    structure MV: MONO_VECTOR
                       where type elem = elem
                         and type vector = elem Vector.vector): MONO_ARRAY2 =
    struct
-      type elem = V.elem
-      type vector = V.vector
+      type elem = MV.elem
+      type vector = MV.vector
       open Array2
       type array = elem array
       type region = {base: array,

--- a/basis-library/arrays-and-vectors/mono-array2.sig
+++ b/basis-library/arrays-and-vectors/mono-array2.sig
@@ -13,21 +13,21 @@ signature MONO_ARRAY2 =
 
       datatype traversal = datatype Array2.traversal
 
-      val array: int * int * elem -> array 
-      val fromList: elem list list -> array 
-      val tabulate: traversal -> int * int * (int * int -> elem) -> array 
-      val sub: array * int * int -> elem 
-      val update: array * int * int * elem -> unit 
-      val dimensions: array -> int * int 
-      val nCols: array -> int 
-      val nRows: array -> int 
-      val row: array * int -> vector 
-      val column: array * int -> vector 
+      val app: traversal -> (elem -> unit) -> array -> unit
+      val appi: traversal -> (int * int * elem -> unit) -> region -> unit
+      val array: int * int * elem -> array
+      val column: array * int -> vector
       val copy: {src: region, dst: array, dst_row: int, dst_col: int} -> unit
-      val appi: traversal -> (int * int * elem -> unit) -> region -> unit 
-      val app: traversal -> (elem -> unit) -> array -> unit 
-      val foldi: traversal -> (int * int * elem * 'b -> 'b) -> 'b -> region -> 'b 
+      val dimensions: array -> int * int
       val fold: traversal -> (elem * 'b -> 'b) -> 'b -> array -> 'b
-      val modifyi: traversal -> (int * int * elem -> elem) -> region -> unit 
-      val modify: traversal -> (elem -> elem) -> array -> unit 
+      val foldi: traversal -> (int * int * elem * 'b -> 'b) -> 'b -> region -> 'b
+      val fromList: elem list list -> array
+      val modify: traversal -> (elem -> elem) -> array -> unit
+      val modifyi: traversal -> (int * int * elem -> elem) -> region -> unit
+      val nCols: array -> int
+      val nRows: array -> int
+      val row: array * int -> vector
+      val sub: array * int * int -> elem
+      val tabulate: traversal -> int * int * (int * int -> elem) -> array
+      val update: array * int * int * elem -> unit
    end

--- a/basis-library/arrays-and-vectors/mono-vector-slice.sig
+++ b/basis-library/arrays-and-vectors/mono-vector-slice.sig
@@ -37,6 +37,7 @@ signature MONO_VECTOR_SLICE_EXTRA =
       val dropl: (elem -> bool) -> slice -> slice
       val dropr: (elem -> bool) -> slice -> slice
       val fields: (elem -> bool) -> slice -> slice list
+      val fromPoly: elem VectorSlice.slice -> slice
       val isPrefix: (elem * elem -> bool) -> vector -> slice -> bool
       val isSubvector: (elem * elem -> bool) -> vector -> slice -> bool
       val isSuffix: (elem * elem -> bool) -> vector -> slice -> bool
@@ -47,6 +48,7 @@ signature MONO_VECTOR_SLICE_EXTRA =
       val takel: (elem -> bool) -> slice -> slice
       val taker: (elem -> bool) -> slice -> slice
       val toList: slice -> elem list
+      val toPoly: slice -> elem VectorSlice.slice
       val tokens: (elem -> bool) -> slice -> slice list
       val translate: (elem -> vector) -> slice -> vector
       val triml: int -> slice -> slice
@@ -60,7 +62,5 @@ signature EQTYPE_MONO_VECTOR_SLICE_EXTRA =
    sig
       include MONO_VECTOR_SLICE_EXTRA
 
-      val fromPoly: elem VectorSlice.slice -> slice
       val span: slice * slice -> slice
-      val toPoly: slice -> elem VectorSlice.slice
    end

--- a/basis-library/arrays-and-vectors/mono-vector.fun
+++ b/basis-library/arrays-and-vectors/mono-vector.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2015 Matthew Fluet.
+ * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -13,12 +14,16 @@ functor MonoVector (type elem): MONO_VECTOR_EXTRA
       type array = elem array
       type elem = elem
       type vector = elem vector
+      val fromPoly = fn v => v
+      val toPoly = fn v => v
       structure MonoVectorSlice = 
          struct
             open VectorSlice
             type elem = elem
             type vector = vector
             type slice = elem slice
+            val fromPoly = fn s => s
+            val toPoly = fn s => s
          end
    end
 
@@ -29,6 +34,7 @@ functor EqtypeMonoVector (eqtype elem): EQTYPE_MONO_VECTOR_EXTRA
       type array = elem array
       type elem = elem
       type vector = elem vector
+      type vector_eqtype = vector
       val fromPoly = fn v => v
       val toPoly = fn v => v
       structure MonoVectorSlice = 

--- a/basis-library/arrays-and-vectors/mono-vector.sig
+++ b/basis-library/arrays-and-vectors/mono-vector.sig
@@ -25,32 +25,33 @@ signature MONO_VECTOR =
       val update: vector * int * elem -> vector
    end
 
-signature MONO_VECTOR_EXTRA_PRE = 
+signature MONO_VECTOR_EXTRA_COMMON =
    sig
       include MONO_VECTOR
 
       type array
 
-      val unsafeFromArray: array -> vector
-      val unsafeSub: vector * int -> elem
-
       val append: vector * vector -> vector
       val concatWith: vector -> vector list -> vector
       val duplicate: vector -> vector
       val fields: (elem -> bool) -> vector -> vector list
+      val fromPoly: elem Vector.vector -> vector
       val isPrefix: (elem * elem -> bool) -> vector -> vector -> bool
       val isSubvector: (elem * elem -> bool) -> vector -> vector -> bool
       val isSuffix: (elem * elem -> bool) -> vector -> vector -> bool
       val toList: vector -> elem list
+      val toPoly: vector -> elem Vector.vector
       val tokens: (elem -> bool) -> vector -> vector list
       val translate: (elem -> vector) -> vector -> vector
       val unfoldi: int * 'a * (int * 'a -> elem * 'a) -> vector * 'a
+      val unsafeFromArray: array -> vector
+      val unsafeSub: vector * int -> elem
       val vector: int * elem -> vector
    end
 
 signature MONO_VECTOR_EXTRA =
    sig
-      include MONO_VECTOR_EXTRA_PRE
+      include MONO_VECTOR_EXTRA_COMMON
 
       structure MonoVectorSlice: MONO_VECTOR_SLICE_EXTRA 
          where type elem = elem
@@ -59,12 +60,11 @@ signature MONO_VECTOR_EXTRA =
 
 signature EQTYPE_MONO_VECTOR_EXTRA =
    sig
-      include MONO_VECTOR_EXTRA_PRE
+      eqtype vector_eqtype
+      include MONO_VECTOR_EXTRA_COMMON
+      sharing type vector_eqtype = vector
 
       structure MonoVectorSlice: EQTYPE_MONO_VECTOR_SLICE_EXTRA 
          where type elem = elem
            and type vector = vector
-
-      val fromPoly: elem Vector.vector -> vector 
-      val toPoly: vector -> elem Vector.vector
    end

--- a/basis-library/arrays-and-vectors/mono.sml
+++ b/basis-library/arrays-and-vectors/mono.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2015 Matthew Fluet.
+ * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -6,242 +7,260 @@
  * See the file MLton-LICENSE for details.
  *)
 
-signature EQ_MONO =
+signature EQTYPE_MONO =
    sig
-      structure Array: MONO_ARRAY_EXTRA
-      structure Array2: MONO_ARRAY2
-      structure ArraySlice: MONO_ARRAY_SLICE_EXTRA
-      structure Vector: EQTYPE_MONO_VECTOR_EXTRA
-      structure VectorSlice: EQTYPE_MONO_VECTOR_SLICE_EXTRA
-      sharing type Array.array = ArraySlice.array = Vector.array
-      sharing type Array.elem = Array2.elem = ArraySlice.elem = Vector.elem
-         = VectorSlice.elem
-      sharing type Array.vector = Array2.vector = ArraySlice.vector
-         = Vector.vector = VectorSlice.vector
-      sharing type ArraySlice.vector_slice = VectorSlice.slice
+      type elem
+      structure MonoArray: MONO_ARRAY_EXTRA
+      structure MonoArray2: MONO_ARRAY2
+      structure MonoVector: EQTYPE_MONO_VECTOR_EXTRA
+      sharing type MonoArray.array = MonoVector.array
+      sharing type elem = MonoArray.elem = MonoArray2.elem = MonoVector.elem
+      sharing type MonoArray.vector = MonoArray2.vector = MonoVector.vector
+      sharing type MonoArray.MonoArraySlice.vector_slice = MonoVector.MonoVectorSlice.slice
    end
 
-functor EqMono (eqtype elem) =
+signature MONO =
+   sig
+      type elem
+      structure MonoArray: MONO_ARRAY_EXTRA
+      structure MonoArray2: MONO_ARRAY2
+      structure MonoVector: MONO_VECTOR_EXTRA
+      sharing type MonoArray.array = MonoVector.array
+      sharing type elem = MonoArray.elem = MonoArray2.elem = MonoVector.elem
+      sharing type MonoArray.vector = MonoArray2.vector = MonoVector.vector
+      sharing type MonoArray.MonoArraySlice.vector_slice = MonoVector.MonoVectorSlice.slice
+   end
+
+functor EqtypeMonoX (eqtype elem) =
    struct
-      structure Vector = EqtypeMonoVector (type elem = elem)
-      structure VectorSlice = Vector.MonoVectorSlice
-      structure Array = MonoArray (type elem = elem
-                                   structure V = Vector)
-      structure ArraySlice = Array.MonoArraySlice
-      structure Array2 = MonoArray2 (type elem = elem
-                                     structure V = Vector)
+      type elem = elem
+      structure MonoVector = EqtypeMonoVector (type elem = elem)
+      structure MonoArray = MonoArray (type elem = elem
+                                       structure MV = MonoVector)
+      structure MonoArray2 = MonoArray2 (type elem = elem
+                                         structure MV = MonoVector)
    end
 
-functor Mono (type elem) =
+functor EqtypeMono (eqtype elem) :> EQTYPE_MONO where type elem = elem =
    struct
-      structure Vector = MonoVector (type elem = elem)
-      structure VectorSlice = Vector.MonoVectorSlice
-      structure Array = MonoArray (type elem = elem
-                                   structure V = Vector)
-      structure ArraySlice = Array.MonoArraySlice
-      structure Array2 = MonoArray2 (type elem = elem
-                                     structure V = Vector)
+      type elem = elem
+      structure MonoVector = EqtypeMonoVector (type elem = elem)
+      structure MonoArray = MonoArray (type elem = elem
+                                       structure MV = MonoVector)
+      structure MonoArray2 = MonoArray2 (type elem = elem
+                                         structure MV = MonoVector)
+   end
+
+functor Mono (type elem) :> MONO where type elem = elem =
+   struct
+      type elem = elem
+      structure MonoVector = MonoVector (type elem = elem)
+      structure MonoArray = MonoArray (type elem = elem
+                                       structure MV = MonoVector)
+      structure MonoArray2 = MonoArray2 (type elem = elem
+                                         structure MV = MonoVector)
    end
 
 local
-   structure S = EqMono (type elem = Primitive.Bool.bool)
+   structure S = EqtypeMono (type elem = Primitive.Bool.bool)
    open S
 in
-   structure BoolVector = Vector
-   structure BoolVectorSlice = VectorSlice
-   structure BoolArray = Array
-   structure BoolArraySlice = ArraySlice
-   structure BoolArray2 = Array2
+   structure BoolVector = MonoVector
+   structure BoolVectorSlice = MonoVector.MonoVectorSlice
+   structure BoolArray = MonoArray
+   structure BoolArraySlice = MonoArray.MonoArraySlice
+   structure BoolArray2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Int8.int)
+   structure S = EqtypeMono (type elem = Primitive.Int8.int)
    open S
 in
-   structure Int8Vector = Vector
-   structure Int8VectorSlice = VectorSlice
-   structure Int8Array = Array
-   structure Int8ArraySlice = ArraySlice
-   structure Int8Array2 = Array2
+   structure Int8Vector = MonoVector
+   structure Int8VectorSlice = MonoVector.MonoVectorSlice
+   structure Int8Array = MonoArray
+   structure Int8ArraySlice = MonoArray.MonoArraySlice
+   structure Int8Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Int16.int)
+   structure S = EqtypeMono (type elem = Primitive.Int16.int)
    open S
 in
-   structure Int16Vector = Vector
-   structure Int16VectorSlice = VectorSlice
-   structure Int16Array = Array
-   structure Int16ArraySlice = ArraySlice
-   structure Int16Array2 = Array2
+   structure Int16Vector = MonoVector
+   structure Int16VectorSlice = MonoVector.MonoVectorSlice
+   structure Int16Array = MonoArray
+   structure Int16ArraySlice = MonoArray.MonoArraySlice
+   structure Int16Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Int32.int)
+   structure S = EqtypeMono (type elem = Primitive.Int32.int)
    open S
 in
-   structure Int32Vector = Vector
-   structure Int32VectorSlice = VectorSlice
-   structure Int32Array = Array
-   structure Int32ArraySlice = ArraySlice
-   structure Int32Array2 = Array2
+   structure Int32Vector = MonoVector
+   structure Int32VectorSlice = MonoVector.MonoVectorSlice
+   structure Int32Array = MonoArray
+   structure Int32ArraySlice = MonoArray.MonoArraySlice
+   structure Int32Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Int64.int)
+   structure S = EqtypeMono (type elem = Primitive.Int64.int)
    open S
 in
-   structure Int64Vector = Vector
-   structure Int64VectorSlice = VectorSlice
-   structure Int64Array = Array
-   structure Int64ArraySlice = ArraySlice
-   structure Int64Array2 = Array2
+   structure Int64Vector = MonoVector
+   structure Int64VectorSlice = MonoVector.MonoVectorSlice
+   structure Int64Array = MonoArray
+   structure Int64ArraySlice = MonoArray.MonoArraySlice
+   structure Int64Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.IntInf.int)
+   structure S = EqtypeMono (type elem = Primitive.IntInf.int)
    open S
 in
-   structure IntInfVector = Vector
-   structure IntInfVectorSlice = VectorSlice
-   structure IntInfArray = Array
-   structure IntInfArraySlice = ArraySlice
-   structure IntInfArray2 = Array2
+   structure IntInfVector = MonoVector
+   structure IntInfVectorSlice = MonoVector.MonoVectorSlice
+   structure IntInfArray = MonoArray
+   structure IntInfArraySlice = MonoArray.MonoArraySlice
+   structure IntInfArray2 = MonoArray2
 end
 local
    structure S = Mono (type elem = Primitive.Real32.real)
    open S
 in
-   structure Real32Vector = Vector
-   structure Real32VectorSlice = VectorSlice
-   structure Real32Array = Array
-   structure Real32ArraySlice = ArraySlice
-   structure Real32Array2 = Array2
+   structure Real32Vector = MonoVector
+   structure Real32VectorSlice = MonoVector.MonoVectorSlice
+   structure Real32Array = MonoArray
+   structure Real32ArraySlice = MonoArray.MonoArraySlice
+   structure Real32Array2 = MonoArray2
 end
 local
    structure S = Mono (type elem = Primitive.Real64.real)
    open S
 in
-   structure Real64Vector = Vector
-   structure Real64VectorSlice = VectorSlice
-   structure Real64Array = Array
-   structure Real64ArraySlice = ArraySlice
-   structure Real64Array2 = Array2
+   structure Real64Vector = MonoVector
+   structure Real64VectorSlice = MonoVector.MonoVectorSlice
+   structure Real64Array = MonoArray
+   structure Real64ArraySlice = MonoArray.MonoArraySlice
+   structure Real64Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Word8.word)
+   structure S = EqtypeMono (type elem = Primitive.Word8.word)
    open S
 in
-   structure Word8Vector = Vector
-   structure Word8VectorSlice = VectorSlice
-   structure Word8Array = Array
-   structure Word8ArraySlice = ArraySlice
-   structure Word8Array2 = Array2
+   structure Word8Vector = MonoVector
+   structure Word8VectorSlice = MonoVector.MonoVectorSlice
+   structure Word8Array = MonoArray
+   structure Word8ArraySlice = MonoArray.MonoArraySlice
+   structure Word8Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Word16.word)
+   structure S = EqtypeMono (type elem = Primitive.Word16.word)
    open S
 in
-   structure Word16Vector = Vector
-   structure Word16VectorSlice = VectorSlice
-   structure Word16Array = Array
-   structure Word16ArraySlice = ArraySlice
-   structure Word16Array2 = Array2
+   structure Word16Vector = MonoVector
+   structure Word16VectorSlice = MonoVector.MonoVectorSlice
+   structure Word16Array = MonoArray
+   structure Word16ArraySlice = MonoArray.MonoArraySlice
+   structure Word16Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Word32.word)
+   structure S = EqtypeMono (type elem = Primitive.Word32.word)
    open S
 in
-   structure Word32Vector = Vector
-   structure Word32VectorSlice = VectorSlice
-   structure Word32Array = Array
-   structure Word32ArraySlice = ArraySlice
-   structure Word32Array2 = Array2
+   structure Word32Vector = MonoVector
+   structure Word32VectorSlice = MonoVector.MonoVectorSlice
+   structure Word32Array = MonoArray
+   structure Word32ArraySlice = MonoArray.MonoArraySlice
+   structure Word32Array2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Primitive.Word64.word)
+   structure S = EqtypeMono (type elem = Primitive.Word64.word)
    open S
 in
-   structure Word64Vector = Vector
-   structure Word64VectorSlice = VectorSlice
-   structure Word64Array = Array
-   structure Word64ArraySlice = ArraySlice
-   structure Word64Array2 = Array2
+   structure Word64Vector = MonoVector
+   structure Word64VectorSlice = MonoVector.MonoVectorSlice
+   structure Word64Array = MonoArray
+   structure Word64ArraySlice = MonoArray.MonoArraySlice
+   structure Word64Array2 = MonoArray2
 end
 
 
 local
-   structure S = EqMono (type elem = Char.char)
+   structure S = EqtypeMonoX (type elem = Char.char)
    open S
 in
-   structure CharArray = Array
-   structure CharArray2 = Array2
-   structure CharArraySlice = ArraySlice
-   structure CharVector = Vector
-   structure CharVectorSlice = VectorSlice
+   structure CharVector = MonoVector
+   structure CharVectorSlice = MonoVector.MonoVectorSlice
+   structure CharArray = MonoArray
+   structure CharArraySlice = MonoArray.MonoArraySlice
+   structure CharArray2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = WideChar.char)
+   structure S = EqtypeMonoX (type elem = WideChar.char)
    open S
 in
-   structure WideCharArray = Array
-   structure WideCharArray2 = Array2
-   structure WideCharArraySlice = ArraySlice
-   structure WideCharVector = Vector
-   structure WideCharVectorSlice = VectorSlice
+   structure WideCharVector = MonoVector
+   structure WideCharVectorSlice = MonoVector.MonoVectorSlice
+   structure WideCharArray = MonoArray
+   structure WideCharArraySlice = MonoArray.MonoArraySlice
+   structure WideCharArray2 = MonoArray2
+end
+
+local
+   structure S = EqtypeMono (type elem = Int.int)
+   open S
+in
+   structure IntVector = MonoVector
+   structure IntVectorSlice = MonoVector.MonoVectorSlice
+   structure IntArray = MonoArray
+   structure IntArraySlice = MonoArray.MonoArraySlice
+   structure IntArray2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Int.int)
+   structure S = EqtypeMono (type elem = LargeInt.int)
    open S
 in
-   structure IntVector = Vector
-   structure IntVectorSlice = VectorSlice
-   structure IntArray = Array
-   structure IntArraySlice = ArraySlice
-   structure IntArray2 = Array2
-end
-local
-   structure S = EqMono (type elem = LargeInt.int)
-   open S
-in
-   structure LargeIntVector = Vector
-   structure LargeIntVectorSlice = VectorSlice
-   structure LargeIntArray = Array
-   structure LargeIntArraySlice = ArraySlice
-   structure LargeIntArray2 = Array2
+   structure LargeIntVector = MonoVector
+   structure LargeIntVectorSlice = MonoVector.MonoVectorSlice
+   structure LargeIntArray = MonoArray
+   structure LargeIntArraySlice = MonoArray.MonoArraySlice
+   structure LargeIntArray2 = MonoArray2
 end
 local
    structure S = Mono (type elem = Real.real)
    open S
 in
-   structure RealVector = Vector
-   structure RealVectorSlice = VectorSlice
-   structure RealArray = Array
-   structure RealArraySlice = ArraySlice
-   structure RealArray2 = Array2
+   structure RealVector = MonoVector
+   structure RealVectorSlice = MonoVector.MonoVectorSlice
+   structure RealArray = MonoArray
+   structure RealArraySlice = MonoArray.MonoArraySlice
+   structure RealArray2 = MonoArray2
 end
 local
    structure S = Mono (type elem = LargeReal.real)
    open S
 in
-   structure LargeRealVector = Vector
-   structure LargeRealVectorSlice = VectorSlice
-   structure LargeRealArray = Array
-   structure LargeRealArraySlice = ArraySlice
-   structure LargeRealArray2 = Array2
+   structure LargeRealVector = MonoVector
+   structure LargeRealVectorSlice = MonoVector.MonoVectorSlice
+   structure LargeRealArray = MonoArray
+   structure LargeRealArraySlice = MonoArray.MonoArraySlice
+   structure LargeRealArray2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = Word.word)
+   structure S = EqtypeMono (type elem = Word.word)
    open S
 in
-   structure WordVector = Vector
-   structure WordVectorSlice = VectorSlice
-   structure WordArray = Array
-   structure WordArraySlice = ArraySlice
-   structure WordArray2 = Array2
+   structure WordVector = MonoVector
+   structure WordVectorSlice = MonoVector.MonoVectorSlice
+   structure WordArray = MonoArray
+   structure WordArraySlice = MonoArray.MonoArraySlice
+   structure WordArray2 = MonoArray2
 end
 local
-   structure S = EqMono (type elem = LargeWord.word)
+   structure S = EqtypeMono (type elem = LargeWord.word)
    open S
 in
-   structure LargeWordVector = Vector
-   structure LargeWordVectorSlice = VectorSlice
-   structure LargeWordArray = Array
-   structure LargeWordArraySlice = ArraySlice
-   structure LargeWordArray2 = Array2
+   structure LargeWordVector = MonoVector
+   structure LargeWordVectorSlice = MonoVector.MonoVectorSlice
+   structure LargeWordArray = MonoArray
+   structure LargeWordArraySlice = MonoArray.MonoArraySlice
+   structure LargeWordArray2 = MonoArray2
 end

--- a/basis-library/arrays-and-vectors/sequence0.sml
+++ b/basis-library/arrays-and-vectors/sequence0.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 2014 Rob Simmons.
+(* Copyright (C) 2015 Matthew Fluet.
+ * Copyright (C) 2014 Rob Simmons.
  * Copyright (C) 2013 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
@@ -9,15 +10,15 @@
  *)
 
 functor PrimSequence (S: sig
-                        type 'a sequence 
-                        type 'a elt
-                        (* fromArray should be constant time. *)
-                        val fromArray: 'a elt array -> 'a sequence 
-                        val isMutable: bool
-                        val length: 'a sequence -> SeqIndex.int
-                        val subUnsafe: 'a sequence * SeqIndex.int -> 'a elt
-                     end
-                  ): PRIM_SEQUENCE =
+                            type 'a sequence
+                            type 'a elt
+                            (* fromArray should be constant time. *)
+                            val fromArray: 'a elt array -> 'a sequence
+                            val isMutable: bool
+                            val length: 'a sequence -> SeqIndex.int
+                            val subUnsafe: 'a sequence * SeqIndex.int -> 'a elt
+                         end) :> PRIM_SEQUENCE where type 'a sequence = 'a S.sequence
+                                               where type 'a elt = 'a S.elt =
    struct
       structure Array = Primitive.Array
       

--- a/basis-library/net/socket.sml
+++ b/basis-library/net/socket.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2012,2013 Matthew Fluet.
+(* Copyright (C) 2012,2013,2015 Matthew Fluet.
  * Copyright (C) 2002-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -389,10 +389,10 @@ fun mk_out_flags {don't_route, oob} =
               0x0))
 
 local
-   fun make (base, primSend, primSendTo) =
+   fun make (toPoly, base, primSend, primSendTo) =
       let
          val base = fn sl => let val (buf, i, sz) = base sl
-                             in (buf, i, sz)
+                             in (toPoly buf, i, sz)
                              end
          fun send' (s, sl, out_flags) =
             let
@@ -450,10 +450,10 @@ local
 in
    val (sendArr, sendArr', sendArrNB, sendArrNB',
         sendArrTo, sendArrTo', sendArrToNB, sendArrToNB') =
-      make (Word8ArraySlice.base, Prim.sendArr, Prim.sendArrTo)
+      make (Word8Array.toPoly, Word8ArraySlice.base, Prim.sendArr, Prim.sendArrTo)
    val (sendVec, sendVec', sendVecNB, sendVecNB',
         sendVecTo, sendVecTo', sendVecToNB, sendVecToNB') =
-      make (Word8VectorSlice.base, Prim.sendVec, Prim.sendVecTo)
+      make (Word8Vector.toPoly, Word8VectorSlice.base, Prim.sendVec, Prim.sendVecTo)
 end
 
 type in_flags = {peek: bool, oob: bool}

--- a/doc/changelog
+++ b/doc/changelog
@@ -1,5 +1,9 @@
 Here are the changes from version 20130715 to version YYYYMMDD.
 
+* 2015-06-10
+  - Hide equality status of poly (and mono) vector and array slices.
+  - Hide type equality of mono and poly Word8.word arrays and vectors.
+
 * 2015-06-08
   - Added "reentrant" attribute to _import.  An _import-ed C function
     that (directly or indirectly) calls an _export-ed SML function


### PR DESCRIPTION
* Hide type equality of mono and poly Word8.word arrays and vectors; fixes MLton/mlton#45.
* Hide equality status of poly (and mono) vector and array slices; fixes MLton/mlton#47.
