### PR TITLE
Fixes to bootstrapping script and documentation

### DIFF
--- a/bin/add-cross
+++ b/bin/add-cross
@@ -57,7 +57,7 @@ original=`pwd`
 dir=`dirname "$0"`
 src=`cd "$dir/.." && pwd`
 
-PATH="$dir":$PATH
+PATH="$src"/bin:$PATH
 
 # libDir is the mlton lib directory where you would like the
 # cross-compiler information to be installed.  If you have installed

--- a/doc/guide/src/PortingMLton.adoc
+++ b/doc/guide/src/PortingMLton.adoc
@@ -150,6 +150,7 @@ mlton -stop g -target <target> mlton.mlb
 rm -rf self
 mv <target> self
 ----
+Also make sure you have all the header files in build/lib/include. You can copy them from a host machine that has run `make runtime`.
 
 4. On the target machine, compile and link MLton.  That is, in the  mlton directory, do something like:
 +
@@ -167,6 +168,8 @@ gcc -o build/lib/mlton-compile \
 ----
 make basis-no-check script mlbpathmap targetmap constants libraries tools
 ----
+
+6. Making the last tool, mlyacc, will fail, because mlyacc cannot bootstrap its own yacc.grm.* files. On the host machine, run `make -C mlyacc src/yacc.grm.sml`. Then copy both files to the target machine, and compile mlyacc, making sure to supply the path to your newly compile mllex: `make -C mlyacc MLLEX=mllex/mllex`. 
 
 There are other details to get right, like making sure that the tools
 directories were clean so that the tools are rebuilt on the new

--- a/doc/guide/src/PortingMLton.adoc
+++ b/doc/guide/src/PortingMLton.adoc
@@ -166,7 +166,7 @@ gcc -o build/lib/mlton-compile \
 5. At this point, MLton should be working and you can finish the rest of a usual make on the target machine.
 +
 ----
-make basis-no-check script mlbpathmap targetmap constants libraries tools
+make basis-no-check script mlbpathmap constants libraries tools
 ----
 
 6. Making the last tool, mlyacc, will fail, because mlyacc cannot bootstrap its own yacc.grm.* files. On the host machine, run `make -C mlyacc src/yacc.grm.sml`. Then copy both files to the target machine, and compile mlyacc, making sure to supply the path to your newly compile mllex: `make -C mlyacc MLLEX=mllex/mllex`. 


### PR DESCRIPTION
Successfully bootstrapping MLton on Fedora aarch64 required two sets of changes that I have put in this pull request.

1. add-cross should set the $PATH variable in a more robust way. Using dirname to set the $PATH of the bin directory, when add-cross is invoked from the bin directory itself, results in '.' being added to $PATH. This causes add-cross to fail. Using a relative path from "$src" picks up the full path of the bin directory from pwd.

2. The documentation neglects to mention two steps. The first is the copying of all relevant includes to the target machine. The second is a complexity in bootstrapping mlyacc. Note that the changes I made to the documentation presuppose that the includes in build/lib/include, and the files mlyacc/src/mlyacc.grm.*, are all architecture-independent. I believe this is correct, but I might be mistaken.

(Sorry for any confusion for the previous pull request. I'm also sorry for not separating these out, I'm not sure how to.)