### PR TITLE
Remove use of open in lrtable.sml of MLYacc lib

### DIFF
--- a/lib/mlyacc-lib/lrtable.sml
+++ b/lib/mlyacc-lib/lrtable.sml
@@ -1,7 +1,7 @@
 (* ML-Yacc Parser Generator (c) 1989 Andrew W. Appel, David R. Tarditi *)
 structure LrTable : LR_TABLE =
     struct
-        open Array List
+        val sub = Array.sub
         infix 9 sub
         datatype ('a,'b) pairlist = EMPTY
                                   | PAIR of 'a * 'b * ('a,'b) pairlist


### PR DESCRIPTION
Recent versions of SML/NJ (and, hopefully, future versions of MLton)
have implemented proposed Basis Library improvements, including adding
`List.sub` as an alias for `List.nth`.  In the MLYacc library, a
declaration of the form

    open Array List

results in `List.sub` shadowing `Array.sub`, leading to subsequent type
errors at the use of `sub`.  As the only unqualified name needed is
`sub`, replace the declaration with

    val sub = Array.sub

as has been done in the SML/NJ sources (see
https://smlnj-gforge.cs.uchicago.edu/scm/viewvc.php?view=rev&root=smlnj&revision=4133).