### PR TITLE
Added path.sig and path.fun to mlb-formal.

### DIFF
--- a/doc/mlb-formal/mlb-formal.tex
+++ b/doc/mlb-formal/mlb-formal.tex
@@ -151,7 +151,11 @@ shown in Figure~\ref{fig:mlb:S:GrammaticalRules}.
 \msf{path.mlb} &
 \mbox{import ML basis} \\&&
 \msf{path.sml} 
-& \mbox{import source} \\
+& \mbox{import source} \\&&
+\msf{path.sig} 
+& \mbox{import signature} \\&&
+\msf{path.fun} 
+& \mbox{import source (functor)} \\
 
 \mit{basbind} & ::= &  
 \mit{basid} ~\mtt{=}~ \mit{basexp} ~\langle\mtt{and}~ \mit{basbind}\rangle \\


### PR DESCRIPTION
I checked all 3 major compilers - MLton, smlnj, MLKit. Their `.mlb` files include only `.mlb`, `.sml`, `.sig` and `.fun` files. Two latter file types are missing from mlb-formal.tex. Please check if I added them properly.