### PR TITLE
Correct off-by-one error in column numbers

### DIFF
--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -446,7 +446,7 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 <TEXT>"\\\""     => (addTextString "\""; continue ());
 <TEXT>\\\\       => (addTextString "\\"; continue ());
 <TEXT>\\{ws}+    => (YYBEGIN TEXT_FMT; continue ());
-<TEXT>\\{eol}    => (Source.newline (source, newLinePos (yypos + 1) yytext); YYBEGIN TEXT_FMT; continue ());
+<TEXT>\\{eol}    => (Source.newline (source, newLinePos yypos yytext); YYBEGIN TEXT_FMT; continue ());
 <TEXT>\\         => (error (source, yypos, yypos, "Illegal escape in text constant")
                      ; continue ());
 <TEXT>{eol}      => (Source.newline (source, newLinePos yypos yytext)

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -48,6 +48,10 @@ fun error (source, left, right, msg) =
                      msg)
 
 
+(* Windows line endings are two characters.  We want to record the position of
+ * the last end-of-line character, for accurate column number reporting.  *)
+fun newLinePos yypos yytext = yypos + size yytext - 1
+
 (* Comments *)
 local
    val commentLeft = ref SourcePos.bogus
@@ -280,7 +284,7 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 
 %%
 <INITIAL>{ws}+  => (continue ());
-<INITIAL>{eol}  => (Source.newline (source, yypos); continue ());
+<INITIAL>{eol}  => (Source.newline (source, newLinePos yypos yytext); continue ());
 
 
 <INITIAL>"_address" => (tok (Tokens.ADDRESS, source, yypos, yypos + size yytext));
@@ -442,17 +446,17 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
 <TEXT>"\\\""     => (addTextString "\""; continue ());
 <TEXT>\\\\       => (addTextString "\\"; continue ());
 <TEXT>\\{ws}+    => (YYBEGIN TEXT_FMT; continue ());
-<TEXT>\\{eol}    => (Source.newline (source, yypos + 1); YYBEGIN TEXT_FMT; continue ());
+<TEXT>\\{eol}    => (Source.newline (source, newLinePos (yypos + 1) yytext); YYBEGIN TEXT_FMT; continue ());
 <TEXT>\\         => (error (source, yypos, yypos, "Illegal escape in text constant")
                      ; continue ());
-<TEXT>{eol}      => (Source.newline (source, yypos)
+<TEXT>{eol}      => (Source.newline (source, newLinePos yypos yytext)
                      ; textError (Source.getPos (source, yypos), "Unclosed text constant at end of line")
                      ; continue ());
 <TEXT>.          => (error (source, yypos, yypos, "Illegal character in text constant")
                      ; continue ());
 
 <TEXT_FMT>{ws}+  => (continue ());
-<TEXT_FMT>{eol}  => (Source.newline (source, yypos); continue ());
+<TEXT_FMT>{eol}  => (Source.newline (source, newLinePos yypos yytext); continue ());
 <TEXT_FMT>\\     => (YYBEGIN TEXT; continue ());
 <TEXT_FMT>.      => (error (source, yypos, yypos, "Illegal formatting character in text continuation")
                      ; continue ());
@@ -474,7 +478,7 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
     ; continue ());
 
 <LINE_COMMENT>{eol} =>
-   (Source.newline (source, yypos)
+   (Source.newline (source, newLinePos yypos yytext)
     ; finishComment ()
     ; continue ());
 <LINE_COMMENT>. =>
@@ -498,7 +502,7 @@ real=(~?)(({decnum}{frac}?{exp})|({decnum}{frac}{exp}?));
    (finishComment ()
     ; continue ());
 <BLOCK_COMMENT>{eol} =>
-   (Source.newline (source, yypos)
+   (Source.newline (source, newLinePos yypos yytext)
     ; continue ());
 <BLOCK_COMMENT>. =>
    (continue ());


### PR DESCRIPTION
When files were encoded with Windows-style `\r\n` line endings, we were
incorrectly including the `\n` when computing the column number.

Closes #170.

### Test Strategy

I'm not sure if there are automated tests; if there are, I'd be glad to add a
test for this change.

Regardless, it builds and fixes the issue locally for me (according to the
"Steps to Reproduce" in #170).