### PR TITLE
Configure GMP location via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ CP := /bin/cp -fpR
 GZIP := gzip --force --best
 RANLIB := ranlib
 
+WITH_GMP :=
+ifneq ($(WITH_GMP),)
+WITH_GMP_INC_DIR := $(WITH_GMP)/include
+WITH_GMP_LIB_DIR := $(WITH_GMP)/lib
+endif
+
 # If we're compiling with another version of MLton, then we want to do
 # another round of compilation so that we get a MLton built without
 # stubs.
@@ -213,7 +219,8 @@ runtime:
 
 .PHONY: script
 script:
-	$(CP) bin/mlton-script "$(MLTON)"
+	sed -e "/^gmpIncDir=/s;.*;gmpIncDir='$(WITH_GMP_INC_DIR)';" -e "/^gmpLibDir=/s;.*;gmpLibDir='$(WITH_GMP_LIB_DIR)';"	\
+		<bin/mlton-script >"$(MLTON)"
 	chmod a+x "$(MLTON)"
 	$(CP) "$(SRC)/bin/platform" "$(LIB)"
 	$(CP) "$(SRC)/bin/static-library" "$(LIB)"

--- a/bin/mlton-script
+++ b/bin/mlton-script
@@ -70,28 +70,21 @@ doit () {
         exit 1
 }
 
+# You may need to set 'gmpIncDir' so the C compiler can find gmp.h.
+gmpIncDir=
+if [ -n "$gmpIncDir" ]; then
+gmpCCOpts="-cc-opt -I$gmpIncDir"
+fi
+# You may need to set 'gmpLibDir' so the C compiler can find libgmp.
+gmpLibDir=
+if [ -n "$gmpLibDir" ]; then
+gmpLinkOpts="-link-opt -L$gmpLibDir -target-link-opt netbsd -Wl,-R$gmpLibDir"
+fi
+
 # For align-{functions,jumps,loops}, we use -m for now instead of
 # -f because old gcc's will barf on -f, while newer ones only warn
 # about -m.  Someday, when we think we won't run into older gcc's,
 # these should be changed to -f.
-
-# You may need to add a line with -cc-opt 'I/path/to/gmp.h' so the
-# C compiler can find gmp.h
-# You may need to add a line with -link-opt '-L/path/to/libgmp' so
-# that the linker can find libgmp.
-
-# The darwin linker complains (loudly) about non-existent library
-# search paths.
-darwinLinkOpts=''
-if [ -d '/usr/local/lib' ]; then
-        darwinLinkOpts="$darwinLinkOpts -L/usr/local/lib"
-fi
-if [ -d '/opt/local/lib' ]; then
-        darwinLinkOpts="$darwinLinkOpts -L/opt/local/lib"
-fi
-if [ -d '/sw/lib' ]; then
-        darwinLinkOpts="$darwinLinkOpts -L/sw/lib"
-fi
 
 doit "$lib" \
         -ar-script "$lib/static-library"                         \
@@ -100,19 +93,13 @@ doit "$lib" \
         -cc-opt '-O1 -fno-common'                                \
         -cc-opt '-fno-strict-aliasing -fomit-frame-pointer -w'   \
         -link-opt '-lm -lgmp'                                    \
+        $gmpCCOpts $gmpLinkOpts                                  \
         -mlb-path-map "$lib/mlb-path-map"                        \
         -target-as-opt amd64 '-m64'                              \
         -target-as-opt x86 '-m32'                                \
         -target-cc-opt alpha                                     \
                 '-mieee -mbwx -mtune=ev6 -mfp-rounding-mode=d'   \
         -target-cc-opt amd64 '-m64'                              \
-        -target-cc-opt darwin                                    \
-                '-I/usr/local/include
-                 -I/opt/local/include
-                 -I/sw/include'                                  \
-        -target-cc-opt freebsd '-I/usr/local/include'            \
-        -target-cc-opt netbsd '-I/usr/pkg/include'               \
-        -target-cc-opt openbsd '-I/usr/local/include'            \
         -target-cc-opt aix '-maix64'                             \
         -target-cc-opt ia64 "$ia64hpux -mtune=itanium2"          \
         -target-cc-opt sparc '-m32 -mcpu=v8 -Wa,-xarch=v8plusa'  \
@@ -128,16 +115,12 @@ doit "$lib" \
         -target-link-opt alpha                                   \
                 '-mieee -mbwx -mtune=ev6 -mfp-rounding-mode=d'   \
         -target-link-opt darwin "$darwinLinkOpts"                \
-        -target-link-opt freebsd '-L/usr/local/lib/'             \
         -target-link-opt aix '-maix64'                           \
         -target-link-opt ia64 "$ia64hpux"                        \
         -target-link-opt linux '-Wl,-znoexecstack'               \
         -target-link-opt mingw                                   \
                 '-lws2_32 -lkernel32 -lpsapi -lnetapi32 -lwinmm' \
         -target-link-opt mingw '-Wl,--enable-stdcall-fixup'      \
-        -target-link-opt netbsd                                  \
-                '-Wl,-R/usr/pkg/lib -L/usr/pkg/lib/'             \
-        -target-link-opt openbsd '-L/usr/local/lib/'             \
         -target-link-opt solaris '-lnsl -lsocket -lrt'           \
         -target-link-opt x86 '-m32'                              \
         -profile-exclude '\$\(SML_LIB\)'                         \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -21,6 +21,12 @@ AR := $(TARGET)-ar rc
 RANLIB := $(TARGET)-ranlib
 endif
 
+WITH_GMP :=
+ifneq ($(WITH_GMP),)
+WITH_GMP_INC_DIR := "$(WITH_GMP)/include"
+WITH_GMP_LIB_DIR := "$(WITH_GMP)/lib"
+endif
+
 TARGET_ARCH := $(shell ../bin/host-arch)
 TARGET_OS := $(shell ../bin/host-os)
 GCC_MAJOR_VERSION :=						\
@@ -142,32 +148,19 @@ ifeq ($(TARGET_OS), cygwin)
 EXE := .exe
 endif
 
-ifeq ($(TARGET_OS), darwin)
-XCFLAGS += -I/usr/local/include -I/sw/include -I/opt/local/include
-endif
-
-ifeq ($(TARGET_OS), freebsd)
-XCFLAGS += -I/usr/local/include
-endif
-
 ifeq ($(TARGET_OS), mingw)
 EXE := .exe
 # GCC doesn't recognize the %I64 format specifier which means %ll on windows
 XCFLAGS += -Wno-format -Wno-missing-format-attribute
 endif
 
-ifeq ($(TARGET_OS), netbsd)
-XCFLAGS += -I/usr/pkg/include
-endif
-
-ifeq ($(TARGET_OS), openbsd)
-XCFLAGS += -I/usr/local/include
-endif
-
 ifeq ($(TARGET_OS), solaris)
 XCFLAGS += -funroll-all-loops
 endif
 
+ifneq ($(WITH_GMP_INC_DIR),)
+XCFLAGS += -I$(WITH_GMP_INC_DIR)
+endif
 
 XCFLAGS += -I. -Iplatform
 OPTCFLAGS := $(CFLAGS) $(CPPFLAGS) $(XCFLAGS) $(OPTXCFLAGS)
@@ -391,6 +384,7 @@ flags:
 	echo GCC_MINOR_VERSION = $(GCC_MINOR_VERSION)
 	echo GCC_VERSION = $(GCC_VERSION)
 	echo EXE = $(EXE)
+	echo XCFLAGS = $(XCFLAGS)
 	echo OPTXCFLAGS = $(OPTXCFLAGS)
 	echo DEBUGXCFLAGS = $(DEBUGXCFLAGS)
 	echo PICXCFLAGS = $(PICXCFLAGS)


### PR DESCRIPTION
Use a WITH_GMP Makefile variable to specify the GMP location.  The GMP
location is propagated to the bin/mlton script.

Configuring the GMP location is only necessary if gmp.h and/or libgmp
are not found on the default include and/or library paths.

See MLton/mlton#134.