### PR TITLE
Fix args to GC_mmapAnon_safe_protect

### DIFF
--- a/runtime/gc/signals.c
+++ b/runtime/gc/signals.c
@@ -26,7 +26,7 @@ void initSignalStack (GC_state s) {
 #if NEEDS_SIGALTSTACK_EXEC
     prot = prot | PROT_EXEC;
 #endif
-    void *ss_sp = GC_mmapAnon_safe_protect (NULL, 2 * ss_size, psize, psize, prot);
+    void *ss_sp = GC_mmapAnon_safe_protect (NULL, 2 * ss_size, prot, psize, psize);
     altstack.ss_sp = (void*)((pointer)ss_sp + ss_size);
     altstack.ss_size = ss_size;
     altstack.ss_flags = 0;


### PR DESCRIPTION
Commit 6435e0e erroneously passed the `prot` as the last, rather than
the third, argument to GC_mmapAnon_safe_protect.