### PR TITLE
Various SuccessorML updates

### DIFF
--- a/basis-library/text/char0.sml
+++ b/basis-library/text/char0.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -26,20 +27,20 @@ local
             ord       = Int.zextdFromWord8 o Prim8.idToWord8,
             minChar   = #"\000",
             maxChar   = #"\255",
-            numChars  = 256
+            numChars  = 256 (* 0x100 *)
          }
          val fChar16 : Prim16.char t = {
             chrUnsafe = Prim16.idFromWord16 o Int.sextdToWord16,
             ord       = Int.zextdFromWord16 o Prim16.idToWord16,
             minChar   = #"\000",
             maxChar   = #"\uFFFF",
-            numChars  = 65536
+            numChars  = 65536 (* 0x10000 *)
             }
          val fChar32 : Prim32.char t = {
             chrUnsafe = Prim32.idFromWord32 o Int.sextdToWord32,
             ord       = Int.zextdFromWord32 o Prim32.idToWord32,
             minChar   = #"\000",
-            maxChar   = #"\U0010FFFF",
+            maxChar   = Prim32.idFromWord32 0wx0010FFFF,
             numChars  = 1114112 (* 0x110000 *)
          }
       end

--- a/bin/regression
+++ b/bin/regression
@@ -193,6 +193,7 @@ for f in *.sml; do
                         ann 
                                 \"allowFFI true\"
                                 \"allowOverload true\"
+                                \"allowExtendedTextConsts true\"
                                 \"nonexhaustiveMatch ignore\"
                                 \"redundantMatch ignore\"
                         in $f.sml 

--- a/doc/guide/src/MLBasisAnnotations.adoc
+++ b/doc/guide/src/MLBasisAnnotations.adoc
@@ -28,6 +28,49 @@ If `true`, allow `_address`, `_export`, `_import`, and `_symbol`
 expressions to appear in source files.  See
 <:ForeignFunctionInterface:>.
 
+* +allowSuccessorML {false|true}+
++
+--
+Allow or disallow all of the <:SuccessorML:> features.  This is a
+proxy for all of the following annotations.
+
+** +allowDoDecls {false|true}+
++
+If `true`, allow `do` declarations.
+
+** +allowExtendedLiterals {false|true}+
++
+If `true`, allow extended literals.
+
+** +allowLineComments {false|true}+
++
+If `true`, allow line comments.
+
+** +allowOptBar {false|true}+
++
+If `true`, allow a bar to appear before the first constructor of a
+`datatype` declaration or specification and allow a bar to appear
+before the first matchrule of `case`, `fn`, and `handle` expressions.
+
+** +allowOptSemicolon {false|true}+
++
+If `true`, allows a semicolon to appear after the last expression in a
+sequence expression or `let` body.
+
+** +allowOrPats {false|true}+
++
+If `true`, allows disjunctive patterns.
+
+** +allowRecPunning {false|true}+
++
+If `true`, allows record punning.
+
+** +allowSigWithtype {false|true}+
++
+If `true`, allows `withtype` to modify datatype specifications in
+signatures.
+--
+
 * +forceUsed+
 +
 Force all identifiers in the basis denoted by the body of the `ann` to
@@ -80,46 +123,6 @@ error will abort a compile, while a warning will not.
 * +warnUnused {false|true}+
 +
 Report unused identifiers.
-
-Here are the annotations for enabling SuccessorML
-features.  The default value for all of these annotations is false,
-the SuccessorML features are all disabled by default.
-For information on the SuccessorML features
-see <:SuccessorML:>.
-
-* +allowDoDecls {false|true}+
-+
-If `true` allows for the usage of do declarations.
-
-* +allowExtendedLiterals {false|true}+
-+
-If `true` allows for the usage of extended literals.
-
-* +allowLineComments {false|true}+
-+
-If `true` allows for the usage of line comments.
-
-* +allowOptBar {false|true}+
-+
-If `true` allows for a pattern bar to optionally be placed before the
-first match in a case expression.
-
-* +allowOptSemicolon {false|true}+
-+
-If `true` allows for a semicolon to optionally be placed after the last
-expression in a series.
-
-* +allowOrPats {false|true}+
-+
-If `true` allows for the usage of disjunctive patterns.
-
-* +allowRecPunning {false|true}+
-+
-If `true` allows for the usage record punning.
-
-* +allowSigWithtype {false|true}+
-+
-If `true` allows for the usage the withtype keyword in signatures.
 
 == Next Steps ==
 

--- a/doc/guide/src/MLBasisAnnotations.adoc
+++ b/doc/guide/src/MLBasisAnnotations.adoc
@@ -38,9 +38,16 @@ proxy for all of the following annotations.
 +
 If `true`, allow `do` declarations.
 
-** +allowExtendedLiterals {false|true}+
+** +allowExtendedConsts {false|true}+
 +
-If `true`, allow extended literals.
+--
+Allow or disallow all of the extended constants features.  This is a
+proxy for all of the following annoations.
+
+*** +allowExtendedNumConsts {false|true}+
++
+If `true`, allow extended numeric constants.
+--
 
 ** +allowLineComments {false|true}+
 +

--- a/doc/guide/src/MLBasisAnnotations.adoc
+++ b/doc/guide/src/MLBasisAnnotations.adoc
@@ -47,6 +47,10 @@ proxy for all of the following annoations.
 *** +allowExtendedNumConsts {false|true}+
 +
 If `true`, allow extended numeric constants.
+
+*** +allowExtendedTextConsts {false|true}+
++
+If `true`, allow extended text constants.
 --
 
 ** +allowLineComments {false|true}+

--- a/doc/guide/src/MLBasisAnnotations.adoc
+++ b/doc/guide/src/MLBasisAnnotations.adoc
@@ -36,13 +36,13 @@ proxy for all of the following annotations.
 
 ** +allowDoDecls {false|true}+
 +
-If `true`, allow `do` declarations.
+If `true`, allow a +do _exp_+ declaration form.
 
 ** +allowExtendedConsts {false|true}+
 +
 --
 Allow or disallow all of the extended constants features.  This is a
-proxy for all of the following annoations.
+proxy for all of the following annotations.
 
 *** +allowExtendedNumConsts {false|true}+
 +
@@ -55,13 +55,15 @@ If `true`, allow extended text constants.
 
 ** +allowLineComments {false|true}+
 +
-If `true`, allow line comments.
+If `true`, allow line comments beginning with the token ++(*)++.
 
 ** +allowOptBar {false|true}+
 +
-If `true`, allow a bar to appear before the first constructor of a
-`datatype` declaration or specification and allow a bar to appear
-before the first matchrule of `case`, `fn`, and `handle` expressions.
+If `true`, allow a bar to appear before the first match rule of a
+`case`, `fn`, or `handle` expression, allow a bar to appear before the
+first function-value binding of a `fun` declaration, and allow a bar
+to appear before the first constructor binding or description of a
+`datatype` declaration or specification.
 
 ** +allowOptSemicolon {false|true}+
 +
@@ -70,16 +72,17 @@ sequence expression or `let` body.
 
 ** +allowOrPats {false|true}+
 +
-If `true`, allows disjunctive patterns.
+If `true`, allows disjunctive (a.k.a., "or") patterns of the form
++_pat_ | _pat_+.
 
-** +allowRecPunning {false|true}+
+** +allowRecordPunExps {false|true}+
 +
-If `true`, allows record punning.
+If `true`, allows record punning expressions.
 
 ** +allowSigWithtype {false|true}+
 +
-If `true`, allows `withtype` to modify datatype specifications in
-signatures.
+If `true`, allows `withtype` to modify a `datatype` specification in a
+signature.
 --
 
 * +forceUsed+

--- a/doc/guide/src/SuccessorML.adoc
+++ b/doc/guide/src/SuccessorML.adoc
@@ -1,19 +1,21 @@
 SuccessorML
 ===========
 
-The purpose of http://successor-ml.org[successor ML], or sML for
-short, is to provide a vehicle for the continued evolution of ML,
-using Standard ML as a starting point. The intention is for successor
-ML to be a living, evolving dialect of ML that is responsive to
-community needs and advances in language design, implementation, and
-semantics.
+The purpose of http://sml-family.org/successor-ml/[successor ML], or
+sML for short, is to provide a vehicle for the continued evolution of
+ML, using Standard ML as a starting point. The intention is for
+successor ML to be a living, evolving dialect of ML that is responsive
+to community needs and advances in language design, implementation,
+and semantics.
 
 == SuccessorML Features in MLton ==
 
 The following SuccessorML features have been implemented in MLton.
-The features are disabled by default, and may be enabled utilizing
-the feature's corresponding <:MLBasisAnnotations:ML Basis annotation>
-which is listed directly after the feature name.
+The features are disabled by default, and may be enabled utilizing the
+feature's corresponding <:MLBasisAnnotations:ML Basis annotation>
+which is listed directly after the feature name.  In addition, the
++allowSuccessorML {false|true}+ annotation can be used to
+simultaneously enable all of the features.
 
 * Do Declarations: +allowDoDecls {false|true}+
 +

--- a/doc/guide/src/SuccessorML.adoc
+++ b/doc/guide/src/SuccessorML.adoc
@@ -63,7 +63,7 @@ val i = 4__327__829
 val r = 6.022_140_9e23
 ----
 
-** Extended Text Constants: +allowExtendedTextConsts {false|true}+
+** <!Anchor(ExtendedTextConsts)> Extended Text Constants: +allowExtendedTextConsts {false|true}+
 +
 Allow characters with integer codes &ge; 128 and &le; 247 that
 correspond to syntactically well-formed UTF-8 byte sequences in text

--- a/doc/guide/src/SuccessorML.adoc
+++ b/doc/guide/src/SuccessorML.adoc
@@ -39,14 +39,18 @@ Instead, the following syntax may be used:
 do print "Hello world.\n"
 ----
 
-* Extended Literals: +allowExtendedLiterals {false|true}+
+* Extended Constants: +allowExtendedConsts {false|true}+
 +
-This feature allows for binary literals to be used.
-Additionally, underscores may be used throughout
-literals to group digits together for convenience.
-Note: literals cannot be started or ended with underscores.
+--
+Allow or disallow all of the extended constants features.  This is a
+proxy for all of the following annoations.
+
+** Extended Numeric Constants: +allowExtendedNumConsts {false|true}+
 +
-Below are some examples of extended literal syntax.
+Allow underscores as a separator in numeric literal and allow binary
+integer and word constants.
++
+Below are some examples of extended numeric constant syntax.
 +
 [source,sml]
 ----
@@ -54,6 +58,7 @@ val b = 0b10101
 val nb = ~0b10_10_10
 val bw = 0wb1010
 val x = 4_327_829
+val r = 6.022_140_9e23
 ----
 +
 Below are some non-examples of extended literal syntax.
@@ -63,8 +68,10 @@ Below are some non-examples of extended literal syntax.
 val b = 0b101_
 val nb = ~0b_10_10_
 val h = 0x_09_a
-val x - _12_3
+val x = _12_3
+val r = 3.14_19_
 ----
+--
 
 * Line Comments: +allowLineComments {false|true}+
 +

--- a/doc/guide/src/SuccessorML.adoc
+++ b/doc/guide/src/SuccessorML.adoc
@@ -17,78 +17,173 @@ which is listed directly after the feature name.  In addition, the
 +allowSuccessorML {false|true}+ annotation can be used to
 simultaneously enable all of the features.
 
-* Do Declarations: +allowDoDecls {false|true}+
+* `do` Declarations: +allowDoDecls {false|true}+
 +
-Evaluating functions for their side effects is a common idiom seen
-in SML.  This feature allows for the same functionality but in an
-alternative syntax.  It is requried that the expression being
-evaluated has the type of unit in order to use a do declaration.
-+
-Commonly one may perform either of the following:
-+
-[source,sml]
-----
-val _ = print "Hello world.\n"
-val () = print "Hello world.\n"
-----
-+
-Instead, the following syntax may be used:
+Allow a +do _exp_+ declaration form, which evaluates _exp_ for its
+side effects.  The following example uses a `do` declaration:
 +
 [source,sml]
 ----
 do print "Hello world.\n"
+----
++
+and is equivalent to:
++
+[source,sml]
+----
+val () = print "Hello world.\n"
 ----
 
 * Extended Constants: +allowExtendedConsts {false|true}+
 +
 --
 Allow or disallow all of the extended constants features.  This is a
-proxy for all of the following annoations.
+proxy for all of the following annotations.
 
 ** Extended Numeric Constants: +allowExtendedNumConsts {false|true}+
 +
-Allow underscores as a separator in numeric literals and allow binary
+Allow underscores as a separator in numeric constants and allow binary
 integer and word constants.
 +
-Below are some examples of extended numeric constant syntax.
+Underscores in a numeric constant must occur between digits and
+consecutive underscores are allowed.
++
+Binary integer constants use the prefix +0b+ and binary word constants
+use the prefix +0wb+.
++
+The following example uses extended numeric constants (although it may
+be incorrectly syntax highlighted):
 +
 [source,sml]
 ----
-val b = 0b10101
+val pb = 0b10101
 val nb = ~0b10_10_10
-val bw = 0wb1010
-val x = 4_327_829
+val wb = 0wb1010
+val i = 4__327__829
 val r = 6.022_140_9e23
-----
-+
-Below are some non-examples of extended numeric constant syntax.
-+
-[source,sml]
-----
-val b = 0b101_
-val nb = ~0b_10_10_
-val h = 0x_09_a
-val x = _12_3
-val r = 3.14_19_
 ----
 
 ** Extended Text Constants: +allowExtendedTextConsts {false|true}+
 +
-Allow characters with integer codes >= 128 that correspond to
-syntactically well-formed UTF8 byte sequences in string constants.
+Allow characters with integer codes &ge; 128 and &le; 247 that
+correspond to syntactically well-formed UTF-8 byte sequences in text
+constants.
++
+////
+and allow `\Uxxxxxxxx` numeric escapes in text constants.
+////
++
+Any 1, 2, 3, or 4 byte sequence that can be properly decoded to a
+binary number according to the UTF-8 encoding/decoding scheme is
+allowed in a text constant (but invalid sequences are not explicitly
+rejected) and denotes the corresponding sequence of characters with
+integer codes &ge; 128 and &le; 247.  This feature enables "UTF-8
+convenience" (but not comprehensive Unicode support); in particular,
+it allows one to copy text from a browser and paste it into a string
+constant in an editor and, furthermore, if the string is printed to a
+terminal, then will (typically) appear as the original text.  The
+following example uses UTF-8 byte sequences:
++
+[source,sml]
+----
+val s1 : String.string = "\240\159\130\161"
+val s2 : String.string = "🂡"
+val _ = print ("s1 --> " ^ s1 ^ "\n")
+val _ = print ("s2 --> " ^ s2 ^ "\n")
+val _ = print ("String.size s1 --> " ^ Int.toString (String.size s1) ^ "\n")
+val _ = print ("String.size s2 --> " ^ Int.toString (String.size s2) ^ "\n")
+val _ = print ("s1 = s2 --> " ^ Bool.toString (s1 = s2) ^ "\n")
+----
++
+and, when compiled and executed, will display:
++
+----
+s1 --> 🂡
+s2 --> 🂡
+String.size s1 --> 4
+String.size s2 --> 4
+s1 = s2 --> true
+----
++
+Note that the `String.string` type corresponds to any sequence of
+8-bit values, including invalid UTF-8 sequences; hence the string
+constant `"\192"` (a UTF-8 leading byte with no UTF-8 continuation
+byte) is valid.  Similarly, the `Char.char` type corresponds to a
+single 8-bit value; hence the char constant `#"α"` is not valid, as
+the text constant `"α"` denotes a sequence of two 8-bit values.
++
+////
+A `\Uxxxxxxxx` numeric escape denotes a single character with the
+hexadecimal integer code `xxxxxxxx`.  Such numeric escapes are not
+necessary for the `String.string` and `Char.char` types, since
+characters in such text constants must have integer codes &le; 255 and
+the `\ddd` and `\uxxxx` numeric escapes suffice.  However, the
+`\Uxxxxxxxx` numeric escapes are useful for the `WideString.string`
+and `WideChar.char` types, since characters in such text constants may
+have integer codes &le; 2^32^-1.  The following uses a `\Uxxxxxxxx`
+numeric escape (although it may be incorrectly syntax highlighted):
++
+[source,sml]
+----
+val s1 : WideString.string = "\U0001F0A1" (* 'PLAYING CARD ACE OF SPADES' (U+1F0A1) *)
+val _ = print ("WideString.size s1 --> " ^ Int.toString (WideString.size s1) ^ "\n")
+----
++
+and, when compiled and executed, will display:
++
+----
+WideString.size s1 --> 1
+----
++
+Note that the `WideString.string` type corresponds to any sequence of
+32-bit values, including invalid Unicode code points; hence, the
+string constants `"\U001F0000"` and `"\U40000000"` are valid (but the
+corresponding integer codes are not valid Unicode code points).
+Similarly, the `WideChar.char` type corresponds to a single 32-bit
+value.
++
+Finally, note that a UTF-8 byte sequence in a `WideString.string` or
+`WideChar.char` text constant does not denote a single 32-bit value,
+but rather a sequence of 32-bit values &ge; 128 and &le; 247.  The
+following example uses both UTF-8 byte sequences and `\Uxxxxxxxx`
+numeric escapes (although it may be incorrectly syntax highlighted):
++
+[source,sml]
+----
+val s1 : WideString.string = "\U0001F0A1" (* 'PLAYING CARD ACE OF SPADES' (U+1F0A1) *)
+val s2 : WideString.string = "🂡"
+val s3 : WideString.string = "\U000000F0\U0000009F\U00000082\U000000A1"
+val _ = print ("WideString.size s1 --> " ^ Int.toString (WideString.size s1) ^ "\n")
+val _ = print ("WideString.size s2 --> " ^ Int.toString (WideString.size s2) ^ "\n")
+val _ = print ("WideString.size s3 --> " ^ Int.toString (WideString.size s3) ^ "\n")
+val _ = print ("s1 = s2 --> " ^ Bool.toString (s1 = s2) ^ "\n")
+val _ = print ("s2 = s3 --> " ^ Bool.toString (s2 = s3) ^ "\n")
+----
++
+and, when compiled and executed, will display:
++
+----
+WideString.size s1 --> 1
+WideString.size s2 --> 4
+WideString.size s3 --> 4
+s1 = s2 --> false
+s2 = s3 --> true
+----
+////
 --
 
 * Line Comments: +allowLineComments {false|true}+
 +
-Line comments may be may be started with ++(*)++.
+Allow line comments beginning with the token ++(*)++.  The following
+example uses a line comment:
 +
 [source,sml]
 ----
 (*) This is a line comment
 ----
 +
-Line comments may also be nested inside block comments.
-The following is valid SML code utilizing line comments.
+Line comments properly nest within block comments.  The following
+example uses line comments nested within block comments:
 +
 [source,sml]
 ----
@@ -100,95 +195,133 @@ val x = 4 (*) This is a line comment
 val y = 5 (*) This is a line comment *)
 *)
 ----
-+
-Please note that with this feature enabled the following
-SML code which would previously compile will now result
-in a compilation error due to the unexpected `*)`.
-+
-[source,sml]
-----
-(*)
-val x = 0
-*)
-----
 
 * Optional Pattern Bars: +allowOptBar {false|true}+
 +
-A bar may be optionally placed before the first rule of a match.
-By eliminating the special case of the first match requiring no
-bar, this allows for easier refactoring.
+Allow a bar to appear before the first match rule of a `case`, `fn`,
+or `handle` expression, allow a bar to appear before the first
+function-value binding of a `fun` declaration, and allow a bar to
+appear before the first constructor binding or description of a
+`datatype` declaration or specification.  The following example uses
+leading bars in a `datatype` declaration, a `fun` declaration, and a
+`case` expression:
 +
 [source,sml]
 ----
-case exp of
-  | A => 1
-  | B => 2
-  | C => 3
+datatype t =
+  | C
+  | B
+  | A
+
+fun
+  | f NONE = 0
+  | f (SOME t) =
+     (case t of
+        | A => 1
+        | B => 2
+        | C => 3)
 ----
 +
-This optional bar may also be placed for `fn` and `handle`,
-function declarations, and `datatype` declarations.
+By eliminating the special case of the first element, this feature
+allows for simpler refactoring (e.g., sorting the lines of the
+`datatype` declaration's constructor bindings to put the constructors
+in alphabetical order).
 
 * Optional Semicolons: +allowOptSemicolon {false|true}+
 +
-In the same spirit, a semicolon may be optionally placed
-after the the last expression in a sequence.
+Allow a semicolon to appear after the last expression in a sequence or
+`let`-body expression.  The following example uses a trailing
+semicolon in the body of a `let` expression:
 +
 [source,sml]
 ----
-let
-   val x = 3
-in
-   f x;
-   g x;
-end
+fun h z =
+  let
+    val x = 3 * z
+  in
+     f x ;
+     g x ;
+  end
 ----
++
+By eliminating the special case of the last element, this feature
+allows for simpler refactoring.
 
 * Disjunctive (Or) Patterns: +allowOrPats {false|true}+
 +
-This feature allows for being able to utilize "or-patterns".
-One can "or" multiple matches together without having to re-write
-the same resultant right-hand-side expression.  Note that
-disjunctive patterns require an additional surrounding parenthesis.
-+
-For example `exp` could be matched as follows:
+Allow disjunctive (a.k.a., "or") patterns of the form +_pat~1~_ |
+_pat~2~_+, which matches a value that matches either +_pat~1~_+ or
++_pat~2~_+.  Disjunctive patterns have lower precedence than `as`
+patterns and constraint patterns, much as `orelse` expressions have
+lower precedence than `andalso` expressions and constraint
+expressions.  Both sub-patterns of a disjunctive pattern must bind the
+same variables with the same types.  The following example uses
+disjunctive patterns:
 +
 [source,sml]
 ----
-case exp of
-    (A | B | C) =>  1
-  | (D | E) => 2
+datatype t = A of int | B of int | C of int | D of int * int | E of int * int
+
+fun f t =
+  case t of
+     A x | B x | C x => x + 1
+   | D (x, _) | E (_, x) => x * 2
 ----
 
-* Record Punning: +allowRecPunning {false|true}+
+* Record Punning Expressions: +allowRecordPunExps {false|true}+
 +
-Records with fields that are of the form id=id can be abbreviated
-to id.  Previously this was only allowed in patterns.
-+
-For example:
-+
-[source,sml]
-----
-fn {a, b, c} => {a=a, b=b+1, c=c}
-----
-+
-May be abbreviated to:
+Allow record punning expressions, whereby an identifier +_vid_+ as an
+expression row in a record expression denotes the expression row
++_vid_ = _vid_+ (i.e., treating a label as a variable).  The following
+example uses record punning expressions (and also record punning
+patterns):
 +
 [source,sml]
 ----
-fn {a, b, c} => {a, b=b+1, c}
+fun incB r =
+  case r of {a, b, c} => {a, b = b + 1, c}
+----
++
+and is equivalent to:
++
+[source,sml]
+----
+fun incB r =
+  case r of {a = a, b = b, c = c} => {a = a, b = b + 1, c = c}
 ----
 
-* Withtype for Signatures: +allowSigWithtype {false|true}+
+* `withtype` in Signatures: +allowSigWithtype {false|true}+
 +
-This feature allows for the use of the `withtype` keyword in
-signatures.  Previously, `withtype` was only allowed in structures.
+Allow `withtype` to modify a `datatype` specification in a signature.
+The following example uses `withtype` in a signature (and also
+`withtype` in a declaration):
 +
 [source,sml]
 ----
-signature S =
-   sig
-      datatype a = A1 of int | A2 of int * t
-      withtype t = int * a option
-   end
+signature STREAM =
+  sig
+    datatype 'a u = Nil | Cons of 'a * 'a t
+    withtype 'a t = unit -> 'a u
+  end
+structure Stream : STREAM =
+  struct
+    datatype 'a u = Nil | Cons of 'a * 'a t
+    withtype 'a t = unit -> 'a u
+  end
+----
++
+and is equivalent to:
++
+[source,sml]
+----
+signature STREAM =
+  sig
+    datatype 'a u = Nil | Cons of 'a * (unit -> 'a u)
+    type 'a t = unit -> 'a u
+  end
+structure Stream : STREAM =
+  struct
+    datatype 'a u = Nil | Cons of 'a * (unit -> 'a u)
+    type 'a t = unit -> 'a u
+  end
 ----

--- a/doc/guide/src/SuccessorML.adoc
+++ b/doc/guide/src/SuccessorML.adoc
@@ -53,7 +53,6 @@ Below are some examples of extended literal syntax.
 val b = 0b10101
 val nb = ~0b10_10_10
 val bw = 0wb1010
-val bw' = 0bw10_10
 val x = 4_327_829
 ----
 +

--- a/doc/guide/src/SuccessorML.adoc
+++ b/doc/guide/src/SuccessorML.adoc
@@ -47,7 +47,7 @@ proxy for all of the following annoations.
 
 ** Extended Numeric Constants: +allowExtendedNumConsts {false|true}+
 +
-Allow underscores as a separator in numeric literal and allow binary
+Allow underscores as a separator in numeric literals and allow binary
 integer and word constants.
 +
 Below are some examples of extended numeric constant syntax.
@@ -61,7 +61,7 @@ val x = 4_327_829
 val r = 6.022_140_9e23
 ----
 +
-Below are some non-examples of extended literal syntax.
+Below are some non-examples of extended numeric constant syntax.
 +
 [source,sml]
 ----
@@ -71,6 +71,11 @@ val h = 0x_09_a
 val x = _12_3
 val r = 3.14_19_
 ----
+
+** Extended Text Constants: +allowExtendedTextConsts {false|true}+
++
+Allow characters with integer codes >= 128 that correspond to
+syntactically well-formed UTF8 byte sequences in string constants.
 --
 
 * Line Comments: +allowLineComments {false|true}+

--- a/doc/guide/src/Unicode.adoc
+++ b/doc/guide/src/Unicode.adoc
@@ -1,47 +1,57 @@
 Unicode
 =======
 
-The current release of MLton does not support Unicode.  We are working
-on adding support.
+== Support in The Definition of Standard ML ==
 
- * `WideChar` structure.
- * UTF-8 encoded source files.
+There is no real support for Unicode in the
+<:DefinitionOfStandardML:Definition>; there are only a few throw-away
+sentences along the lines of "the characters with numbers 0 to 127
+coincide with the ASCII character set."
 
-There is no real support for Unicode in the <:DefinitionOfStandardML:Definition>;
-there are only a few throw-away sentences along the lines of "ASCII
-must be a subset of the character set in programs".
+== Support in The Standard ML Basis Library ==
 
-Neither is there real support for Unicode in the <:BasisLibrary:Basis Library>.
-The general consensus (which includes the opinions of the
-editors of the Basis Library) is that the `WideChar` structure is
-insufficient for the purposes of Unicode.  There is no `LargeChar`
-structure, which in itself is a deficiency, since a programmer can not
-program against the largest supported character size.
+Neither is there real support for Unicode in the <:BasisLibrary:Basis
+Library>.  The general consensus (which includes the opinions of the
+editors of the Basis Library) is that the `WideChar` and `WideString`
+structures are insufficient for the purposes of Unicode.  There is no
+`LargeChar` structure, which in itself is a deficiency, since a
+programmer can not program against the largest supported character
+size.
 
-MLton has some preliminary support for 16 and 32 bit characters and
-strings.  It is even possible to include arbitrary Unicode characters
-in 32-bit strings using a `\Uxxxxxxxx` escape sequence.  (This
-longer escape sequence is a minor extension over the Definition which
-only allows `\uxxxx`.)  This is by no means completely
-satisfactory in terms of support for Unicode, but it is what is
-currently available.
+== Current Support in MLton ==
+
+MLton, as a minor extension over the Definition, supports UTF-8 byte
+sequences in text constants.  This feature enables "UTF-8 convenience"
+(but not comprehensive Unicode support); in particular, it allows one
+to copy text from a browser and paste it into a string constant in an
+editor and, furthermore, if the string is printed to a terminal, then
+will (typically) appear as the original text.  See the
+<:SuccessorML#ExtendedTextConsts:extended text constants feature of
+Successor ML> for more details.
+
+MLton, also as a minor extension over the Definition, supports
+`\Uxxxxxxxx` numeric escapes in text constants and has preliminary
+internal support for 16- and 32-bit characters and strings.
+
+MLton provides `WideChar` and `WideString` structures, corresponding
+to 32-bit characters and strings, respectively.
+
+== Questions and Discussions ==
 
 There are periodic flurries of questions and discussion about Unicode
 in MLton/SML.  In December 2004, there was a discussion that led to
 some seemingly sound design decisions.  The discussion started at:
 
-   http://www.mlton.org/pipermail/mlton/2004-December/026396.html
+ * http://www.mlton.org/pipermail/mlton/2004-December/026396.html
 
 There is a good summary of points at:
 
-   http://www.mlton.org/pipermail/mlton/2004-December/026440.html
+ * http://www.mlton.org/pipermail/mlton/2004-December/026440.html
 
 In November 2005, there was a followup discussion and the beginning of
 some coding.
 
-  http://www.mlton.org/pipermail/mlton/2005-November/028300.html
-
-We are optimistic that support will appear in the next MLton release.
+ * http://www.mlton.org/pipermail/mlton/2005-November/028300.html
 
 == Also see ==
 

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -113,6 +113,7 @@ signature CONTROL_FLAGS =
             (* Successor ML *)
             val allowDoDecls: (bool,bool) t
             val allowExtendedNumConsts: (bool,bool) t
+            val allowExtendedTextConsts: (bool,bool) t
             val allowLineComments: (bool,bool) t
             val allowOptBar: (bool,bool) t
             val allowOptSemicolon: (bool,bool) t

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -126,8 +126,8 @@ signature CONTROL_FLAGS =
             val expert: ('args, 'st) t -> bool
             val name: ('args, 'st) t -> string
 
-            datatype ('a, 'b) parseResult =
-               Bad | Deprecated of 'a | Good of 'b | Other
+            datatype 'a parseResult =
+               Bad | Good of 'a | Other | Proxy of 'a list * {deprecated: bool}
 
             structure Id :
                sig
@@ -135,17 +135,17 @@ signature CONTROL_FLAGS =
                   val name: t -> string
                end
             val equalsId: ('args, 'st) t * Id.t -> bool
-            val parseId: string -> (Id.t list , Id.t) parseResult
+            val parseId: string -> Id.t parseResult
 
             structure Args :
                sig
                   type t
                   val processAnn: t -> (unit -> unit)
                end
-            val parseIdAndArgs: string -> ((Id.t * Args.t) list, Id.t * Args.t) parseResult
+            val parseIdAndArgs: string -> (Id.t * Args.t) parseResult
 
-            val processDefault: string -> (Id.t list, unit) parseResult
-            val processEnabled: string * bool -> (Id.t list, unit) parseResult
+            val processDefault: string -> Id.t parseResult
+            val processEnabled: string * bool -> Id.t parseResult
 
             val withDef: (unit -> 'a) -> 'a
             val snapshot: unit -> (unit -> 'a) -> 'a

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012,2014-2016 Matthew Fluet.
+(* Copyright (C) 2009-2012,2014-2017 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -118,7 +118,7 @@ signature CONTROL_FLAGS =
             val allowOptBar: (bool,bool) t
             val allowOptSemicolon: (bool,bool) t
             val allowOrPats: (bool,bool) t
-            val allowRecPunning: (bool,bool) t
+            val allowRecordPunExps: (bool,bool) t
             val allowSigWithtype: (bool,bool) t
 
             val current: ('args, 'st) t -> 'st

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -112,7 +112,7 @@ signature CONTROL_FLAGS =
 
             (* Successor ML *)
             val allowDoDecls: (bool,bool) t
-            val allowExtendedLiterals: (bool,bool) t
+            val allowExtendedNumConsts: (bool,bool) t
             val allowLineComments: (bool,bool) t
             val allowOptBar: (bool,bool) t
             val allowOptSemicolon: (bool,bool) t

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012,2014-2015 Matthew Fluet.
+(* Copyright (C) 2009-2012,2014-2016 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -97,14 +97,6 @@ signature CONTROL_FLAGS =
             val allowConstant: (bool,bool) t
             val allowFFI: (bool,bool) t
             val allowOverload: (bool,bool) t
-            val allowOptBar: (bool,bool) t
-            val allowOptSemicolon: (bool,bool) t
-            val allowLineComments: (bool,bool) t
-            val allowDoDecls: (bool,bool) t
-            val allowOrPats: (bool,bool) t
-            val allowRecPunning: (bool,bool) t
-            val allowExtendedLiterals: (bool,bool) t
-            val allowSigWithtype: (bool,bool) t
             val allowPrim: (bool,bool) t
             val allowRebindEquals: (bool,bool) t
             val deadCode: (bool,bool) t
@@ -117,6 +109,16 @@ signature CONTROL_FLAGS =
             val sequenceNonUnit: (DiagEIW.t,DiagEIW.t) t
             val valrecConstr: (DiagEIW.t,DiagEIW.t) t
             val warnUnused: (bool,bool) t
+
+            (* Successor ML *)
+            val allowDoDecls: (bool,bool) t
+            val allowExtendedLiterals: (bool,bool) t
+            val allowLineComments: (bool,bool) t
+            val allowOptBar: (bool,bool) t
+            val allowOptSemicolon: (bool,bool) t
+            val allowOrPats: (bool,bool) t
+            val allowRecPunning: (bool,bool) t
+            val allowSigWithtype: (bool,bool) t
 
             val current: ('args, 'st) t -> 'st
             val default: ('args, 'st) t -> 'st

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -522,6 +522,9 @@ structure Elaborate =
          val (allowExtendedNumConsts, ac) =
             makeBool ({name = "allowExtendedNumConsts",
                        default = false, expert = false}, ac)
+         val (allowExtendedTextConsts, ac) =
+            makeBool ({name = "allowExtendedTextConsts",
+                       default = false, expert = false}, ac)
          val (allowLineComments, ac) =
             makeBool ({name = "allowLineComments",
                        default = false, expert = false}, ac)
@@ -541,10 +544,11 @@ structure Elaborate =
             makeBool ({name = "allowSigWithtype",
                        default = false, expert = false}, ac)
          val extendedConstsCtrls =
-            [allowExtendedNumConsts]
+            [allowExtendedNumConsts, allowExtendedTextConsts]
          val successorMLCtrls =
-            [allowDoDecls, allowExtendedNumConsts, allowLineComments,
-             allowOptBar, allowOptSemicolon, allowOrPats, allowRecPunning,
+            [allowDoDecls, allowExtendedNumConsts,
+             allowExtendedTextConsts, allowLineComments, allowOptBar,
+             allowOptSemicolon, allowOrPats, allowRecPunning,
              allowSigWithtype]
 
 

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -519,8 +519,8 @@ structure Elaborate =
          val (allowDoDecls, ac) =
             makeBool ({name = "allowDoDecls",
                        default = false, expert = false}, ac)
-         val (allowExtendedLiterals, ac) =
-            makeBool ({name = "allowExtendedLiterals",
+         val (allowExtendedNumConsts, ac) =
+            makeBool ({name = "allowExtendedNumConsts",
                        default = false, expert = false}, ac)
          val (allowLineComments, ac) =
             makeBool ({name = "allowLineComments",
@@ -540,8 +540,10 @@ structure Elaborate =
          val (allowSigWithtype, ac) =
             makeBool ({name = "allowSigWithtype",
                        default = false, expert = false}, ac)
+         val extendedConstsCtrls =
+            [allowExtendedNumConsts]
          val successorMLCtrls =
-            [allowDoDecls, allowExtendedLiterals, allowLineComments,
+            [allowDoDecls, allowExtendedNumConsts, allowLineComments,
              allowOptBar, allowOptSemicolon, allowOrPats, allowRecPunning,
              allowSigWithtype]
 
@@ -617,6 +619,12 @@ structure Elaborate =
          val ac = {parseId = parseId, parseIdAndArgs = parseIdAndArgs}
 
          (* Successor ML *)
+         val ac =
+            makeProxyBoolSimple ({alts = List.map (extendedConstsCtrls, id),
+                                  default = false,
+                                  deprecated = false,
+                                  expert = false,
+                                  name = "allowExtendedConsts"}, ac)
          val ac =
             makeProxyBoolSimple ({alts = List.map (successorMLCtrls, id),
                                   default = false,

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012,2014-2016 Matthew Fluet.
+(* Copyright (C) 2009-2012,2014-2017 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -537,8 +537,8 @@ structure Elaborate =
          val (allowOrPats, ac) =
             makeBool ({name = "allowOrPats",
                        default = false, expert = false}, ac)
-         val (allowRecPunning, ac) =
-            makeBool ({name = "allowRecPunning",
+         val (allowRecordPunExps, ac) =
+            makeBool ({name = "allowRecordPunExps",
                        default = false, expert = false}, ac)
          val (allowSigWithtype, ac) =
             makeBool ({name = "allowSigWithtype",
@@ -548,7 +548,7 @@ structure Elaborate =
          val successorMLCtrls =
             [allowDoDecls, allowExtendedNumConsts,
              allowExtendedTextConsts, allowLineComments, allowOptBar,
-             allowOptSemicolon, allowOrPats, allowRecPunning,
+             allowOptSemicolon, allowOrPats, allowRecordPunExps,
              allowSigWithtype]
 
 

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012,2014-2015 Matthew Fluet.
+(* Copyright (C) 2009-2012,2014-2016 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -449,30 +449,6 @@ structure Elaborate =
          val (allowOverload, ac) =
             makeBool ({name = "allowOverload", 
                        default = false, expert = true}, ac)
-         val (allowOptBar, ac) =
-            makeBool ({name = "allowOptBar",
-                       default = false, expert = false}, ac)
-         val (allowOptSemicolon, ac) =
-            makeBool ({name = "allowOptSemicolon",
-                       default = false, expert = false}, ac)
-         val (allowLineComments, ac) =
-            makeBool ({name = "allowLineComments",
-                       default = false, expert = false}, ac)
-         val (allowDoDecls, ac) =
-            makeBool ({name = "allowDoDecls",
-                       default = false, expert = false}, ac)
-         val (allowRecPunning, ac) =
-            makeBool ({name = "allowRecPunning",
-                       default = false, expert = false}, ac)
-         val (allowOrPats, ac) =
-            makeBool ({name = "allowOrPats",
-                       default = false, expert = false}, ac)
-         val (allowExtendedLiterals, ac) =
-            makeBool ({name = "allowExtendedLiterals",
-                       default = false, expert = false}, ac)
-         val (allowSigWithtype, ac) =
-            makeBool ({name = "allowSigWithtype",
-                       default = false, expert = false}, ac)
          val (allowRebindEquals, ac) =
             makeBool ({name = "allowRebindEquals", 
                        default = false, expert = true}, ac)
@@ -535,6 +511,32 @@ structure Elaborate =
                           default = DiagEIW.Warn, expert = false}, ac)
          val (warnUnused, ac) =
             makeBool ({name = "warnUnused", 
+                       default = false, expert = false}, ac)
+
+         (* Successor ML *)
+         val (allowDoDecls, ac) =
+            makeBool ({name = "allowDoDecls",
+                       default = false, expert = false}, ac)
+         val (allowExtendedLiterals, ac) =
+            makeBool ({name = "allowExtendedLiterals",
+                       default = false, expert = false}, ac)
+         val (allowLineComments, ac) =
+            makeBool ({name = "allowLineComments",
+                       default = false, expert = false}, ac)
+         val (allowOptBar, ac) =
+            makeBool ({name = "allowOptBar",
+                       default = false, expert = false}, ac)
+         val (allowOptSemicolon, ac) =
+            makeBool ({name = "allowOptSemicolon",
+                       default = false, expert = false}, ac)
+         val (allowOrPats, ac) =
+            makeBool ({name = "allowOrPats",
+                       default = false, expert = false}, ac)
+         val (allowRecPunning, ac) =
+            makeBool ({name = "allowRecPunning",
+                       default = false, expert = false}, ac)
+         val (allowSigWithtype, ac) =
+            makeBool ({name = "allowSigWithtype",
                        default = false, expert = false}, ac)
 
          val {parseId, parseIdAndArgs, withDef, snapshot} = ac

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -437,6 +437,8 @@ structure Elaborate =
              parseIdAndArgs = fn _ => Bad,
              withDef = fn () => (fn () => ()),
              snapshot = fn () => fn () => (fn () => ())}
+
+
          val (allowConstant, ac) =
             makeBool ({name = "allowConstant", 
                        default = false, expert = true}, ac)
@@ -538,6 +540,11 @@ structure Elaborate =
          val (allowSigWithtype, ac) =
             makeBool ({name = "allowSigWithtype",
                        default = false, expert = false}, ac)
+         val successorMLCtrls =
+            [allowDoDecls, allowExtendedLiterals, allowLineComments,
+             allowOptBar, allowOptSemicolon, allowOrPats, allowRecPunning,
+             allowSigWithtype]
+
 
          val {parseId, parseIdAndArgs, withDef, snapshot} = ac
       end
@@ -609,6 +616,13 @@ structure Elaborate =
       in
          val ac = {parseId = parseId, parseIdAndArgs = parseIdAndArgs}
 
+         (* Successor ML *)
+         val ac =
+            makeProxyBoolSimple ({alts = List.map (successorMLCtrls, id),
+                                  default = false,
+                                  deprecated = false,
+                                  expert = false,
+                                  name = "allowSuccessorML"}, ac)
 
          val {parseId, parseIdAndArgs} = ac
       end

--- a/mlton/front-end/ml.grm
+++ b/mlton/front-end/ml.grm
@@ -222,6 +222,7 @@ type 'a whereAnd = wherespec list * SourcePos.t * 'a list
   %term
       CHAR of IntInf.t
     | INT of {digits: string,
+              extended: bool,
               negate: bool,
               radix: StringCvt.radix}
     | LONGID of string
@@ -320,6 +321,7 @@ type 'a whereAnd = wherespec list * SourcePos.t * 'a list
        | longvid of Longvid.t
        | longvidNoEqual of Longvid.t
        | match of Match.t
+       | numeric of int
        | opaspat of Pat.t option
        | opcon of Con.t
        | ot_list of Exp.t list
@@ -451,7 +453,7 @@ type 'a whereAnd = wherespec list * SourcePos.t * 'a list
         -> IN LONGID END | -> ELSE LONGID
 
 %value CHAR (IntInf.fromInt (Char.ord #"a"))
-%value INT ({digits = "0", negate = false, radix = StringCvt.DEC})
+%value INT ({digits = "0", extended = false, negate = false, radix = StringCvt.DEC})
 %value LONGID ("bogus")
 %value REAL ("13.0")
 %value STRING (Vector.fromList [])
@@ -879,7 +881,7 @@ priority :                      (Priority.T NONE)
 
 int : INT
    (let
-       val {digits, negate, radix} = INT
+       val {digits, negate, radix, ...} = INT
     in
        case StringCvt.scanString (fn r => IntInf.scan (radix, r)) digits of
           NONE => Error.bug "parser saw invalid int"
@@ -897,9 +899,9 @@ word : WORD
 
 digit : INT
    (let
-       val {digits, negate, radix} = INT
+       val {digits, extended, negate, radix} = INT
     in
-       if 1 = String.size digits andalso not negate andalso radix = StringCvt.DEC
+       if 1 = String.size digits andalso not extended andalso not negate andalso radix = StringCvt.DEC
           then valOf (Int.fromString digits)
        else let
                open Layout
@@ -910,6 +912,28 @@ digit : INT
             in
                0
             end
+    end)
+
+numeric : INT
+   (let
+       val {digits, extended, negate, radix} = INT
+       fun err () =
+          let
+             open Layout
+             val _ =
+                Control.error (reg (INTleft, INTright),
+                               str "invalid numeric label",
+                               empty)
+          in
+             1
+          end
+    in
+       if String.sub (digits, 0) <> #"0" andalso not extended andalso not negate andalso radix = StringCvt.DEC
+          then case StringCvt.scanString (fn r => IntInf.scan (radix, r)) digits of
+                  NONE => Error.bug "parser saw invalid int"
+                | SOME i => (IntInf.toInt (if negate then ~ i else i)
+                             handle Exn.Overflow => err ())
+       else err ()
     end)
 
 datatypeRhs
@@ -1281,22 +1305,8 @@ tycon : idNoAsterisk           (Tycon.fromSymbol idNoAsterisk)
 tyvar : TYVAR                  (Tyvar.newString (TYVAR, {left = TYVARleft,
                                                          right = TYVARright}))
 field : id                     (Field.Symbol (#1 id))
-      | int                    (let
-                                   val int =
-                                      IntInf.toInt int
-                                      handle Exn.Overflow =>
-                                         (error (reg (intleft, intright),
-                                                 "field too huge")
-                                          ; 0)
-                                in
-                                   Field.Int
-                                   (if int <= 0
-                                       then (error (reg (intleft, intright),
-                                                    "nonpositive field")
-                                             ; ~1)
-                                    else
-                                       int - 1)
-                                end) (* int - 1 because fields are 0-based *)
+      | numeric                (Field.Int (numeric - 1))
+                               (* numeric - 1 because fields are 0-based *)
 
 strid : id                     (Strid.fromSymbol id)
 sigid : id                     (Sigid.fromSymbol id)

--- a/mlton/front-end/ml.grm
+++ b/mlton/front-end/ml.grm
@@ -13,7 +13,7 @@ local
 in
    val allowOptBar = fn () => current allowOptBar
    val allowOptSemicolon = fn () => current allowOptSemicolon
-   val allowRecPunning = fn () => current allowRecPunning
+   val allowRecordPunExps = fn () => current allowRecordPunExps
 end
 
 open Ast
@@ -993,15 +993,30 @@ rules : rule            ([rule])
 rule    : pat DARROW exp        ((pat,exp))
 
 elabel  : field EQUALOP exp     (field,exp)
-        | vidNoEqual            (if allowRecPunning ()
+        | vidNoEqual constraint (if allowRecordPunExps ()
                                     then ()
-                                    else error (reg (vidNoEqualleft, vidNoEqualright), "Record punning disallowed, compile with -default-ann 'allowRecPunning true'")
-                                 ; (Field.Symbol (Vid.toSymbol vidNoEqual), 
-                                    Exp.makeRegion' (Exp.FlatApp 
-                                    (Vector.new1 (Exp.makeRegion' (Exp.Var {name = (Longvid.short vidNoEqual), 
-                                                                            fixop = Fixop.None}, 
-                                                                   vidNoEqualleft, vidNoEqualright))), 
-                                    vidNoEqualleft, vidNoEqualright)))
+                                    else error (reg (vidNoEqualleft, vidNoEqualright), "Record punning expressions disallowed, compile with -default-ann 'allowRecordPunExps true'")
+                                 ; (Field.Symbol (Vid.toSymbol vidNoEqual),
+                                    let
+                                      val exp =
+                                        Exp.makeRegion'
+                                        (Exp.FlatApp
+                                         (Vector.new1
+                                          (Exp.makeRegion'
+                                           (Exp.Var {name = Longvid.short vidNoEqual,
+                                                     fixop = Fixop.None},
+                                            vidNoEqualleft, vidNoEqualright))),
+                                         vidNoEqualleft, vidNoEqualright)
+                                      val exp =
+                                        case constraint of
+                                           NONE => exp
+                                         | SOME ty =>
+                                             Exp.makeRegion'
+                                             (Exp.Constraint (exp, ty),
+                                              vidNoEqualleft, constraintright)
+                                    in
+                                      exp
+                                    end))
 
 elabels : elabel COMMA elabels  (elabel :: elabels)
         | elabel                ([elabel])

--- a/mlton/front-end/ml.grm
+++ b/mlton/front-end/ml.grm
@@ -264,7 +264,6 @@ type 'a whereAnd = wherespec list * SourcePos.t * 'a list
        | constr of Con.t * Type.t option
        | constraint of Type.t option
        | constrs of (Con.t * Type.t option) list
-       | constrsTop of (Con.t * Type.t option) list
        | constOrBool of Const.t
        | cpat of Pat.t
        | cpatnode of Pat.node
@@ -324,9 +323,10 @@ type 'a whereAnd = wherespec list * SourcePos.t * 'a list
        | numeric of int
        | opaspat of Pat.t option
        | opcon of Con.t
-       | ot_list of Exp.t list
+       | optbar of unit
+       | optbar' of unit
+       | optsemicolon of unit
        | pat of Pat.t
-       | pat_2c of Pat.t list
        | patitem of (Field.t * Pat.Item.t)
        | patitems of ((Field.t * Pat.Item.t) list * bool)
        | pats of Pat.t list
@@ -335,7 +335,6 @@ type 'a whereAnd = wherespec list * SourcePos.t * 'a list
        | repl of DatatypeRhs.node
        | rule of rule
        | rules of rule list
-       | rulesTop of rule list
        | rvalbind of rvb list
        | rvalbindRest of rvb list
        | sdec of Dec.t
@@ -385,7 +384,6 @@ type 'a whereAnd = wherespec list * SourcePos.t * 'a list
        | ty' of Type.t
        | ty'node of Type.node
        | ty0_pc of Type.t list
-       | ty1 of Type.t
        | tyOpt of Type.t option
        | tycon of Tycon.t
        | tynode of Type.node
@@ -791,11 +789,8 @@ funs    : clausesTop               ([clausesTop])
         | clausesTop AND funs      (clausesTop :: funs)
 
 clausesTop: clauses (Vector.fromList clauses)
-          | BAR clauses (if allowOptBar ()
-                            then ()
-                            else error (reg (BARleft, BARright), "Optional clauses bar disallowed, compile with -default-ann 'allowOptBar true'")
-                         ;(Vector.fromList clauses))
-          
+          | optbar' clauses (Vector.fromList clauses)
+
 clauses : clause                ([clause])
         | clause BAR clauses    (clause :: clauses)
 
@@ -842,12 +837,6 @@ tyvarseq: tyvar                   (Vector.new1 tyvar)
 tyvar_pc: tyvar                ([tyvar])
         | tyvar COMMA tyvar_pc (tyvar :: tyvar_pc)
 
-constrsTop : constrs            (constrs)
-           | BAR constrs        (if allowOptBar ()
-                                    then ()
-                                    else error (reg (BARleft, BARright), "Optional constrs bar disallowed, compile with -default-ann 'allowOptBar true'")
-                                ;(constrs))
-        
 constrs : constr                ([constr])
         | constr BAR constrs    (constr :: constrs)
 
@@ -964,8 +953,8 @@ dbs'
    | db AND dbs'
      (db :: dbs')
 
-db : tyvars tycon EQUALOP constrsTop
-     ({cons = Vector.fromList constrsTop,
+db : tyvars tycon EQUALOP optbar constrs
+     ({cons = Vector.fromList constrs,
        tycon = tycon,
        tyvars = tyvars})
 
@@ -978,15 +967,9 @@ withtypes
 longvidands : longvid  ([longvid])
             | longvid AND longvidands (longvid :: longvidands)
 
-match : rulesTop           (Match.makeRegion' (Match.T (Vector.fromList rulesTop),
-                                            rulesTopleft, rulesTopright))
+match : optbar rules    (Match.makeRegion' (Match.T (Vector.fromList rules),
+                                            rulesleft, rulesright))
 
-rulesTop : rules        (rules)
-         | BAR rules    (if allowOptBar ()
-                            then ()
-                            else error (reg (BARleft, BARright), "Optional rules bar disallowed, compile with -default-ann 'allowOptBar true'")
-                         ;(rules))
-                                            
 rules : rule            ([rule])
       | rule BAR rules  (rule :: rules)
 
@@ -1021,12 +1004,8 @@ elabel  : field EQUALOP exp     (field,exp)
 elabels : elabel COMMA elabels  (elabel :: elabels)
         | elabel                ([elabel])
 
-exp_ps  : exp SEMICOLON exp     ([exp1, exp2])
+exp_ps  : exp optsemicolon      ([exp])
         | exp SEMICOLON exp_ps  (exp :: exp_ps)
-        | exp SEMICOLON exp SEMICOLON (if allowOptSemicolon ()
-                                          then ()
-                                          else error (reg (SEMICOLON2left, SEMICOLON2right), "Optional semicolon disallowed, compile with -default-ann 'allowOptSemicolon true'")
-                                       ;([exp1, exp2]))
 
 exp : expnode (Exp.makeRegion' (expnode, expnodeleft, expnoderight))
 
@@ -1059,16 +1038,19 @@ aexp    : OP longvid            (Exp.Var {name = longvid,
           (Exp.Record (Record.fromVector (Vector.fromList elabels)))
         | LBRACE RBRACE         (Exp.unit)
         | LPAREN RPAREN         (Exp.unit)
-        | LPAREN expnode RPAREN (expnode)
-        | LPAREN exp_ps RPAREN  (Exp.Seq (Vector.fromList exp_ps))
+        | LPAREN exp_ps RPAREN
+            (case exp_ps of
+                [exp] => Exp.node exp
+              | _ => Exp.Seq (Vector.fromList exp_ps))
         | LPAREN exp_2c RPAREN  (Exp.tuple (Vector.fromList exp_2c))
         | LBRACKET exp_list RBRACKET  (Exp.List (Vector.fromList exp_list))
         | LBRACKET RBRACKET           (Exp.List (Vector.new0 ()))
-        | LET decs IN exp END   (Exp.Let (decs, exp))
         | LET decs IN exp_ps END
-            (Exp.Let (decs, Exp.makeRegion' (Exp.Seq (Vector.fromList exp_ps),
-                                             exp_psleft,
-                                             exp_psright)))
+            (Exp.Let (decs,
+                      case exp_ps of
+                         [exp] => exp
+                       | _ => Exp.makeRegion' (Exp.Seq (Vector.fromList exp_ps),
+                                               exp_psleft, exp_psright)))
         | ADDRESS string symattributes COLON ty SEMICOLON
           (Exp.Prim (PrimKind.Address {attributes = symattributes,
                                        name = string,
@@ -1200,7 +1182,7 @@ apatnode : longvidNoEqual        (Pat.Var {name = longvidNoEqual,
 
 pats : ([])
      | pat commapats (pat :: commapats)
-     
+
 barcpats : cpat ([cpat])
          | cpat BAR barcpats (cpat :: barcpats)
 
@@ -1261,6 +1243,21 @@ ty0_pc  : ty COMMA ty           ([ty1, ty2])
 (*---------------------------------------------------*)
 (*                       Atoms                       *)
 (*---------------------------------------------------*)
+
+optbar
+   : (* empty *) ()
+   | optbar'     ()
+
+optbar'
+   : BAR         (if allowOptBar ()
+                    then ()
+                    else error (reg (BARleft, BARright), "Optional bar disallowed, compile with -default-ann 'allowOptBar true'"))
+
+optsemicolon
+   : (* empty *) ()
+   | SEMICOLON   (if allowOptSemicolon ()
+                    then ()
+                    else error (reg (SEMICOLONleft, SEMICOLONright), "Optional semicolon disallowed, compile with -default-ann 'allowOptSemicolon true'"))
 
 constOrBool
    : const (const)

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -324,9 +324,8 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 
 <A>"(*)"        => (if allowLineComments ()
                        then (YYBEGIN C
-                            ; continue ())
-                       else (inc commentLevel; continue ())
-                   );
+                             ; continue ())
+                       else (inc commentLevel; continue ()));
 <A>"(*"         => (inc commentLevel; continue ());
 <A>{eol}        => (Source.newline (source, yypos) ; continue ());
 <A>"*)"         => (dec commentLevel

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -436,11 +436,8 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
                      ; continue ());
 <TEXT>\\U{hexDigit}{8} =>
                     (addTextNumEsc (source, yypos, yytext, 2,
-                                    (* \Uxxxxxxxx string constants are used in Basis Library
-                                     * implementation and regression suite.
-                                     *)
-                                    (* {extended = SOME "\\Uxxxxxxxx numeric escapes"}, *)
-                                    {extended = NONE}, StringCvt.HEX)
+                                    {extended = SOME "\\Uxxxxxxxx numeric escapes"},
+                                    StringCvt.HEX)
                      ; continue ());
 <TEXT>"\\\""     => (addTextString "\""; continue ());
 <TEXT>\\\\       => (addTextString "\\"; continue ());

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -328,7 +328,7 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
                        else (inc commentLevel; continue ())
                    );
 <A>"(*"         => (inc commentLevel; continue ());
-<A>\n           => (Source.newline (source, yypos) ; continue ());
+<A>{eol}        => (Source.newline (source, yypos) ; continue ());
 <A>"*)"         => (dec commentLevel
                     ; if 0 = !commentLevel then YYBEGIN INITIAL else ()
                     ; continue ());

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -117,20 +117,22 @@ fun doit (yytext, source, yypos, drop, {extended: bool}, mkTok) =
             else ()
    in
       mkTok (String.keepAll (String.dropPrefix (yytext, drop), fn c => not (c = #"_")),
+             {extended = extended},
              Source.getPos (source, left), Source.getPos (source, right))
    end
 in
 fun real (yytext, source, yypos) =
-   doit (yytext, source, yypos, 0, {extended = false}, fn (digits, l, r) =>
+   doit (yytext, source, yypos, 0, {extended = false}, fn (digits, {extended: bool}, l, r) =>
          Tokens.REAL (digits, l, r))
 fun int (yytext, source, yypos, drop, {extended: bool}, {negate: bool}, radix) =
-   doit (yytext, source, yypos, drop, {extended = extended}, fn (digits, l, r) =>
+   doit (yytext, source, yypos, drop, {extended = extended}, fn (digits, {extended: bool}, l, r) =>
          Tokens.INT ({digits = digits,
+                      extended = extended,
                       negate = negate,
                       radix = radix},
                      l, r))
 fun word (yytext, source, yypos, drop, {extended: bool}, radix) =
-   doit (yytext, source, yypos, drop, {extended = extended}, fn (digits, l, r) =>
+   doit (yytext, source, yypos, drop, {extended = extended}, fn (digits, {extended: bool}, l, r) =>
          Tokens.WORD ({digits = digits,
                        radix = radix},
                       l, r))

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -336,7 +336,8 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 <B>{eol}        => (YYBEGIN INITIAL
                     ; Source.newline (source, yypos) ; continue ());
 <B>.            => (continue ());
-<C>{eol}        => (YYBEGIN A; continue ());
+<C>{eol}        => (YYBEGIN A
+                    ; Source.newline (source, yypos) ; continue ());
 <C>.            => (continue ());
 <S>\"           => (let
                        val s = Vector.fromListRev (!charlist)

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -1,17 +1,20 @@
-(* Heavily modified from the SML/NJ sources by sweeks@sweeks.com. *)
+(* Heavily modified from SML/NJ sources. *)
 
 (* ml.lex
  *
  * Copyright 1989 by AT&T Bell Laboratories
  *
- * $Log: ml.lex,v $
- * Revision 1.3  1997/05/22  20:17:22  jhr
- * Changed lexer to accept "1e1" style floating-point literals.
+ * SML/NJ is released under a BSD-style license.
+ * See the file NJ-LICENSE for details.
+ *)
+
+(* Copyright (C) 2009,2016-2017 Matthew Fluet.
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+ *    Jagannathan, and Stephen Weeks.
+ * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * Revision 1.2  1997/01/28  23:20:40  jhr
- * Integer and word literals are now represented by IntInf.int (instead of
- * as strings).
- *
+ * MLton is released under a BSD-style license.
+ * See the file MLton-LICENSE for details.
  *)
 
 type svalue = Tokens.svalue
@@ -29,108 +32,94 @@ in
    val allowExtendedTextConsts = fn () => current allowExtendedTextConsts
 end
 
-val charlist: IntInf.t list ref = ref []
-val colNum: int ref = ref 0
-val commentLevel: int ref = ref 0
-val commentStart = ref SourcePos.bogus
-val lineFile: File.t ref = ref ""
-val lineNum: int ref = ref 0
-val stringStart = ref SourcePos.bogus
-val stringtype = ref false
-
-fun lineDirective (source, file, yypos) =
-   Source.lineDirective (source, file,
-                         {lineNum = !lineNum,
-                          lineStart = yypos - !colNum})
-
-fun addString (s: string) =
-   charlist :=
-   String.fold (s, !charlist, fn (c, ac) => Int.toIntInf (Char.ord c) :: ac)
-
-fun addChar (c: char) = addString (String.fromChar c)
-
-fun inc (ri as ref (i: int)) = ri := i + 1
-
-fun dec (ri as ref (i: int)) = ri := i - 1
-
-fun error (source, left, right, msg) = 
-   Control.errorStr (Region.make {left = Source.getPos (source, left),
-                                  right = Source.getPos (source, right)},
-                     msg)
-
-fun stringError (source, right, msg) =
-   Control.errorStr (Region.make {left = !stringStart,
-                                  right = Source.getPos (source, right)},
-                     msg)
-
-fun addNumEsc (yytext, source, yypos, drop, {extended: string option}, radix): unit =
-   let
-      val left = yypos
-      val right = yypos + size yytext
-      val _ =
-         case extended of
-            NONE => ()
-          | SOME msg =>
-               if allowExtendedTextConsts ()
-                  then ()
-                  else error (source, left, right,
-                              concat ["Extended text constants (using ", msg,
-                                      ") disallowed, compile with -default-ann 'allowExtendedTextConsts true'"])
-   in
-      case StringCvt.scanString (fn r => IntInf.scan (radix, r)) (String.dropPrefix (yytext, drop)) of
-         NONE => error (source, left, right, "illegal numeric escape in string")
-       | SOME i => List.push (charlist, i)
-   end
-
-fun addUTF8 (yytext, source, yypos): unit =
-   let
-      val left = yypos
-      val right = yypos + size yytext
-   in
-      if not (allowExtendedTextConsts ())
-         then error (source, left, right,
-                     "Extended text constants (using UTF-8 byte sequences) disallowed, compile with -default-ann 'allowExtendedTextConsts true'")
-         else addString yytext
-   end
-
-
-val eof: lexarg -> lexresult =
-   fn {source, ...} =>
-   let
-      val pos = Source.lineStart source
-      val _ =
-         if !commentLevel > 0
-            then Control.errorStr (Region.make {left = !commentStart,
-                                                right = pos},
-                                   "unclosed comment")
-         else ()
-   in
-      Tokens.EOF (pos, pos)
-   end
-
-val size = String.size
-
 fun tok (t, s, l, r) =
    let
       val l = Source.getPos (s, l)
       val r = Source.getPos (s, r)
-      val _ =
-         if true
-            then ()
-         else
-            print (concat ["tok (",
-                           SourcePos.toString l,
-                           ", " ,
-                           SourcePos.toString r,
-                           ")\n"])
    in
       t (l, r)
    end
 
 fun tok' (t, x, s, l) = tok (fn (l, r) => t (x, l, r), s, l, l + size x)
 
+fun error (source, left, right, msg) =
+   Control.errorStr (Region.make {left = Source.getPos (source, left),
+                                  right = Source.getPos (source, right)},
+                     msg)
+
+
+(* Comments *)
 local
-fun doit (yytext, source, yypos, drop, {extended: string option}, mkTok) =
+   val commentLeft = ref SourcePos.bogus
+   val commentStack: (unit -> unit) list ref = ref []
+in
+   fun commentError (right, msg) =
+      Control.errorStr (Region.make {left = !commentLeft,
+                                     right = right},
+                        msg)
+   val inComment = fn () => not (List.isEmpty (!commentStack))
+   fun startComment (source, yypos, th) =
+      let
+         val _ =
+            if inComment ()
+               then ()
+               else commentLeft := Source.getPos (source, yypos)
+         val _ = List.push (commentStack, th)
+      in
+         ()
+      end
+   fun finishComment () =
+      (List.pop commentStack) ()
+end
+
+
+(* Line Directives *)
+local
+   val lineDirCol: int ref = ref ~1
+   val lineDirFile: File.t option ref = ref NONE
+   val lineDirLine: int ref = ref ~1
+in
+   fun startLineDir (source, yypos, th) =
+      let
+         val _ = lineDirCol := ~1
+         val _ = lineDirFile := NONE
+         val _ = lineDirLine := ~1
+      in
+         startComment (source, yypos, th)
+      end
+   fun addLineDirLineCol (line, col) =
+      let
+         val _ = lineDirLine := line
+         val _ = lineDirCol := col
+      in
+         ()
+      end
+   fun addLineDirFile file =
+      let
+         val _ = lineDirFile := SOME file
+      in
+         ()
+      end
+   fun finishLineDir (source, yypos) =
+      let
+         val col = !lineDirCol
+         val file = !lineDirFile
+         val line = !lineDirLine
+         val _ = lineDirCol := ~1
+         val _ = lineDirFile := NONE
+         val _ = lineDirLine := ~1
+      in
+         Source.lineDirective (source, file,
+                               {lineNum = line,
+                                lineStart = yypos - col})
+         ; finishComment ()
+      end
+end
+
+
+(* Numeric Constants *)
+local
+fun doit (source, yypos, yytext, drop, {extended: string option}, mkTok) =
    let
       val left = yypos
       val right = yypos + size yytext
@@ -155,40 +144,130 @@ fun doit (yytext, source, yypos, drop, {extended: string option}, mkTok) =
              Source.getPos (source, left), Source.getPos (source, right))
    end
 in
-fun real (yytext, source, yypos) =
-   doit (yytext, source, yypos, 0, {extended = NONE}, fn (digits, {extended: bool}, l, r) =>
+fun real (source, yypos, yytext) =
+   doit (source, yypos, yytext, 0, {extended = NONE}, fn (digits, {extended: bool}, l, r) =>
          Tokens.REAL (digits, l, r))
-fun int (yytext, source, yypos, drop, {extended: string option}, {negate: bool}, radix) =
-   doit (yytext, source, yypos, drop, {extended = extended}, fn (digits, {extended: bool}, l, r) =>
+fun int (source, yypos, yytext, drop, {extended: string option}, {negate: bool}, radix) =
+   doit (source, yypos, yytext, drop, {extended = extended}, fn (digits, {extended: bool}, l, r) =>
          Tokens.INT ({digits = digits,
                       extended = extended,
                       negate = negate,
                       radix = radix},
                      l, r))
-fun word (yytext, source, yypos, drop, {extended: string option}, radix) =
-   doit (yytext, source, yypos, drop, {extended = extended}, fn (digits, {extended: bool}, l, r) =>
+fun word (source, yypos, yytext, drop, {extended: string option}, radix) =
+   doit (source, yypos, yytext, drop, {extended = extended}, fn (digits, {extended: bool}, l, r) =>
          Tokens.WORD ({digits = digits,
                        radix = radix},
                       l, r))
 end
 
+
+(* Text Constants *)
+local
+   val chars: IntInf.t list ref = ref []
+   val inText = ref false
+   val textLeft = ref SourcePos.bogus
+   val textFinishFn: (IntInf.t vector * SourcePos.t * SourcePos.t -> unit -> lexresult) ref = ref (fn _ => raise Fail "textFinish")
+in
+   fun textError (right, msg) =
+      Control.errorStr (Region.make {left = !textLeft,
+                                     right = right},
+                        msg)
+   fun startText (tl, tf) =
+      let
+         val _ = chars := []
+         val _ = inText := true
+         val _ = textLeft := tl
+         val _ = textFinishFn := tf
+      in
+         ()
+      end
+   fun finishText (textRight) =
+      let
+         val cs = Vector.fromListRev (!chars)
+         val tf = (!textFinishFn) (cs, !textLeft, textRight)
+         val _ = chars := []
+         val _ = inText := false
+         val _ = textLeft := SourcePos.bogus
+         val _ = textFinishFn := (fn _ => raise Fail "textFinish")
+      in
+         tf ()
+      end
+   val inText = fn () => !inText
+   fun addTextString (s: string) =
+      chars := String.fold (s, !chars, fn (c, ac) => Int.toIntInf (Char.ord c) :: ac)
+   fun addTextCharCode (i: IntInf.int) = List.push (chars, i)
+end
+fun addTextChar (c: char) = addTextString (String.fromChar c)
+fun addTextNumEsc (source, yypos, yytext, drop, {extended: string option}, radix): unit =
+   let
+      val left = yypos
+      val right = yypos + size yytext
+      val _ =
+         case extended of
+            NONE => ()
+          | SOME msg =>
+               if allowExtendedTextConsts ()
+                  then ()
+                  else error (source, left, right,
+                              concat ["Extended text constants (using ", msg,
+                                      ") disallowed, compile with -default-ann 'allowExtendedTextConsts true'"])
+   in
+      case StringCvt.scanString (fn r => IntInf.scan (radix, r)) (String.dropPrefix (yytext, drop)) of
+         NONE => error (source, left, right, "Illegal numeric escape in text constant")
+       | SOME i => addTextCharCode i
+   end
+fun addTextUTF8 (source, yypos, yytext): unit =
+   let
+      val left = yypos
+      val right = yypos + size yytext
+   in
+      if not (allowExtendedTextConsts ())
+         then error (source, left, right,
+                     "Extended text constants (using UTF-8 byte sequences) disallowed, compile with -default-ann 'allowExtendedTextConsts true'")
+         else addTextString yytext
+   end
+
+
+(* EOF *)
+val eof: lexarg -> lexresult =
+   fn {source, ...} =>
+   let
+      val pos = Source.lineStart source
+      val _ =
+         if inComment ()
+            then commentError (SourcePos.bogus, "Unclosed comment at end of file")
+            else ()
+      val _ =
+         if inText ()
+            then textError (SourcePos.bogus, "Unclosed text constant at end of file")
+            else ()
+   in
+      Tokens.EOF (pos, pos)
+   end
+
+
 %% 
 %full
-%reject
-%s A B C S F L LL LLC LLCQ;
+
+%s TEXT TEXT_FMT  BLOCK_COMMENT LINE_COMMENT  LINE_DIR1 LINE_DIR2 LINE_DIR3 LINE_DIR4;
+
 %header (functor MLLexFun (structure Tokens : ML_TOKENS));
 %arg ({source});
-alphanum=[A-Za-z'_0-9]*;
-alphanumId=[A-Za-z]{alphanum};
-sym=[-!%&$+/:<=>?@~`^|#*]|"\\";
-symId={sym}+;
-id={alphanumId}|{symId};
-longid={id}("."{id})*;
-ws=("\012"|[\t\ ])*;
-nrws=("\012"|[\t\ ])+;
+
+ws=\t|"\011"|"\012"|" ";
 cr="\013";
 nl="\010";
 eol=({cr}{nl}|{nl}|{cr});
+
+alphanum=[A-Za-z0-9'_];
+alphanumId=[A-Za-z]{alphanum}*;
+tyvarId="'"{alphanum}*;
+sym="!"|"%"|"&"|"$"|"#"|"+"|"-"|"/"|":"|"<"|"="|">"|"?"|"@"|"\\"|"~"|"`"|"^"|"|"|"*";
+symId={sym}+;
+id={alphanumId}|{symId};
+longId={id}("."{id})*;
+
 decDigit=[0-9];
 decnum={decDigit}("_"*{decDigit})*;
 hexDigit=[0-9a-fA-F];
@@ -200,249 +279,270 @@ exp=[eE](~?){decnum};
 real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 
 %%
-<INITIAL>{ws}   => (continue ());
+<INITIAL>{ws}+  => (continue ());
 <INITIAL>{eol}  => (Source.newline (source, yypos); continue ());
-<INITIAL>"_address" =>
-   (tok (Tokens.ADDRESS, source, yypos, yypos + size yytext));
-<INITIAL>"_build_const" =>
-   (tok (Tokens.BUILD_CONST, source, yypos, yypos + size yytext));
-<INITIAL>"_command_line_const" =>
-   (tok (Tokens.COMMAND_LINE_CONST, source, yypos, yypos + size yytext));
-<INITIAL>"_const" =>
-   (tok (Tokens.CONST, source, yypos, yypos + size yytext));
-<INITIAL>"_export" =>
-   (tok (Tokens.EXPORT, source, yypos, yypos + size yytext));
-<INITIAL>"_import" =>
-   (tok (Tokens.IMPORT, source, yypos, yypos + size yytext));
-<INITIAL>"_overload" =>
-   (tok (Tokens.OVERLOAD, source, yypos, yypos + size yytext));
-<INITIAL>"_symbol" =>
-   (tok (Tokens.SYMBOL, source, yypos, yypos + size yytext));
-<INITIAL>"_prim" =>
-   (tok (Tokens.PRIM, source, yypos, yypos + size yytext));
-<INITIAL>"_"    => (tok (Tokens.WILD, source, yypos, yypos + 1));
-<INITIAL>","    => (tok (Tokens.COMMA, source, yypos, yypos + 1));
-<INITIAL>"{"    => (tok (Tokens.LBRACE, source, yypos, yypos + 1));
-<INITIAL>"}"    => (tok (Tokens.RBRACE, source, yypos, yypos + 1));
-<INITIAL>"["    => (tok (Tokens.LBRACKET, source, yypos, yypos + 1));
-<INITIAL>"]"    => (tok (Tokens.RBRACKET, source, yypos, yypos + 1));
-<INITIAL>";"    => (tok (Tokens.SEMICOLON, source, yypos, yypos + 1));
-<INITIAL>"("    => (tok (Tokens.LPAREN, source, yypos, yypos + 1));
-<INITIAL>")"    => (tok (Tokens.RPAREN, source, yypos, yypos + 1));
-<INITIAL>"..."  => (tok (Tokens.DOTDOTDOT, source, yypos, yypos + 3));
-<INITIAL>"|" => (tok (Tokens.BAR, source, yypos, yypos + 1));
-<INITIAL>":" => (tok (Tokens.COLON, source, yypos, yypos + 1));
-<INITIAL>":>" => (tok (Tokens.COLONGT, source, yypos, yypos + 1));
-<INITIAL>"=" => (tok (Tokens.EQUALOP, source, yypos, yypos + 1));
-<INITIAL>"#" => (tok (Tokens.HASH, source, yypos, yypos + 1));
-<INITIAL>"->" => (tok (Tokens.ARROW, source, yypos, yypos + 2));
-<INITIAL>"=>" => (tok (Tokens.DARROW, source, yypos, yypos + 2));
-<INITIAL>"and" => (tok (Tokens.AND, source, yypos, yypos + 3));
-<INITIAL>"abstype" => (tok (Tokens.ABSTYPE, source, yypos, yypos + 7));
-<INITIAL>"as" => (tok (Tokens.AS, source, yypos, yypos + 2));
-<INITIAL>"case" => (tok (Tokens.CASE, source, yypos, yypos + 4));
-<INITIAL>"datatype" => (tok (Tokens.DATATYPE, source, yypos, yypos + 8));
-<INITIAL>"else" => (tok (Tokens.ELSE, source, yypos, yypos + 4));
-<INITIAL>"end" => (tok (Tokens.END, source, yypos, yypos + 3));
-<INITIAL>"eqtype" => (tok (Tokens.EQTYPE, source, yypos, yypos + 6));
-<INITIAL>"exception" => (tok (Tokens.EXCEPTION, source, yypos, yypos + 9));
-<INITIAL>"do" => (tok (Tokens.DO, source, yypos, yypos + 2));
-<INITIAL>"fn" => (tok (Tokens.FN, source, yypos, yypos + 2));
-<INITIAL>"fun" => (tok (Tokens.FUN, source, yypos, yypos + 3));
-<INITIAL>"functor" => (tok (Tokens.FUNCTOR, source, yypos, yypos + 7));
-<INITIAL>"handle" => (tok (Tokens.HANDLE, source, yypos, yypos + 6));
-<INITIAL>"if" => (tok (Tokens.IF, source, yypos, yypos + 2));
-<INITIAL>"in" => (tok (Tokens.IN, source, yypos, yypos + 2));
-<INITIAL>"include" => (tok (Tokens.INCLUDE, source, yypos, yypos + 7));
-<INITIAL>"infix" => (tok (Tokens.INFIX, source, yypos, yypos + 5));
-<INITIAL>"infixr" => (tok (Tokens.INFIXR, source, yypos, yypos + 6));
-<INITIAL>"let" => (tok (Tokens.LET, source, yypos, yypos + 3));
-<INITIAL>"local" => (tok (Tokens.LOCAL, source, yypos, yypos + 5));
-<INITIAL>"nonfix" => (tok (Tokens.NONFIX, source, yypos, yypos + 6));
-<INITIAL>"of" => (tok (Tokens.OF, source, yypos, yypos + 2));
-<INITIAL>"op" => (tok (Tokens.OP, source, yypos, yypos + 2));
-<INITIAL>"open" => (tok (Tokens.OPEN, source, yypos, yypos + 4));
-<INITIAL>"raise" => (tok (Tokens.RAISE, source, yypos, yypos + 5));
-<INITIAL>"rec" => (tok (Tokens.REC, source, yypos, yypos + 3));
-<INITIAL>"sharing" => (tok (Tokens.SHARING, source, yypos, yypos + 7));
-<INITIAL>"sig" => (tok (Tokens.SIG, source, yypos, yypos + 3));
-<INITIAL>"signature" => (tok (Tokens.SIGNATURE, source, yypos, yypos + 9));
-<INITIAL>"struct" => (tok (Tokens.STRUCT, source, yypos, yypos + 6));
-<INITIAL>"structure" => (tok (Tokens.STRUCTURE, source, yypos, yypos + 9));
-<INITIAL>"then" => (tok (Tokens.THEN, source, yypos, yypos + 4));
-<INITIAL>"type" => (tok (Tokens.TYPE, source, yypos, yypos + 4));
-<INITIAL>"val" => (tok (Tokens.VAL, source, yypos, yypos + 3));
-<INITIAL>"where" => (tok (Tokens.WHERE, source, yypos, yypos + 5));
-<INITIAL>"while" => (tok (Tokens.WHILE, source, yypos, yypos + 5));
-<INITIAL>"with" => (tok (Tokens.WITH, source, yypos, yypos + 4));
-<INITIAL>"withtype" => (tok (Tokens.WITHTYPE, source, yypos, yypos + 8));
-<INITIAL>"orelse" => (tok (Tokens.ORELSE, source, yypos, yypos + 6));
-<INITIAL>"andalso" => (tok (Tokens.ANDALSO, source, yypos, yypos + 7));
-<INITIAL>"'"{alphanum}? => (tok' (Tokens.TYVAR, yytext, source, yypos));
-<INITIAL>{longid} =>
+
+
+<INITIAL>"_address" => (tok (Tokens.ADDRESS, source, yypos, yypos + size yytext));
+<INITIAL>"_build_const" => (tok (Tokens.BUILD_CONST, source, yypos, yypos + size yytext));
+<INITIAL>"_command_line_const" => (tok (Tokens.COMMAND_LINE_CONST, source, yypos, yypos + size yytext));
+<INITIAL>"_const" => (tok (Tokens.CONST, source, yypos, yypos + size yytext));
+<INITIAL>"_export" => (tok (Tokens.EXPORT, source, yypos, yypos + size yytext));
+<INITIAL>"_import" => (tok (Tokens.IMPORT, source, yypos, yypos + size yytext));
+<INITIAL>"_overload" => (tok (Tokens.OVERLOAD, source, yypos, yypos + size yytext));
+<INITIAL>"_prim" => (tok (Tokens.PRIM, source, yypos, yypos + size yytext));
+<INITIAL>"_symbol" => (tok (Tokens.SYMBOL, source, yypos, yypos + size yytext));
+
+<INITIAL>"#" => (tok (Tokens.HASH, source, yypos, yypos + size yytext));
+<INITIAL>"(" => (tok (Tokens.LPAREN, source, yypos, yypos + size yytext));
+<INITIAL>")" => (tok (Tokens.RPAREN, source, yypos, yypos + size yytext));
+<INITIAL>"," => (tok (Tokens.COMMA, source, yypos, yypos + size yytext));
+<INITIAL>"->" => (tok (Tokens.ARROW, source, yypos, yypos + size yytext));
+<INITIAL>"..." => (tok (Tokens.DOTDOTDOT, source, yypos, yypos + size yytext));
+<INITIAL>":" => (tok (Tokens.COLON, source, yypos, yypos + size yytext));
+<INITIAL>":>" => (tok (Tokens.COLONGT, source, yypos, yypos + size yytext));
+<INITIAL>";" => (tok (Tokens.SEMICOLON, source, yypos, yypos + size yytext));
+<INITIAL>"=" => (tok (Tokens.EQUALOP, source, yypos, yypos + size yytext));
+<INITIAL>"=>" => (tok (Tokens.DARROW, source, yypos, yypos + size yytext));
+<INITIAL>"[" => (tok (Tokens.LBRACKET, source, yypos, yypos + size yytext));
+<INITIAL>"]" => (tok (Tokens.RBRACKET, source, yypos, yypos + size yytext));
+<INITIAL>"_" => (tok (Tokens.WILD, source, yypos, yypos + size yytext));
+<INITIAL>"{" => (tok (Tokens.LBRACE, source, yypos, yypos + size yytext));
+<INITIAL>"|" => (tok (Tokens.BAR, source, yypos, yypos + size yytext));
+<INITIAL>"}" => (tok (Tokens.RBRACE, source, yypos, yypos + size yytext));
+
+<INITIAL>"abstype" => (tok (Tokens.ABSTYPE, source, yypos, yypos + size yytext));
+<INITIAL>"and" => (tok (Tokens.AND, source, yypos, yypos + size yytext));
+<INITIAL>"andalso" => (tok (Tokens.ANDALSO, source, yypos, yypos + size yytext));
+<INITIAL>"as" => (tok (Tokens.AS, source, yypos, yypos + size yytext));
+<INITIAL>"case" => (tok (Tokens.CASE, source, yypos, yypos + size yytext));
+<INITIAL>"datatype" => (tok (Tokens.DATATYPE, source, yypos, yypos + size yytext));
+<INITIAL>"do" => (tok (Tokens.DO, source, yypos, yypos + size yytext));
+<INITIAL>"else" => (tok (Tokens.ELSE, source, yypos, yypos + size yytext));
+<INITIAL>"end" => (tok (Tokens.END, source, yypos, yypos + size yytext));
+<INITIAL>"eqtype" => (tok (Tokens.EQTYPE, source, yypos, yypos + size yytext));
+<INITIAL>"exception" => (tok (Tokens.EXCEPTION, source, yypos, yypos + size yytext));
+<INITIAL>"fn" => (tok (Tokens.FN, source, yypos, yypos + size yytext));
+<INITIAL>"fun" => (tok (Tokens.FUN, source, yypos, yypos + size yytext));
+<INITIAL>"functor" => (tok (Tokens.FUNCTOR, source, yypos, yypos + size yytext));
+<INITIAL>"handle" => (tok (Tokens.HANDLE, source, yypos, yypos + size yytext));
+<INITIAL>"if" => (tok (Tokens.IF, source, yypos, yypos + size yytext));
+<INITIAL>"in" => (tok (Tokens.IN, source, yypos, yypos + size yytext));
+<INITIAL>"include" => (tok (Tokens.INCLUDE, source, yypos, yypos + size yytext));
+<INITIAL>"infix" => (tok (Tokens.INFIX, source, yypos, yypos + size yytext));
+<INITIAL>"infixr" => (tok (Tokens.INFIXR, source, yypos, yypos + size yytext));
+<INITIAL>"let" => (tok (Tokens.LET, source, yypos, yypos + size yytext));
+<INITIAL>"local" => (tok (Tokens.LOCAL, source, yypos, yypos + size yytext));
+<INITIAL>"nonfix" => (tok (Tokens.NONFIX, source, yypos, yypos + size yytext));
+<INITIAL>"of" => (tok (Tokens.OF, source, yypos, yypos + size yytext));
+<INITIAL>"op" => (tok (Tokens.OP, source, yypos, yypos + size yytext));
+<INITIAL>"open" => (tok (Tokens.OPEN, source, yypos, yypos + size yytext));
+<INITIAL>"orelse" => (tok (Tokens.ORELSE, source, yypos, yypos + size yytext));
+<INITIAL>"raise" => (tok (Tokens.RAISE, source, yypos, yypos + size yytext));
+<INITIAL>"rec" => (tok (Tokens.REC, source, yypos, yypos + size yytext));
+<INITIAL>"sharing" => (tok (Tokens.SHARING, source, yypos, yypos + size yytext));
+<INITIAL>"sig" => (tok (Tokens.SIG, source, yypos, yypos + size yytext));
+<INITIAL>"signature" => (tok (Tokens.SIGNATURE, source, yypos, yypos + size yytext));
+<INITIAL>"struct" => (tok (Tokens.STRUCT, source, yypos, yypos + size yytext));
+<INITIAL>"structure" => (tok (Tokens.STRUCTURE, source, yypos, yypos + size yytext));
+<INITIAL>"then" => (tok (Tokens.THEN, source, yypos, yypos + size yytext));
+<INITIAL>"type" => (tok (Tokens.TYPE, source, yypos, yypos + size yytext));
+<INITIAL>"val" => (tok (Tokens.VAL, source, yypos, yypos + size yytext));
+<INITIAL>"where" => (tok (Tokens.WHERE, source, yypos, yypos + size yytext));
+<INITIAL>"while" => (tok (Tokens.WHILE, source, yypos, yypos + size yytext));
+<INITIAL>"with" => (tok (Tokens.WITH, source, yypos, yypos + size yytext));
+<INITIAL>"withtype" => (tok (Tokens.WITHTYPE, source, yypos, yypos + size yytext));
+
+
+<INITIAL>{tyvarId} => (tok' (Tokens.TYVAR, yytext, source, yypos));
+<INITIAL>{longId} =>
    (case yytext of
-       "*" => tok (Tokens.ASTERISK, source, yypos, yypos + 1)
+       "*" => tok (Tokens.ASTERISK, source, yypos, yypos + size yytext)
      | _ => tok' (Tokens.LONGID, yytext, source, yypos));
+
+
 <INITIAL>{real} =>
-   (real (yytext, source, yypos));
+   (real (source, yypos, yytext));
 <INITIAL>{decnum} =>
-   (int (yytext, source, yypos, 0, {extended = NONE}, {negate = false}, StringCvt.DEC));
+   (int (source, yypos, yytext, 0, {extended = NONE}, {negate = false}, StringCvt.DEC));
 <INITIAL>"~"{decnum} =>
-   (int (yytext, source, yypos, 1, {extended = NONE}, {negate = true}, StringCvt.DEC));
+   (int (source, yypos, yytext, 1, {extended = NONE}, {negate = true}, StringCvt.DEC));
 <INITIAL>"0x"{hexnum} =>
-   (int (yytext, source, yypos, 2, {extended = NONE}, {negate = false}, StringCvt.HEX));
+   (int (source, yypos, yytext, 2, {extended = NONE}, {negate = false}, StringCvt.HEX));
 <INITIAL>"~0x"{hexnum} =>
-   (int (yytext, source, yypos, 3, {extended = NONE}, {negate = true}, StringCvt.HEX));
+   (int (source, yypos, yytext, 3, {extended = NONE}, {negate = true}, StringCvt.HEX));
 <INITIAL>"0b"{binnum} =>
-   (int (yytext, source, yypos, 2, {extended = SOME "binary notation"}, {negate = false}, StringCvt.BIN));
+   (int (source, yypos, yytext, 2, {extended = SOME "binary notation"}, {negate = false}, StringCvt.BIN));
 <INITIAL>"~0b"{binnum} =>
-   (int (yytext, source, yypos, 3, {extended = SOME "binary notation"}, {negate = true}, StringCvt.BIN));
+   (int (source, yypos, yytext, 3, {extended = SOME "binary notation"}, {negate = true}, StringCvt.BIN));
 <INITIAL>"0w"{decnum} =>
-   (word (yytext, source, yypos, 2, {extended = NONE}, StringCvt.DEC));
+   (word (source, yypos, yytext, 2, {extended = NONE}, StringCvt.DEC));
 <INITIAL>"0wx"{hexnum} =>
-   (word (yytext, source, yypos, 3, {extended = NONE}, StringCvt.HEX));
+   (word (source, yypos, yytext, 3, {extended = NONE}, StringCvt.HEX));
 <INITIAL>"0wb"{binnum} =>
-   (word (yytext, source, yypos, 3, {extended = SOME "binary notation"}, StringCvt.BIN));
-<INITIAL>\"     => (charlist := []
-                    ; stringStart := Source.getPos (source, yypos)
-                    ; stringtype := true
-                    ; YYBEGIN S
-                    ; continue ());
-<INITIAL>\#\"   => (charlist := []
-                    ; stringStart := Source.getPos (source, yypos)
-                    ; stringtype := false
-                    ; YYBEGIN S
-                    ; continue ());
-<INITIAL>"(*)"	=> (if allowLineComments ()
-                       then (YYBEGIN B
-                            ; commentStart := Source.getPos (source, yypos)
-                            ; continue ())
-                       else (YYBEGIN A
-                            ; commentLevel := 1
-                            ; commentStart := Source.getPos (source, yypos)
-                            ; continue ())
-                    );
-<INITIAL>"(*#line"{nrws}
-                => (YYBEGIN L
-                    ; commentStart := Source.getPos (source, yypos)
-                    ; commentLevel := 1
-                    ; continue ());
-<INITIAL>"(*"   => (YYBEGIN A
-                    ; commentLevel := 1
-                    ; commentStart := Source.getPos (source, yypos)
-                    ; continue ());
-<INITIAL>.      => (error (source, yypos, yypos + 1, "illegal token") ;
-                    continue ());
+   (word (source, yypos, yytext, 3, {extended = SOME "binary notation"}, StringCvt.BIN));
 
-<L>[0-9]+       => (YYBEGIN LL
-                    ; (lineNum := valOf (Int.fromString yytext)
-                       ; colNum := 1)
-                      handle Overflow => YYBEGIN A
-                    ; continue ());
-<LL>\.          => ((* cheat: take n > 0 dots *) continue ());
-<LL>[0-9]+      => (YYBEGIN LLC
-                    ; (colNum := valOf (Int.fromString yytext))
-                      handle Overflow => YYBEGIN A
-                    ; continue ());
-<LL>.           => (YYBEGIN LLC; continue ()
-                (* note hack, since ml-lex chokes on the empty string for 0* *));
-<LLC>"*)"       => (YYBEGIN INITIAL
-                    ; lineDirective (source, NONE, yypos + 2)
-                    ; commentLevel := 0; charlist := []; continue ());
-<LLC>{ws}\"     => (YYBEGIN LLCQ; continue ());
-<LLCQ>[^\"]*    => (lineFile := yytext; continue ());
-<LLCQ>\""*)"    => (YYBEGIN INITIAL
-                    ; lineDirective (source, SOME (!lineFile), yypos + 3)
-                    ; commentLevel := 0; charlist := []; continue ());
-<L,LLC,LLCQ>"*)" => (YYBEGIN INITIAL; commentLevel := 0; charlist := []; continue ());
-<L,LLC,LLCQ>.   => (YYBEGIN A; continue ());
+<INITIAL>"\"" =>
+   (startText (Source.getPos (source, yypos), fn (cs, l, r) => fn () =>
+               (YYBEGIN INITIAL;
+                Tokens.STRING (cs, l, r)))
+    ; YYBEGIN TEXT
+    ; continue ());
+<INITIAL>"#\"" =>
+   (startText (Source.getPos (source, yypos), fn (cs, l, r) =>
+               (let
+                   fun err () =
+                      textError (r, "character constant not of size 1")
+                   val c =
+                      case Int.compare (Vector.length cs, 1) of
+                         LESS => (err (); 0)
+                       | EQUAL => Vector.sub (cs, 0)
+                       | GREATER => (err (); Vector.sub (cs, 0))
+                in
+                   fn () =>
+                   (YYBEGIN INITIAL;
+                    Tokens.CHAR (c, l, r))
+                end))
+    ; YYBEGIN TEXT
+    ; continue ());
 
-<A>"(*)"        => (if allowLineComments ()
-                       then (YYBEGIN C
-                             ; continue ())
-                       else (inc commentLevel; continue ()));
-<A>"(*"         => (inc commentLevel; continue ());
-<A>{eol}        => (Source.newline (source, yypos) ; continue ());
-<A>"*)"         => (dec commentLevel
-                    ; if 0 = !commentLevel then YYBEGIN INITIAL else ()
-                    ; continue ());
-<A>.            => (continue ());
-<B>{eol}        => (YYBEGIN INITIAL
-                    ; Source.newline (source, yypos) ; continue ());
-<B>.            => (continue ());
-<C>{eol}        => (YYBEGIN A
-                    ; Source.newline (source, yypos) ; continue ());
-<C>.            => (continue ());
-
-<S>\"           => (let
-                       val s = Vector.fromListRev (!charlist)
-                       val _ = charlist := nil
-                       fun make (t, v) =
-                          t (v, !stringStart, Source.getPos (source, yypos + 1))
-                       val () = YYBEGIN INITIAL
-                    in
-                       if !stringtype
-                          then make (Tokens.STRING, s)
-                       else
-                          make (Tokens.CHAR,
-                                if 1 <> Vector.length s
-                                   then (error
-                                         (source, yypos, yypos + 1,
-                                          "character constant not length 1")
-                                         ; 0)
-                                else Vector.sub (s, 0))
-                    end);
-<S>\\a          => (addChar #"\a"; continue ());
-<S>\\b          => (addChar #"\b"; continue ());
-<S>\\f          => (addChar #"\f"; continue ());
-<S>\\n          => (addChar #"\n"; continue ());
-<S>\\r          => (addChar #"\r"; continue ());
-<S>\\t          => (addChar #"\t"; continue ());
-<S>\\v          => (addChar #"\v"; continue ());
-<S>\\\^[@-_]    => (addChar (Char.chr(Char.ord(String.sub(yytext, 2)) -Char.ord #"@"));
-                    continue ());
-<S>\\\^.        => (error (source, yypos, yypos + 2,
-                           "illegal control escape in string; must be one of @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_");
-                    continue ());
-<S>\\[0-9]{3}   => (addNumEsc (yytext, source, yypos, 1,
-                               {extended = NONE}, StringCvt.DEC)
-                    ; continue ());
-<S>\\u{hexDigit}{4} =>
-                   (addNumEsc (yytext, source, yypos, 2,
-                               {extended = NONE}, StringCvt.HEX)
-                    ; continue ());
-<S>\\U{hexDigit}{8} =>
-                   (addNumEsc (yytext, source, yypos, 2,
-                               (* \Uxxxxxxxx string constants are used in Basis Library
-                                * implementation and regression suite.
-                                *)
-                               (* {extended = SOME "\\Uxxxxxxxx numeric escapes"}, *)
-                               {extended = NONE}, StringCvt.HEX)
-                    ; continue ());
-<S>\\\"         => (addString "\""; continue ());
-<S>\\\\         => (addString "\\"; continue ());
-<S>\\{nrws}     => (YYBEGIN F; continue ());
-<S>\\{eol}      => (Source.newline (source, yypos + 1) ; YYBEGIN F ; continue ());
-<S>\\           => (error (source, yypos, yypos, "illegal escape in string")
-                    ; continue ());
-<S>{eol}        => (Source.newline (source, yypos)
-                    ; stringError (source, yypos, "unclosed string")
-                    ; continue ());
-<S>" "|[\033-\126] =>
-                   (addString yytext; continue ());
-<S>[\192-\223][\128-\191] =>
-                   (addUTF8 (yytext, source, yypos); continue());
-<S>[\224-\239][\128-\191][\128-\191] =>
-                   (addUTF8 (yytext, source, yypos); continue());
-<S>[\240-\247][\128-\191][\128-\191][\128-\191] =>
-                   (addUTF8 (yytext, source, yypos); continue());
-<S>. =>            (error (source, yypos, yypos, "illegal character in string")
-                    ; continue ());
-
-<F>{eol}         => (Source.newline (source, yypos) ; continue ());
-<F>{ws}          => (continue ());
-<F>\\            => (YYBEGIN S
-                     ; stringStart := Source.getPos (source, yypos)
+<TEXT>"\""       => (finishText (Source.getPos (source, yypos + 1)));
+<TEXT>" "|[\033-\126] =>
+                    (addTextString yytext; continue ());
+<TEXT>[\192-\223][\128-\191] =>
+                    (addTextUTF8 (source, yypos, yytext); continue());
+<TEXT>[\224-\239][\128-\191][\128-\191] =>
+                    (addTextUTF8 (source, yypos, yytext); continue());
+<TEXT>[\240-\247][\128-\191][\128-\191][\128-\191] =>
+                    (addTextUTF8 (source, yypos, yytext); continue());
+<TEXT>\\a        => (addTextChar #"\a"; continue ());
+<TEXT>\\b        => (addTextChar #"\b"; continue ());
+<TEXT>\\t        => (addTextChar #"\t"; continue ());
+<TEXT>\\n        => (addTextChar #"\n"; continue ());
+<TEXT>\\v        => (addTextChar #"\v"; continue ());
+<TEXT>\\f        => (addTextChar #"\f"; continue ());
+<TEXT>\\r        => (addTextChar #"\r"; continue ());
+<TEXT>\\\^[@-_]  => (addTextChar (Char.chr(Char.ord(String.sub(yytext, 2)) - Char.ord #"@"));
+                     continue ());
+<TEXT>\\\^.      => (error (source, yypos, yypos + 2,
+                            "Illegal control escape in text constant; must be one of @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_");
+                     continue ());
+<TEXT>\\[0-9]{3} => (addTextNumEsc (source, yypos, yytext, 1,
+                                    {extended = NONE}, StringCvt.DEC)
                      ; continue ());
-<F>.             => (stringError (source, yypos, "unclosed string")
+<TEXT>\\u{hexDigit}{4} =>
+                    (addTextNumEsc (source, yypos, yytext, 2,
+                                    {extended = NONE}, StringCvt.HEX)
                      ; continue ());
+<TEXT>\\U{hexDigit}{8} =>
+                    (addTextNumEsc (source, yypos, yytext, 2,
+                                    (* \Uxxxxxxxx string constants are used in Basis Library
+                                     * implementation and regression suite.
+                                     *)
+                                    (* {extended = SOME "\\Uxxxxxxxx numeric escapes"}, *)
+                                    {extended = NONE}, StringCvt.HEX)
+                     ; continue ());
+<TEXT>"\\\""     => (addTextString "\""; continue ());
+<TEXT>\\\\       => (addTextString "\\"; continue ());
+<TEXT>\\{ws}+    => (YYBEGIN TEXT_FMT; continue ());
+<TEXT>\\{eol}    => (Source.newline (source, yypos + 1); YYBEGIN TEXT_FMT; continue ());
+<TEXT>\\         => (error (source, yypos, yypos, "Illegal escape in text constant")
+                     ; continue ());
+<TEXT>{eol}      => (Source.newline (source, yypos)
+                     ; textError (Source.getPos (source, yypos), "Unclosed text constant at end of line")
+                     ; continue ());
+<TEXT>.          => (error (source, yypos, yypos, "Illegal character in text constant")
+                     ; continue ());
+
+<TEXT_FMT>{ws}+  => (continue ());
+<TEXT_FMT>{eol}  => (Source.newline (source, yypos); continue ());
+<TEXT_FMT>\\     => (YYBEGIN TEXT; continue ());
+<TEXT_FMT>.      => (error (source, yypos, yypos, "Illegal formatting character in text continuation")
+                     ; continue ());
+
+
+<INITIAL>"(*)" =>
+   (if allowLineComments ()
+       then ()
+       else error (source, yypos, yypos,
+                   "Line comments disallowed, compile with -default-ann 'allowLineConsts true'")
+    ; startComment (source, yypos, fn () =>
+                    YYBEGIN INITIAL)
+    ; YYBEGIN LINE_COMMENT
+    ; continue ());
+<INITIAL>"(*" =>
+   (startComment (source, yypos, fn () =>
+                  YYBEGIN INITIAL)
+    ; YYBEGIN BLOCK_COMMENT
+    ; continue ());
+
+<LINE_COMMENT>{eol} =>
+   (Source.newline (source, yypos)
+    ; finishComment ()
+    ; continue ());
+<LINE_COMMENT>. =>
+   (continue ());
+
+<BLOCK_COMMENT>"(*)" =>
+   (if allowLineComments ()
+       then ()
+       else error (source, yypos, yypos,
+                   "Line comments disallowed, compile with -default-ann 'allowLineConsts true'")
+    ; startComment (source, yypos, fn () =>
+                    YYBEGIN BLOCK_COMMENT)
+    ; YYBEGIN LINE_COMMENT
+    ; continue ());
+<BLOCK_COMMENT>"(*" =>
+   (startComment (source, yypos, fn () =>
+                  YYBEGIN BLOCK_COMMENT)
+    ; YYBEGIN BLOCK_COMMENT
+    ; continue ());
+<BLOCK_COMMENT>"*)" =>
+   (finishComment ()
+    ; continue ());
+<BLOCK_COMMENT>{eol} =>
+   (Source.newline (source, yypos)
+    ; continue ());
+<BLOCK_COMMENT>. =>
+   (continue ());
+
+
+<INITIAL>"(*#line"{ws}+ =>
+   (startLineDir (source, yypos, fn () =>
+                  YYBEGIN INITIAL)
+    ; YYBEGIN LINE_DIR1
+    ; continue ());
+
+<LINE_DIR1>{decDigit}+"."{decDigit}+ =>
+   (let
+       fun err () =
+          (commentError (Source.getPos (source, yypos), "Illegal line directive")
+           ; YYBEGIN BLOCK_COMMENT)
+     in
+        case String.split (yytext, #".") of
+           [line, col] =>
+              (YYBEGIN LINE_DIR2
+               ; addLineDirLineCol (valOf (Int.fromString line), valOf (Int.fromString col))
+                 handle Overflow => err () | Option => err ()
+               ; continue ())
+         | _ => (err (); continue ())
+     end);
+<LINE_DIR2>{ws}+"\"" =>
+   (YYBEGIN LINE_DIR3
+    ; continue ());
+<LINE_DIR3>[^"]*"\"" =>
+   (addLineDirFile (String.dropLast yytext)
+    ; YYBEGIN LINE_DIR4
+    ; continue ());
+<LINE_DIR2,LINE_DIR4>{ws}*"*)" =>
+   (finishLineDir (source, yypos + size yytext)
+    ; continue ());
+<LINE_DIR1,LINE_DIR2,LINE_DIR3,LINE_DIR4>. =>
+   (commentError (Source.getPos (source, yypos), "Illegal line directive")
+    ; YYBEGIN BLOCK_COMMENT
+    ; continue ());
+
+
+<INITIAL>. =>
+   (error (source, yypos, yypos + 1, "Illegal token")
+    ; continue ());

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -149,14 +149,15 @@ nrws=("\012"|[\t\ ])+;
 cr="\013";
 nl="\010";
 eol=({cr}{nl}|{nl}|{cr});
-num=([0-9]([0-9]|"_")*[0-9])|([0-9]+);
-frac="."{num};
-exp=[eE](~?){num};
-real=(~?)(({num}{frac}?{exp})|({num}{frac}{exp}?));
+decDigit=[0-9];
+decnum={decDigit}("_"*{decDigit})*;
 hexDigit=[0-9a-fA-F];
-hexnum=({hexDigit}({hexDigit}|"_")*{hexDigit})|({hexDigit}+);
+hexnum={hexDigit}("_"*{hexDigit})*;
 binDigit=[0-1];
-binnum=({binDigit}({binDigit}|"_")*{binDigit})|({binDigit}+);
+binnum={binDigit}("_"*{binDigit})*;
+frac="."{decnum};
+exp=[eE](~?){decnum};
+real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 
 %%
 <INITIAL>{ws}   => (continue ());
@@ -245,10 +246,10 @@ binnum=({binDigit}({binDigit}|"_")*{binDigit})|({binDigit}+);
 <INITIAL>{real} =>
    ((extLiteral (yytext, source, yypos, yypos + size yytext));
    (tok' (Tokens.REAL, stripUscores yytext, source, yypos)));
-<INITIAL>{num} =>
+<INITIAL>{decnum} =>
    ((extLiteral (yytext, source, yypos, yypos + size yytext));
    (int (yytext, 0, source, yypos, {negate = false}, StringCvt.DEC)));
-<INITIAL>"~"{num} =>
+<INITIAL>"~"{decnum} =>
    ((extLiteral (yytext, source, yypos, yypos + 1 + size yytext));
    (int (yytext, 1, source, yypos, {negate = true}, StringCvt.DEC)));
 <INITIAL>"0x"{hexnum} =>
@@ -263,7 +264,7 @@ binnum=({binDigit}({binDigit}|"_")*{binDigit})|({binDigit}+);
 <INITIAL>"~0b"{binnum} =>
    ((binLiteral (yytext, source, yypos, yypos + 3 + size yytext));
    (int (yytext, 3, source, yypos, {negate = true}, StringCvt.BIN)));
-<INITIAL>"0w"{num} =>
+<INITIAL>"0w"{decnum} =>
    ((extLiteral (yytext, source, yypos, yypos + 2 + size yytext));
    (word (yytext, 2, source, yypos, StringCvt.DEC)));
 <INITIAL>("0wx"|"0xw"){hexnum} =>
@@ -409,4 +410,3 @@ binnum=({binDigit}({binDigit}|"_")*{binDigit})|({binDigit}+);
                     ; continue ());
 <F>.            => (stringError (source, yypos, "unclosed string")
                     ; continue ());
-

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -266,9 +266,7 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
    (word (yytext, source, yypos, 2, {extended = false}, StringCvt.DEC));
 <INITIAL>"0wx"{hexnum} =>
    (word (yytext, source, yypos, 3, {extended = false}, StringCvt.HEX));
-<INITIAL>"0xw"{hexnum} =>
-   (word (yytext, source, yypos, 3, {extended = true}, StringCvt.HEX));
-<INITIAL>("0wb"|"0bw"){binnum} =>
+<INITIAL>"0wb"{binnum} =>
    (word (yytext, source, yypos, 3, {extended = true}, StringCvt.BIN));
 <INITIAL>\"     => (charlist := []
                     ; stringStart := Source.getPos (source, yypos)

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -59,7 +59,7 @@ local
    open Control.Elaborate
 in
    val allowLineComments = fn () => current allowLineComments
-   val allowExtendedLiterals = fn () => current allowExtendedLiterals
+   val allowExtendedNumConsts = fn () => current allowExtendedNumConsts
 end
 
 fun addOrd (i: IntInf.t): unit = List.push (charlist, i)
@@ -111,7 +111,7 @@ fun doit (yytext, source, yypos, drop, {extended: bool}, mkTok) =
       val left = yypos
       val right = yypos + size yytext
       val _ =
-         if extended andalso not (allowExtendedLiterals ())
+         if extended andalso not (allowExtendedNumConsts ())
             then error (source, left, right,
                         "Extended literals disallowed, compile with -default-ann 'allowExtendedLiterals true'")
             else ()

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -338,6 +338,7 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 <C>{eol}        => (YYBEGIN A
                     ; Source.newline (source, yypos) ; continue ());
 <C>.            => (continue ());
+
 <S>\"           => (let
                        val s = Vector.fromListRev (!charlist)
                        val _ = charlist := nil

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -113,7 +113,7 @@ fun doit (yytext, source, yypos, drop, {extended: bool}, mkTok) =
       val _ =
          if extended andalso not (allowExtendedNumConsts ())
             then error (source, left, right,
-                        "Extended literals disallowed, compile with -default-ann 'allowExtendedLiterals true'")
+                        "Extended numeric constants disallowed, compile with -default-ann 'allowExtendedNumConsts true'")
             else ()
    in
       mkTok (String.keepAll (String.dropPrefix (yytext, drop), fn c => not (c = #"_")),

--- a/mlton/front-end/mlb.lex
+++ b/mlton/front-end/mlb.lex
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2016 Matthew Fluet.
+(* Copyright (C) 2009,2016,2017 Matthew Fluet.
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -13,76 +13,177 @@ type lexarg = {source: Source.t}
 type arg = lexarg
 type ('a,'b) token = ('a,'b) Tokens.token
 
-val charlist: string list ref = ref []
-val colNum: int ref = ref 0
-val commentLevel: int ref = ref 0
-val commentStart = ref SourcePos.bogus
-val lineFile: File.t ref = ref ""
-val lineNum: int ref = ref 0
-val stringStart = ref SourcePos.bogus
-
-fun lineDirective (source, file, yypos) =
-   Source.lineDirective (source, file,
-                         {lineNum = !lineNum,
-                          lineStart = yypos - !colNum})
-fun addString (s: string) = charlist := s :: (!charlist)
-fun addChar (c: char) = addString (String.fromChar c)
-
-fun inc (ri as ref (i: int)) = (ri := i + 1)
-fun dec (ri as ref (i: int)) = (ri := i-1)
-
-fun error (source, left, right, msg) = 
-   Control.errorStr (Region.make {left = Source.getPos (source, left),
-                                  right = Source.getPos (source, right)},
-                     msg)
-
-fun stringError (source, right, msg) =
-   Control.errorStr (Region.make {left = !stringStart,
-                                  right = Source.getPos (source, right)},
-                     msg)
-
-val eof: lexarg -> lexresult =
-   fn {source, ...} =>
-   let
-      val pos = Source.lineStart source
-      val _ =
-         if !commentLevel > 0
-            then Control.errorStr (Region.make {left = !commentStart,
-                                                right = pos},
-                                   "unclosed comment")
-         else ()
-   in
-      Tokens.EOF (pos, pos)
-   end
-
-val size = String.size
-
 fun tok (t, s, l, r) =
    let
       val l = Source.getPos (s, l)
       val r = Source.getPos (s, r)
-      val _ =
-         if true
-            then ()
-         else
-            print (concat ["tok (",
-                           SourcePos.toString l,
-                           ", " ,
-                           SourcePos.toString r,
-                           ")\n"])
    in
       t (l, r)
    end
 
 fun tok' (t, x, s, l) = tok (fn (l, r) => t (x, l, r), s, l, l + size x)
 
+fun error (source, left, right, msg) =
+   Control.errorStr (Region.make {left = Source.getPos (source, left),
+                                  right = Source.getPos (source, right)},
+                     msg)
+
+
+(* Comments *)
+local
+   val commentLeft = ref SourcePos.bogus
+   val commentStack: (unit -> unit) list ref = ref []
+in
+   fun commentError (right, msg) =
+      Control.errorStr (Region.make {left = !commentLeft,
+                                     right = right},
+                        msg)
+   val inComment = fn () => not (List.isEmpty (!commentStack))
+   fun startComment (source, yypos, th) =
+      let
+         val _ =
+            if inComment ()
+               then ()
+               else commentLeft := Source.getPos (source, yypos)
+         val _ = List.push (commentStack, th)
+      in
+         ()
+      end
+   fun finishComment () =
+      (List.pop commentStack) ()
+end
+
+
+(* Line Directives *)
+local
+   val lineDirCol: int ref = ref ~1
+   val lineDirFile: File.t option ref = ref NONE
+   val lineDirLine: int ref = ref ~1
+in
+   fun startLineDir (source, yypos, th) =
+      let
+         val _ = lineDirCol := ~1
+         val _ = lineDirFile := NONE
+         val _ = lineDirLine := ~1
+      in
+         startComment (source, yypos, th)
+      end
+   fun addLineDirLineCol (line, col) =
+      let
+         val _ = lineDirLine := line
+         val _ = lineDirCol := col
+      in
+         ()
+      end
+   fun addLineDirFile file =
+      let
+         val _ = lineDirFile := SOME file
+      in
+         ()
+      end
+   fun finishLineDir (source, yypos) =
+      let
+         val col = !lineDirCol
+         val file = !lineDirFile
+         val line = !lineDirLine
+         val _ = lineDirCol := ~1
+         val _ = lineDirFile := NONE
+         val _ = lineDirLine := ~1
+      in
+         Source.lineDirective (source, file,
+                               {lineNum = line,
+                                lineStart = yypos - col})
+         ; finishComment ()
+      end
+end
+
+
+(* Text Constants *)
+local
+   val chars: char list ref = ref []
+   val inText = ref false
+   val textLeft = ref SourcePos.bogus
+   val textFinishFn: (string * SourcePos.t * SourcePos.t -> unit -> lexresult) ref = ref (fn _ => raise Fail "textFinish")
+in
+   fun textError (right, msg) =
+      Control.errorStr (Region.make {left = !textLeft,
+                                     right = right},
+                        msg)
+   fun startText (tl, tf) =
+      let
+         val _ = chars := []
+         val _ = inText := true
+         val _ = textLeft := tl
+         val _ = textFinishFn := tf
+      in
+         ()
+      end
+   fun finishText (textRight) =
+      let
+         val cs = String.fromListRev (!chars)
+         val tf = (!textFinishFn) (cs, !textLeft, textRight)
+         val _ = chars := []
+         val _ = inText := false
+         val _ = textLeft := SourcePos.bogus
+         val _ = textFinishFn := (fn _ => raise Fail "textFinish")
+      in
+         tf ()
+      end
+   fun addTextString (s: string) =
+      chars := String.fold (s, !chars, fn (c, ac) => c :: ac)
+   val inText = fn () => !inText
+end
+fun addTextChar (c: char) = addTextString (String.fromChar c)
+fun addTextNumEsc (source, yypos, yytext, drop, radix): unit =
+   let
+      val left = yypos
+      val right = yypos + size yytext
+      fun err () =
+         error (source, left, right, "Illegal numeric escape in text constant")
+   in
+      case StringCvt.scanString (fn r => IntInf.scan (radix, r)) (String.dropPrefix (yytext, drop)) of
+         NONE => err ()
+       | SOME i => if i > 255
+                      then err ()
+                      else addTextChar (Char.chr (IntInf.toInt i))
+   end
+fun addTextUTF8 (source, yypos, yytext): unit =
+   addTextString yytext
+
+
+(* EOF *)
+val eof: lexarg -> lexresult =
+   fn {source, ...} =>
+   let
+      val pos = Source.lineStart source
+      val _ =
+         if inComment ()
+            then commentError (SourcePos.bogus, "Unclosed comment at end of file")
+            else ()
+      val _ =
+         if inText ()
+            then textError (SourcePos.bogus, "Unclosed text constant at end of file")
+            else ()
+   in
+      Tokens.EOF (pos, pos)
+   end
+
+
 %% 
-%reject
-%s A B C S F L LL LLC LLCQ;
+%full
+
+%s TEXT TEXT_FMT  BLOCK_COMMENT LINE_COMMENT  LINE_DIR1 LINE_DIR2 LINE_DIR3 LINE_DIR4;
+
 %header (functor MLBLexFun (structure Tokens : MLB_TOKENS));
 %arg ({source});
-alphanum=[A-Za-z'_0-9]*;
-alphanumId=[A-Za-z]{alphanum};
+
+ws=\t|"\011"|"\012"|" ";
+cr="\013";
+nl="\010";
+eol=({cr}{nl}|{nl}|{cr});
+
+alphanum=[A-Za-z0-9'_];
+alphanumId=[A-Za-z]{alphanum}*;
 id={alphanumId};
 
 pathvar="$("([A-Z_][A-Z0-9_]*)")";
@@ -93,166 +194,166 @@ abspath="/"{relpath};
 path={relpath}|{abspath};
 file={path}{filename};
 
-ws=("\012"|[\t\ ])*;
-nrws=("\012"|[\t\ ])+;
-cr="\013";
-nl="\010";
-eol=({cr}{nl}|{nl}|{cr});
-
+decDigit=[0-9];
 hexDigit=[0-9a-fA-F];
 
 %%
-<INITIAL>{ws}   => (continue ());
+<INITIAL>{ws}+  => (continue ());
 <INITIAL>{eol}  => (Source.newline (source, yypos); continue ());
-<INITIAL>"_prim" 
-                => (tok (Tokens.PRIM, source, yypos, yypos + 4));
-<INITIAL>","    => (tok (Tokens.COMMA, source, yypos, yypos + 1));
-<INITIAL>";"    => (tok (Tokens.SEMICOLON, source, yypos, yypos + 1));
-<INITIAL>"="    => (tok (Tokens.EQUALOP, source, yypos, yypos + 1));
-<INITIAL>"ann"  => (tok (Tokens.ANN, source, yypos, yypos + 3));
-<INITIAL>"and"  => (tok (Tokens.AND, source, yypos, yypos + 3));
-<INITIAL>"bas"  => (tok (Tokens.BAS, source, yypos, yypos + 3));
-<INITIAL>"basis" 
-                => (tok (Tokens.BASIS, source, yypos, yypos + 5));
-<INITIAL>"end"  => (tok (Tokens.END, source, yypos, yypos + 3));
-<INITIAL>"functor" 
-                => (tok (Tokens.FUNCTOR, source, yypos, yypos + 7));
-<INITIAL>"in"   => (tok (Tokens.IN, source, yypos, yypos + 2));
-<INITIAL>"let"  => (tok (Tokens.LET, source, yypos, yypos + 3));
-<INITIAL>"local" 
-                => (tok (Tokens.LOCAL, source, yypos, yypos + 5));
-<INITIAL>"open" => (tok (Tokens.OPEN, source, yypos, yypos + 4));
-<INITIAL>"signature" 
-                => (tok (Tokens.SIGNATURE, source, yypos, yypos + 9));
-<INITIAL>"structure" 
-                => (tok (Tokens.STRUCTURE, source, yypos, yypos + 9));
-<INITIAL>{id}   => (tok' (Tokens.ID, yytext, source, yypos));
+
+<INITIAL>"_prim" => (tok (Tokens.PRIM, source, yypos, yypos + size yytext));
+
+<INITIAL>"," => (tok (Tokens.COMMA, source, yypos, yypos + size yytext));
+<INITIAL>";" => (tok (Tokens.SEMICOLON, source, yypos, yypos + size yytext));
+<INITIAL>"=" => (tok (Tokens.EQUALOP, source, yypos, yypos + size yytext));
+
+<INITIAL>"and" => (tok (Tokens.AND, source, yypos, yypos + size yytext));
+<INITIAL>"ann" => (tok (Tokens.ANN, source, yypos, yypos + size yytext));
+<INITIAL>"bas" => (tok (Tokens.BAS, source, yypos, yypos + size yytext));
+<INITIAL>"basis" => (tok (Tokens.BASIS, source, yypos, yypos + size yytext));
+<INITIAL>"end" => (tok (Tokens.END, source, yypos, yypos + size yytext));
+<INITIAL>"functor" => (tok (Tokens.FUNCTOR, source, yypos, yypos + size yytext));
+<INITIAL>"in" => (tok (Tokens.IN, source, yypos, yypos + size yytext));
+<INITIAL>"let" => (tok (Tokens.LET, source, yypos, yypos + size yytext));
+<INITIAL>"local" => (tok (Tokens.LOCAL, source, yypos, yypos + size yytext));
+<INITIAL>"open" => (tok (Tokens.OPEN, source, yypos, yypos + size yytext));
+<INITIAL>"signature" => (tok (Tokens.SIGNATURE, source, yypos, yypos + size yytext));
+<INITIAL>"structure" => (tok (Tokens.STRUCTURE, source, yypos, yypos + size yytext));
+
+<INITIAL>{id} => (tok' (Tokens.ID, yytext, source, yypos));
 <INITIAL>{file} => (tok' (Tokens.FILE, yytext, source, yypos));
 
-<INITIAL>\"     => (charlist := [""]
-                    ; stringStart := Source.getPos (source, yypos)
-                    ; YYBEGIN S
-                    ; continue ());
-<INITIAL>"(*)"  => (YYBEGIN B
-                    ; commentStart := Source.getPos (source, yypos)
-                    ; continue ());
-<INITIAL>"(*#line"{nrws}
-                => (YYBEGIN L
-                    ; commentStart := Source.getPos (source, yypos)
-                    ; commentLevel := 1
-                    ; continue ());
-<INITIAL>"(*"   => (YYBEGIN A
-                    ; commentLevel := 1
-                    ; commentStart := Source.getPos (source, yypos)
-                    ; continue ());
-<INITIAL>.      => (error (source, yypos, yypos + 1, "illegal token") ;
-                    continue ());
+<INITIAL>"\"" =>
+   (startText (Source.getPos (source, yypos), fn (s, l, r) => fn () =>
+               (YYBEGIN INITIAL;
+                Tokens.STRING (s, l, r)))
+    ; YYBEGIN TEXT
+    ; continue ());
 
-<L>[0-9]+       => (YYBEGIN LL
-                    ; (lineNum := valOf (Int.fromString yytext)
-                       ; colNum := 1)
-                      handle Overflow => YYBEGIN A
-                    ; continue ());
-<LL>\.          => ((* cheat: take n > 0 dots *) continue ());
-<LL>[0-9]+      => (YYBEGIN LLC
-                    ; (colNum := valOf (Int.fromString yytext))
-                      handle Overflow => YYBEGIN A
-                    ; continue ());
-<LL>.           => (YYBEGIN LLC; continue ()
-                (* note hack, since ml-lex chokes on the empty string for 0* *));
-<LLC>"*)"       => (YYBEGIN INITIAL
-                    ; lineDirective (source, NONE, yypos + 2)
-                    ; commentLevel := 0; charlist := []; continue ());
-<LLC>{ws}\"     => (YYBEGIN LLCQ; continue ());
-<LLCQ>[^\"]*    => (lineFile := yytext; continue ());
-<LLCQ>\""*)"    => (YYBEGIN INITIAL
-                    ; lineDirective (source, SOME (!lineFile), yypos + 3)
-                    ; commentLevel := 0; charlist := []; continue ());
-<L,LLC,LLCQ>"*)" 
-                => (YYBEGIN INITIAL; commentLevel := 0; charlist := []; continue ());
-<L,LLC,LLCQ>.   => (YYBEGIN A; continue ());
+<TEXT>"\""       => (finishText (Source.getPos (source, yypos + 1)));
+<TEXT>" "|[\033-\126] =>
+                    (addTextString yytext; continue ());
+<TEXT>[\192-\223][\128-\191] =>
+                    (addTextUTF8 (source, yypos, yytext); continue());
+<TEXT>[\224-\239][\128-\191][\128-\191] =>
+                    (addTextUTF8 (source, yypos, yytext); continue());
+<TEXT>[\240-\247][\128-\191][\128-\191][\128-\191] =>
+                    (addTextUTF8 (source, yypos, yytext); continue());
+<TEXT>\\a        => (addTextChar #"\a"; continue ());
+<TEXT>\\b        => (addTextChar #"\b"; continue ());
+<TEXT>\\t        => (addTextChar #"\t"; continue ());
+<TEXT>\\n        => (addTextChar #"\n"; continue ());
+<TEXT>\\v        => (addTextChar #"\v"; continue ());
+<TEXT>\\f        => (addTextChar #"\f"; continue ());
+<TEXT>\\r        => (addTextChar #"\r"; continue ());
+<TEXT>\\\^[@-_]  => (addTextChar (Char.chr(Char.ord(String.sub(yytext, 2)) - Char.ord #"@"));
+                     continue ());
+<TEXT>\\\^.      => (error (source, yypos, yypos + 2, "Illegal control escape in text constant; must be one of @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_");
+                     continue ());
+<TEXT>\\[0-9]{3} => (addTextNumEsc (source, yypos, yytext, 1,
+                                    StringCvt.DEC)
+                     ; continue ());
+<TEXT>\\u{hexDigit}{4} =>
+                    (addTextNumEsc (source, yypos, yytext, 2,
+                                    StringCvt.HEX)
+                     ; continue ());
+<TEXT>\\U{hexDigit}{8} =>
+                    (addTextNumEsc (source, yypos, yytext, 2,
+                                    StringCvt.HEX)
+                     ; continue ());
+<TEXT>"\\\""     => (addTextString "\""; continue ());
+<TEXT>\\\\       => (addTextString "\\"; continue ());
+<TEXT>\\{ws}+    => (YYBEGIN TEXT_FMT; continue ());
+<TEXT>\\{eol}    => (Source.newline (source, yypos + 1); YYBEGIN TEXT_FMT; continue ());
+<TEXT>\\         => (error (source, yypos, yypos, "Illegal escape in text constant")
+                     ; continue ());
+<TEXT>{eol}      => (Source.newline (source, yypos)
+                     ; textError (Source.getPos (source, yypos), "Unclosed text constant at end of line")
+                     ; continue ());
+<TEXT>.          => (error (source, yypos, yypos, "Illegal character in text constant")
+                     ; continue ());
 
-<A>"(*)"        => (YYBEGIN C ; continue ());
-<A>"(*"         => (inc commentLevel; continue ());
-<A>{eol}        => (Source.newline (source, yypos) ; continue ());
-<A>"*)"         => (dec commentLevel
-                    ; if 0 = !commentLevel then YYBEGIN INITIAL else ()
-                    ; continue ());
-<A>.            => (continue ());
-<B>{eol}        => (YYBEGIN INITIAL
-                    ; Source.newline (source, yypos) ; continue ());
-<B>.            => (continue ());
-<C>{eol}        => (YYBEGIN A
-                    ; Source.newline (source, yypos) ; continue ());
-<C>.            => (continue ());
+<TEXT_FMT>{ws}+  => (continue ());
+<TEXT_FMT>{eol}  => (Source.newline (source, yypos); continue ());
+<TEXT_FMT>\\     => (YYBEGIN TEXT; continue ());
+<TEXT_FMT>.      => (error (source, yypos, yypos, "Illegal formatting character in text continuation")
+                     ; continue ());
 
-<S>\"           => (let
-                       val s = concat (rev (!charlist))
-                       val _ = charlist := nil
-                       fun make (t, v) =
-                          t (v, !stringStart, Source.getPos (source, yypos + 1))
-                    in YYBEGIN INITIAL
-                       ; make (Tokens.STRING, s)
-                    end);
-<S>\\a          => (addChar #"\a"; continue ());
-<S>\\b          => (addChar #"\b"; continue ());
-<S>\\f          => (addChar #"\f"; continue ());
-<S>\\n          => (addChar #"\n"; continue ());
-<S>\\r          => (addChar #"\r"; continue ());
-<S>\\t          => (addChar #"\t"; continue ());
-<S>\\v          => (addChar #"\v"; continue ());
-<S>\\\^[@-_]    => (addChar (Char.chr(Char.ord(String.sub(yytext, 2))
-                                      -Char.ord #"@"))
-                    ; continue ());
-<S>\\\^.        => (error (source, yypos, yypos + 2,
-                           "illegal control escape; must be one of @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_")
-                    ; continue ());
-<S>\\[0-9]{3}   => (let
-                       val x =
-                          Char.ord(String.sub(yytext, 1)) * 100
-                          + Char.ord(String.sub(yytext, 2)) * 10
-                          + Char.ord(String.sub(yytext, 3))
-                          - (Char.ord #"0") * 111
-                    in (if x > 255
-                           then stringError (source, yypos,
-                                             "illegal ascii escape")
-                        else addChar(Char.chr x);
-                           continue ())
-                    end);
-<S>\\u{hexDigit}{4} 
-                => (let
-                       val x = 
-                          StringCvt.scanString
-                          (Pervasive.Int.scan StringCvt.HEX)
-                          (String.substring (yytext, 2, 4))
-                       fun err () =
-                          stringError (source, yypos,
-                                       "illegal unicode escape")
-                    in (case x of
-                          SOME x => if x > 255
-                                       then err()
-                                    else addChar(Char.chr x)
-                        | _ => err())
-                        ; continue ()
-                    end);
-<S>\\\"         => (addString "\""; continue ());
-<S>\\\\         => (addString "\\"; continue ());
-<S>\\{nrws}     => (YYBEGIN F; continue ());
-<S>\\{eol}      => (Source.newline (source, yypos) ; YYBEGIN F ; continue ());   
-<S>\\           => (stringError (source, yypos, "illegal string escape")
-                    ; continue ());
-<S>{eol}        => (Source.newline (source, yypos)
-                    ; stringError (source, yypos, "unclosed string")
-                    ; continue ());
-<S>" "|[\033-\126]  
-                => (addString yytext; continue ());
-<S>.            => (stringError (source, yypos + 1, "illegal character in string")
-                    ; continue ());
 
-<F>{eol}        => (Source.newline (source, yypos) ; continue ());
-<F>{ws}         => (continue ());
-<F>\\           => (YYBEGIN S
-                    ; stringStart := Source.getPos (source, yypos)
-                    ; continue ());
-<F>.            => (stringError (source, yypos, "unclosed string")
-                    ; continue ());
+<INITIAL>"(*)" =>
+   (startComment (source, yypos, fn () =>
+                  YYBEGIN INITIAL)
+    ; YYBEGIN LINE_COMMENT
+    ; continue ());
+<INITIAL>"(*" =>
+   (startComment (source, yypos, fn () =>
+                  YYBEGIN INITIAL)
+    ; YYBEGIN BLOCK_COMMENT
+    ; continue ());
+
+<LINE_COMMENT>{eol} =>
+   (Source.newline (source, yypos)
+    ; finishComment ()
+    ; continue ());
+<LINE_COMMENT>. =>
+   (continue ());
+
+<BLOCK_COMMENT>"(*)" =>
+   (startComment (source, yypos, fn () =>
+                  YYBEGIN BLOCK_COMMENT)
+    ; YYBEGIN LINE_COMMENT
+    ; continue ());
+<BLOCK_COMMENT>"(*" =>
+   (startComment (source, yypos, fn () =>
+                  YYBEGIN BLOCK_COMMENT)
+    ; YYBEGIN BLOCK_COMMENT
+    ; continue ());
+<BLOCK_COMMENT>"*)" =>
+   (finishComment ()
+    ; continue ());
+<BLOCK_COMMENT>{eol} =>
+   (Source.newline (source, yypos)
+    ; continue ());
+<BLOCK_COMMENT>. =>
+   (continue ());
+
+
+<INITIAL>"(*#line"{ws}+ =>
+   (startLineDir (source, yypos, fn () =>
+                  YYBEGIN INITIAL)
+    ; YYBEGIN LINE_DIR1
+    ; continue ());
+
+<LINE_DIR1>{decDigit}+"."{decDigit}+ =>
+   (let
+       fun err () =
+          (commentError (Source.getPos (source, yypos), "Illegal line directive")
+           ; YYBEGIN BLOCK_COMMENT)
+     in
+        case String.split (yytext, #".") of
+           [line, col] =>
+              (YYBEGIN LINE_DIR2
+               ; addLineDirLineCol (valOf (Int.fromString line), valOf (Int.fromString col))
+                 handle Overflow => err () | Option => err ()
+               ; continue ())
+         | _ => (err (); continue ())
+     end);
+<LINE_DIR2>{ws}+"\"" =>
+   (YYBEGIN LINE_DIR3
+    ; continue ());
+<LINE_DIR3>[^"]*"\"" =>
+   (addLineDirFile (String.dropLast yytext)
+    ; YYBEGIN LINE_DIR4
+    ; continue ());
+<LINE_DIR2,LINE_DIR4>{ws}*"*)" =>
+   (finishLineDir (source, yypos + size yytext)
+    ; continue ());
+<LINE_DIR1,LINE_DIR2,LINE_DIR3,LINE_DIR4>. =>
+   (commentError (Source.getPos (source, yypos), "Illegal line directive")
+    ; YYBEGIN BLOCK_COMMENT
+    ; continue ());
+
+
+<INITIAL>. =>
+   (error (source, yypos, yypos + 1, "Illegal character")
+    ; continue ());

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010-2011,2013-2015 Matthew Fluet.
+(* Copyright (C) 2010-2011,2013-2016 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -209,17 +209,17 @@ fun makeOptions {usage} =
          case e of
             Control.Elaborate.Bad =>
                usage (concat ["invalid -", flag, " flag: ", s])
-          | Control.Elaborate.Deprecated ids =>
-               if !Control.warnDeprecated
+          | Control.Elaborate.Good _ => ()
+          | Control.Elaborate.Other =>
+               usage (concat ["invalid -", flag, " flag: ", s])
+          | Control.Elaborate.Proxy (ids, {deprecated}) =>
+               if deprecated andalso !Control.warnDeprecated
                   then
                      Out.output
                      (Out.error,
                       concat ["Warning: ", "deprecated annotation: ", s, ", use ",
                               List.toString Control.Elaborate.Id.name ids, ".\n"])
                else ()
-          | Control.Elaborate.Good () => ()
-          | Control.Elaborate.Other =>
-               usage (concat ["invalid -", flag, " flag: ", s])
       open Control Popt
       datatype z = datatype MLton.Platform.Arch.t
       datatype z = datatype MLton.Platform.OS.t


### PR DESCRIPTION
 * Add an `allowSuccessorML {false|true}` MLB annotation to enable all Successor ML features with a single annotation.  Closes MLton/mlton#143.
 * Fix parsing of numeric labels to only accept an INT token that does not begin with 0, is not an extended literal, is not negative, and is decimal.
 * Drop the alternate word prefixes (`0xw` and `0bw`).
 * Unconditionally allow line comments in MLB files.
 * Allow UTF-8 byte sequences in text constants.  Closes MLton/mlton#117.
 * Refactor ml.lex and mlb.lex to be more maintainable.
 * Rename `allowRecPunning` annotation to `allowRecordPunExps`.
 * Update documentation.
