### PR TITLE
Updates to SSA, SSA2, and RSSA IR support infrastructure

### DIFF
--- a/lib/mlton/basic/directed-graph.sig
+++ b/lib/mlton/basic/directed-graph.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -124,6 +124,8 @@ signature DIRECTED_GRAPH =
          'a t * ('a Node.t vector vector)
          -> 'a u t * {destroy: unit -> unit,
                       newNode: 'a Node.t -> 'a u Node.t}
+      (* Removes node and incident edges. *)
+      val removeNode: 'a t * 'a Node.t -> unit
       val removeDuplicateEdges: 'a t -> unit
       (* Strongly-connected components.
        * Each component is given as a list of nodes.

--- a/lib/mlton/basic/directed-graph.sig
+++ b/lib/mlton/basic/directed-graph.sig
@@ -108,6 +108,11 @@ signature DIRECTED_GRAPH =
             val dest: 'a t -> {loops: {headers: 'a Node.t vector,
                                        child: 'a t} vector,
                                notInLoop: 'a Node.t vector}
+            val layoutDot:
+               'a t * {nodeName: 'a Node.t -> string,
+                       options: Dot.GraphOption.t list,
+                       title: string}
+               -> Layout.t
          end
       val loopForestSteensgaard: 'a t * {root: 'a Node.t} -> 'a LoopForest.t
       val new: unit -> 'a t

--- a/lib/mlton/basic/directed-graph.sml
+++ b/lib/mlton/basic/directed-graph.sml
@@ -559,37 +559,68 @@ structure LoopForest =
                       title: string}) =
          let
             open Dot
-            fun label ns =
-               NodeOption.label
-               (Layout.toString (Vector.layout (Layout.str o nodeName) ns))
+            fun label (ns, max) =
+               let
+                  val pred =
+                     case max of
+                        NONE => (fn _ => true)
+                      | SOME max => (fn (i, _) => i < max)
+                  fun loop ns =
+                     let
+                        val {no = ms, yes = ns} = Vector.partitioni (ns, pred)
+                        val ns = String.concatWith (Vector.toListMap (ns, nodeName), ", ")
+                     in
+                        if Vector.isEmpty ms
+                           then [(ns, Center)]
+                           else (ns, Center)::(loop ms)
+                     end
+               in
+                  NodeOption.Label (loop ns)
+               end
             val c = Counter.new 0
             fun newName () = concat ["n", Int.toString (Counter.next c)]
             val nodes = ref []
-            fun loop (T {loops, notInLoop}) =
+            fun loop (T {loops, notInLoop}, root) =
                let
-                  val n = newName ()
-                  val _ = List.push (nodes, {name = n,
-                                             options = [label notInLoop,
-                                                        NodeOption.Shape Box],
-                                             successors = []})
-               in
-                  Vector.fold
-                  (loops, [n], fn ({headers, child}, ac) =>
-                   let
-                      val n = newName ()
-                      val _ =
-                         List.push
-                         (nodes, {name = n,
-                                  options = [label headers,
-                                             NodeOption.Shape Ellipse],
-                                  successors =
-                                  List.revMap (loop child, fn n =>
+                  val ms =
+                     Vector.fold
+                     (loops, [], fn ({headers, child}, ac) =>
+                      let
+                         val n = newName ()
+                         val _ =
+                            List.push
+                            (nodes, {name = n,
+                                     options = [label (headers, SOME 5),
+                                                NodeOption.Shape Ellipse],
+                                     successors =
+                                     List.map (loop (child, false), fn n =>
                                                {name = n, options = []})})
-                   in
-                      n :: ac
-                   end)
+                      in
+                         n :: ac
+                      end)
+                  val n = newName ()
+                  val (max, successors) =
+                     if root
+                        then (SOME 10,
+                              case ms of
+                                 [] => []
+                               | m :: _ => [{name = m,
+                                             options = [EdgeOption.Style Invisible]}])
+                        else (SOME 5, [])
+                  val _ = List.push (nodes, {name = n,
+                                             options = [label (notInLoop, max),
+                                                        NodeOption.Shape Box],
+                                             successors = successors})
+               in
+                  n :: (List.rev ms)
                end
-            val _ = loop forest
+            val ns = loop (forest, true)
+            val options =
+               case ns of
+                  [] => options
+                | _ :: ns =>
+                     (GraphOption.Rank (Same, List.map (ns, fn n => {nodeName = n})))
+                     :: options
          in
             Dot.layout {nodes = !nodes,
                         options = options,

--- a/lib/mlton/basic/directed-graph.sml
+++ b/lib/mlton/basic/directed-graph.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -110,6 +111,20 @@ fun newNode (T {nodes, ...}) =
    let val n = Node.new ()
    in List.push (nodes, n)
       ; n
+   end
+
+fun removeNode (T {nodes, ...}, n) =
+   let
+      fun nodePred n' = Node.equals (n, n')
+      fun edgePred (Edge.Edge {to = n', ...}) = nodePred n'
+      val _ =
+         nodes := List.removeAll (!nodes, nodePred)
+      val _ =
+         List.foreach
+         (!nodes, fn Node.Node {successors, ...} =>
+          successors := List.removeAll (!successors, edgePred))
+   in
+      ()
    end
 
 fun addEdge (_, e as {from = Node.Node {successors, ...}, ...}) =

--- a/lib/mlton/basic/dot.sml
+++ b/lib/mlton/basic/dot.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -172,7 +173,7 @@ val styleToString =
     | Dashed => "dashed"
     | Dotted => "dotted"
     | Filled => "filled"
-    | Invisible => "invisible"
+    | Invisible => "invis"
     | Solid => "solid"
 
 fun labelToString (l: (string * justify) list): string =

--- a/lib/mlton/basic/error.sig
+++ b/lib/mlton/basic/error.sig
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -8,7 +9,9 @@
 signature ERROR =
     sig
        val bug: string -> 'a
-       val reraise: exn * string -> 'a
+       val reraise: exn * {prefix: string, suffix: string} -> 'a
+       val reraisePrefix: exn * string -> 'a
+       val reraiseSuffix: exn * string -> 'a
        val unimplemented: string -> 'a
        val warning: string -> unit
    end

--- a/lib/mlton/basic/error.sml
+++ b/lib/mlton/basic/error.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -10,11 +11,15 @@ struct
 
 fun bug msg = raise (Fail msg)
 
-fun reraise (exn, msg) =
-   bug (concat [msg, "::",
+fun reraise (exn, {prefix, suffix}) =
+   bug (concat [prefix,
                 case exn of
                    Fail msg => msg
-                 | _ => "?"])
+                 | _ => General.exnName exn,
+                suffix])
+
+fun reraisePrefix (exn, msg) = reraise (exn, {prefix = msg, suffix = ""})
+fun reraiseSuffix (exn, msg) = reraise (exn, {prefix = "", suffix = msg})
 
 fun unimplemented msg = raise Fail (concat ["unimplemented: ", msg])
 

--- a/lib/mlton/basic/exn.sml
+++ b/lib/mlton/basic/exn.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -11,16 +12,7 @@ struct
 open Exn0
 
 fun layout e =
-   let
-      open Layout
-   in
-      case e of
-         OS.SysErr (s, _) => str s
-       | Fail s => str s
-       | IO.Io {cause, function, name, ...} =>
-            seq [str (concat [function, " ", name, ": "]), layout cause]
-       | _ => seq [str "unhandled exception: ", str (exnName e)]
-   end
+   Layout.str (message e)
 
 val toString = Layout.toString o layout
 

--- a/lib/mlton/basic/exn0.sml
+++ b/lib/mlton/basic/exn0.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 2005-2006 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 2005-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -13,6 +14,8 @@ type t = exn
 val history = MLton.Exn.history
 
 val name = General.exnName
+
+val message = General.exnMessage
 
 exception Bind = Bind
 exception Match = Match

--- a/lib/mlton/basic/layout.sig
+++ b/lib/mlton/basic/layout.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2014 Matthew Fluet.
+(* Copyright (C) 2009,2014,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -48,6 +48,7 @@ signature LAYOUT =
       val separateLeft: t list * string -> t list
       (* adds string at the end of all objects except last *) 
       val separateRight: t list * string -> t list
+      val setDefaultWidth: int -> unit
       (* layout the objects on the same line *)
       val seq: t list -> t
       (* convert a string to a layout object *)

--- a/lib/mlton/basic/layout.sml
+++ b/lib/mlton/basic/layout.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2014 Matthew Fluet.
+(* Copyright (C) 2009,2014,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -186,11 +186,12 @@ fun outputWidth (t, width, out) =
           print = Out.outputc out}
 
 local
-   val defaultWidth: int = 80
+   val defaultWidth: int ref = ref 80
 in
-   fun output (t, out) = outputWidth (t, defaultWidth, out)
+   fun setDefaultWidth w = defaultWidth := w
+   fun output (t, out) = outputWidth (t, !defaultWidth, out)
    val print =
-      fn (t, p) => print {tree = t, lineWidth = defaultWidth, print = p}
+      fn (t, p) => print {tree = t, lineWidth = !defaultWidth, print = p}
 end
 
 fun outputl (t, out) = (output (t, out); Out.newline out)

--- a/lib/mlton/basic/process.sml
+++ b/lib/mlton/basic/process.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.
@@ -237,13 +238,14 @@ fun makeCommandLine (commandLine: string list -> unit) args =
     handle e =>
        let
           val out = Out.error
-          open Layout
        in
-          output (Exn.layout e, out)
-          ; List.foreach (Exn.history e, fn s =>
-                          (Out.output (out, "\n\t")
-                           ; Out.output (out, s)))
-          ; Out.newline out
+          Out.output (out, concat ["unhandled exception: ", Exn.toString e, "\n"])
+          ; (case Exn.history e of
+                [] => ()
+              | l => (Out.output (out, "with history: \n")
+                      ; List.foreach
+                        (l, fn s =>
+                         Out.output (out, concat ["\t", s, "\n"]))))
           ; OS.Process.failure
        end)
 

--- a/mlton/backend/live.fun
+++ b/mlton/backend/live.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -254,7 +255,7 @@ fun live (function, {shouldConsider: Var.t -> bool}) =
       val processVar =
          Trace.trace ("Live.processVar", Var.layout, Unit.layout) processVar
       val _ = List.foreach (!allVars, processVar)
-      val _ = Function.foreachVar (function, fn (x, _) => removeVarInfo x)
+      val _ = Function.foreachDef (function, fn (x, _) => removeVarInfo x)
       (* handler code and link slots are harder; in particular, they don't
        * satisfy the SSA invariant -- there are multiple definitions;
        * furthermore, a def and use in a block does not mean that the def 

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -258,28 +258,28 @@ structure Statement =
             open Layout
          in
             fn Bind {dst = (x, t), src, ...} =>
-                  seq [Var.layout x, constrain t, str " = ", Operand.layout src]
+                  mayAlign
+                  [seq [Var.layout x, constrain t],
+                   indent (seq [str "= ", Operand.layout src], 2)]
              | Move {dst, src} =>
-                  mayAlign [Operand.layout dst,
-                            seq [str "= ", Operand.layout src]]
+                  mayAlign
+                  [Operand.layout dst,
+                   indent (seq [str ":= ", Operand.layout src], 2)]
              | Object {dst = (dst, ty), header, size} =>
                   mayAlign
                   [seq [Var.layout dst, constrain ty],
-                   seq [str "= Object ",
-                        record [("header", seq [str "0x", Word.layout header]),
-                                ("size", Bytes.layout size)]]]
+                   indent (seq [str "= Object ",
+                                record [("header", seq [str "0x", Word.layout header]),
+                                        ("size", Bytes.layout size)]],
+                           2)]
              | PrimApp {dst, prim, args, ...} =>
-                  let
-                     val rest =
-                        seq [Prim.layout prim, str " ",
-                             Vector.layout Operand.layout args]
-                  in
-                     case dst of
-                        NONE => rest
-                      | SOME (x, t) =>
-                           mayAlign [seq [Var.layout x, constrain t],
-                                     seq [str "= ", rest]]
-                  end
+                  mayAlign
+                  [case dst of
+                      NONE => seq [str "_", constrain (Type.unit)]
+                    | SOME (x, t) => seq [Var.layout x, constrain t],
+                   indent (seq [str "= ", Prim.layout prim, str " ",
+                                Vector.layout Operand.layout args],
+                           2)]
              | Profile e => ProfileExp.layout e
              | ProfileLabel p =>
                   seq [str "ProfileLabel ", ProfileLabel.layout p]

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -617,6 +617,15 @@ structure Block =
                             Transfer.layout transfer],
                            2)]
          end
+
+      fun foreachDef (T {args, statements, transfer, ...}, f) =
+         (Vector.foreach (args, f)
+          ; Vector.foreach (statements, fn s => Statement.foreachDef (s, f))
+          ; Transfer.foreachDef (transfer, f))
+
+      fun foreachUse (T {statements, transfer, ...}, f) =
+         (Vector.foreach (statements, fn s => Statement.foreachUse (s, f))
+          ; Transfer.foreachUse (transfer, f))
    end
 
 structure Function =
@@ -674,13 +683,12 @@ structure Function =
                    indent (align (Vector.toListMap (blocks, Block.layout)), 2)]
          end
 
-      fun foreachVar (T {args, blocks, ...}, f) =
+      fun foreachDef (T {args, blocks, ...}, f) =
          (Vector.foreach (args, f)
-          ; (Vector.foreach
-             (blocks, fn Block.T {args, statements, transfer, ...} =>
-              (Vector.foreach (args, f)
-               ; Vector.foreach (statements, fn s => Statement.foreachDef (s, f))
-               ; Transfer.foreachDef (transfer, f)))))
+          ; (Vector.foreach (blocks, fn b => Block.foreachDef (b, f))))
+
+      fun foreachUse (T {blocks, ...}, f) =
+         Vector.foreach (blocks, fn b => Block.foreachUse (b, f))
 
       fun dfs (T {blocks, start, ...}, v) =
          let

--- a/mlton/backend/rssa.sig
+++ b/mlton/backend/rssa.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -203,7 +203,8 @@ signature RSSA =
              * then applying v' ().
              *)
             val dfs: t * (Block.t -> unit -> unit) -> unit
-            val foreachVar: t * (Var.t * Type.t -> unit) -> unit
+            val foreachDef: t * (Var.t * Type.t -> unit) -> unit
+            val foreachUse: t * (Var.t -> unit) -> unit
             val name: t -> Func.t
             val new: {args: (Var.t * Type.t) vector,
                       blocks: Block.t vector,

--- a/mlton/control/control.sml
+++ b/mlton/control/control.sml
@@ -120,9 +120,11 @@ fun trace (verb, name: string) (f: 'a -> 'b) (a: 'a): 'b =
                       [] => ()
                     | history =>
                          (messageStr (verb, concat [name, " raised with history: "])
+                          ; indent ()
                           ; (List.foreach
                              (history, fn s =>
-                              messageStr (verb, concat ["\t", s])))))
+                              messageStr (verb, s)))
+                          ; unindent ()))
                 ; raise e)
          end
    else
@@ -170,9 +172,11 @@ val ('a, 'b) traceAdd: (traceAccum * string) -> ('a -> 'b) -> 'a -> 'b =
                       [] => ()
                     | history =>
                          (messageStr (verb, concat [name, " raised with history: "])
+                          ; indent ()
                           ; (List.foreach
                              (history, fn s =>
-                              messageStr (verb, concat ["\t", s])))))
+                              messageStr (verb, s)))
+                          ; unindent ()))
                 ; raise e)
           end
      else f a

--- a/mlton/control/control.sml
+++ b/mlton/control/control.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -115,7 +115,7 @@ fun trace (verb, name: string) (f: 'a -> 'b) (a: 'a): 'b =
              before messageStr (verb, concat [name, " finished in ", done ()]))
             handle e =>
                (messageStr (verb, concat [name, " raised in ", done ()])
-                ; messageStr (verb, concat [name, " raised: ", Exn.name e])
+                ; messageStr (verb, concat [name, " raised: ", Exn.toString e])
                 ; (case Exn.history e of
                       [] => ()
                     | history =>

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010-2011,2013-2016 Matthew Fluet.
+(* Copyright (C) 2010-2011,2013-2017 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -520,6 +520,11 @@ fun makeOptions {usage} =
                                     in List.push (keepPasses, re)
                                     end
                    | NONE => usage (concat ["invalid -keep-pass flag: ", s])))),
+       (Expert, "layout-width", " <n>", "target width for pretty printer",
+        Int (fn n =>
+             if n > 0
+                then Layout.setDefaultWidth n
+                else usage (concat ["invalid -layout-width arg: ", Int.toString n]))),
        (Expert, "libname", " <basename>", "the name of the generated library",
         SpaceString (fn s => libname := s)),
        (Normal, "link-opt", " <opt>", "pass option to linker",

--- a/mlton/ssa/analyze.fun
+++ b/mlton/ssa/analyze.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2011 Matthew Fluet.
+(* Copyright (C) 2011,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -15,9 +15,7 @@ datatype z = datatype Exp.t
 datatype z = datatype Transfer.t
 
 fun 'a analyze
-   {coerce, conApp, const,
-    filter, filterWord,
-    fromType, layout, primApp,
+   {coerce, conApp, const, filter, filterWord, fromType, layout, primApp,
     program = Program.T {main, globals, functions, ...},
     select, tuple, useFromTypeOnBinds} =
    let
@@ -26,19 +24,19 @@ fun 'a analyze
          if Vector.length from = Vector.length to
             then Vector.foreach2 (from, to, fn (from, to) =>
                                   coerce {from = from, to = to})
-         else Error.bug (concat ["Analyze.coerces length mismatch: ", msg])
+         else Error.bug (concat ["Analyze.coerces (length mismatch: ", msg, ")"])
       val {get = value: Var.t -> 'a, set = setValue, ...} =
          Property.getSetOnce
          (Var.plist,
-          Property.initRaise ("analyze var value", Var.layout))
+          Property.initRaise ("Analyze.value", Var.layout))
       val value = Trace.trace ("Analyze.value", Var.layout, layout) value
       fun values xs = Vector.map (xs, value)
-      val {get = func, set = setFunc, ...} =
+      val {get = funcInfo, set = setFuncInfo, ...} =
          Property.getSetOnce
-         (Func.plist, Property.initRaise ("analyze func name", Func.layout))
+         (Func.plist, Property.initRaise ("Analyze.funcInfo", Func.layout))
       val {get = labelInfo, set = setLabelInfo, ...} =
          Property.getSetOnce
-         (Label.plist, Property.initRaise ("analyze label", Label.layout))
+         (Label.plist, Property.initRaise ("Analyze.labelInfo", Label.layout))
       val labelArgs = #args o labelInfo
       val labelValues = #values o labelInfo
       fun loopArgs args =
@@ -53,18 +51,18 @@ fun 'a analyze
           let
              val {args, name, raises, returns, ...} = Function.dest f
           in
-             setFunc (name, {args = loopArgs args,
-                             raises = Option.map (raises, fn ts =>
-                                                  Vector.map (ts, fromType)),
-                             returns = Option.map (returns, fn ts =>
-                                                   Vector.map (ts, fromType))})
+             setFuncInfo (name, {args = loopArgs args,
+                                 raises = Option.map (raises, fn ts =>
+                                                      Vector.map (ts, fromType)),
+                                 returns = Option.map (returns, fn ts =>
+                                                       Vector.map (ts, fromType))})
           end)
       fun loopTransfer (t: Transfer.t,
                         shouldReturns: 'a vector option,
                         shouldRaises: 'a vector option): unit =
         (case t of
             Arith {prim, args, overflow, success, ty} =>
-               (coerces ("arith", Vector.new0 (), labelValues overflow)
+               (coerces ("arith overflow", Vector.new0 (), labelValues overflow)
                 ; coerce {from = primApp {prim = prim,
                                           targs = Vector.new0 (),
                                           args = values args,
@@ -72,32 +70,32 @@ fun 'a analyze
                                           resultVar = NONE},
                           to = Vector.sub (labelValues success, 0)})
           | Bug => ()
-          | Call {func = f, args, return, ...} =>
+          | Call {func, args, return, ...} =>
                let
-                  val {args = formals, raises, returns} = func f
-                  val _ = coerces ("formals", values args, formals)
+                  val {args = formals, raises, returns} = funcInfo func
+                  val _ = coerces ("call args/formals", values args, formals)
                   fun noHandler () =
                      case (raises, shouldRaises) of
                         (NONE, NONE) => ()
                       | (NONE, SOME _) => ()
                       | (SOME _, NONE) => 
-                           Error.bug "Analyze.loopTransfer: raise mismatch"
-                      | (SOME vs, SOME vs') => coerces ("noHandler", vs, vs')
+                           Error.bug "Analyze.loopTransfer (raise mismatch)"
+                      | (SOME vs, SOME vs') => coerces ("call caller/raises", vs, vs')
                   datatype z = datatype Return.t
                in
                   case return of
                      Dead =>
                         if isSome returns orelse isSome raises
-                           then Error.bug "Analyze.loopTransfer: return mismatch at Dead"
+                           then Error.bug "Analyze.loopTransfer (return mismatch at Dead)"
                         else ()
                    | NonTail {cont, handler} => 
                         (Option.app (returns, fn vs =>
-                                     coerces ("returns", vs, labelValues cont))
+                                     coerces ("call non-tail/returns", vs, labelValues cont))
                          ; (case handler of
                                Handler.Caller => noHandler ()
                              | Handler.Dead =>
                                   if isSome raises
-                                     then Error.bug "Analyze.loopTransfer: raise mismatch at NonTail"
+                                     then Error.bug "Analyze.loopTransfer (raise mismatch at NonTail/Dead)"
                                   else ()
                              | Handler.Handle h =>
                                   let
@@ -105,8 +103,7 @@ fun 'a analyze
                                         case raises of
                                            NONE => ()
                                          | SOME vs =>
-                                              coerces ("handle", vs,
-                                                       labelValues h)
+                                              coerces ("call handle/raises", vs, labelValues h)
                                   in
                                      ()
                                   end))
@@ -118,9 +115,9 @@ fun 'a analyze
                                  (NONE, NONE) => ()
                                | (NONE, SOME _) => ()
                                | (SOME _, NONE) =>
-                                    Error.bug "Analyze.loopTransfer: return mismatch at Tail"
+                                    Error.bug "Analyze.loopTransfer (return mismatch at Tail)"
                                | (SOME vs, SOME vs') =>
-                                    coerces ("tail", vs, vs')
+                                    coerces ("call tail/returns", vs, vs')
                         in
                            ()
                         end
@@ -132,16 +129,17 @@ fun 'a analyze
                   fun ensureNullary j =
                      if 0 = Vector.length (labelValues j)
                         then ()
-                     else Error.bug (concat ["Analyze.loopTransfer: Case:",
+                     else Error.bug (concat ["Analyze.loopTransfer (case ",
                                              Label.toString j,
-                                             " must be nullary"])
+                                             " must be nullary)"])
                   fun ensureSize (w, s) =
                      if WordSize.equals (s, WordX.size w)
                         then ()
-                     else Error.bug (concat ["Analyze.loopTransfer: Case:",
+                     else Error.bug (concat ["Analyze.loopTransfer (case ",
                                              WordX.toString w,
                                              " must be size ",
-                                             WordSize.toString s])
+                                             WordSize.toString s,
+                                             ")"])
                   fun doitWord (s, cs) =
                      (ignore (filterWord (test, s))
                       ; Vector.foreach (cs, fn (w, j) =>
@@ -161,11 +159,11 @@ fun 'a analyze
           | Goto {dst, args} => coerces ("goto", values args, labelValues dst)
           | Raise xs =>
                (case shouldRaises of
-                   NONE => Error.bug "Analyze.loopTransfer: raise mismatch at Raise"
+                   NONE => Error.bug "Analyze.loopTransfer (raise mismatch at Raise)"
                  | SOME vs => coerces ("raise", values xs, vs))
           | Return xs =>
                (case shouldReturns of
-                   NONE => Error.bug "Analyze.loopTransfer: return mismatch at Return"
+                   NONE => Error.bug "Analyze.loopTransfer (return mismatch at Return)"
                  | SOME vs => coerces ("return", values xs, vs))
           | Runtime {prim, args, return} =>
                let
@@ -188,6 +186,7 @@ fun 'a analyze
                in 
                   ()
                end)
+        handle exn => Error.reraiseSuffix (exn, concat [" in ", Layout.toString (Transfer.layout t)])
       val loopTransfer =
          Trace.trace3
          ("Analyze.loopTransfer",
@@ -196,7 +195,7 @@ fun 'a analyze
           Option.layout (Vector.layout layout),
           Layout.ignore)
          loopTransfer
-      fun loopStatement (Statement.T {var, exp, ty}): unit =
+      fun loopStatement (s as Statement.T {var, exp, ty}): unit =
          let
             val v =
                case exp of
@@ -215,7 +214,7 @@ fun 'a analyze
                              resultType = ty}
                 | Tuple xs =>
                      if 1 = Vector.length xs
-                        then Error.bug "Analyze.loopStatement: unary tuple"
+                        then Error.bug "Analyze.loopStatement (unary tuple)"
                      else tuple (values xs)
                 | Var x => value x
          in
@@ -231,11 +230,13 @@ fun 'a analyze
                      end
              else setValue (var, v))
          end
+         handle exn => Error.reraiseSuffix (exn, concat [" in ", Layout.toString (Statement.layout s)])
       val loopStatement =
          Trace.trace ("Analyze.loopStatement", Statement.layout, Unit.layout)
          loopStatement
-      val _ = coerces ("main", Vector.new0 (), #args (func main))
+      val _ = coerces ("main", Vector.new0 (), #args (funcInfo main))
       val _ = Vector.foreach (globals, loopStatement)
+              handle exn => Error.reraiseSuffix (exn, concat [" in Globals"])
       val _ =
          List.foreach
          (functions, fn f =>
@@ -248,7 +249,7 @@ fun 'a analyze
                                        block = b,
                                        values = loopArgs args,
                                        visited = ref false}))
-             val {returns, raises, ...} = func name
+             val {returns, raises, ...} = funcInfo name
              fun visit (l: Label.t) =
                 let
                    val {block, visited, ...} = labelInfo l
@@ -259,18 +260,21 @@ fun 'a analyze
                       let
                          val _ = visited := true
                          val Block.T {statements, transfer, ...} = block
+                         val _ = (Vector.foreach (statements, loopStatement)
+                                  ; loopTransfer (transfer, returns, raises))
+                                 handle exn => Error.reraiseSuffix (exn, concat [" in ", Label.toString l])
                       in
-                         Vector.foreach (statements, loopStatement)
-                         ; loopTransfer (transfer, returns, raises)
-                         ; Transfer.foreachLabel (transfer, visit)
+                         Transfer.foreachLabel (transfer, visit)
                       end
                 end
+
              val _ = visit start
           in
              ()
-          end)
+          end
+          handle exn => Error.reraiseSuffix (exn, concat [" in ", Func.toString (Function.name f)]))
    in
-      {func = func,
+      {func = funcInfo,
        label = labelValues,
        value = value}
    end

--- a/mlton/ssa/analyze2.fun
+++ b/mlton/ssa/analyze2.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2011 Matthew Fluet.
+(* Copyright (C) 2011,2017 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -24,19 +24,19 @@ fun 'a analyze
          if Vector.length from = Vector.length to
             then Vector.foreach2 (from, to, fn (from, to) =>
                                   coerce {from = from, to = to})
-         else Error.bug (concat ["Analyze2.coerces: length mismatch: ", msg])
+         else Error.bug (concat ["Analyze2.coerces (length mismatch: ", msg, ")"])
       val {get = value: Var.t -> 'a, set = setValue, ...} =
          Property.getSetOnce
          (Var.plist,
-          Property.initRaise ("analyze var value", Var.layout))
+          Property.initRaise ("Analyze2.value", Var.layout))
       val value = Trace.trace ("Analyze2.value", Var.layout, layout) value
       fun values xs = Vector.map (xs, value)
-      val {get = func, set = setFunc, ...} =
+      val {get = funcInfo, set = setFuncInfo, ...} =
          Property.getSetOnce
-         (Func.plist, Property.initRaise ("analyze func name", Func.layout))
+         (Func.plist, Property.initRaise ("Analyze2.funcInfo", Func.layout))
       val {get = labelInfo, set = setLabelInfo, ...} =
          Property.getSetOnce
-         (Label.plist, Property.initRaise ("analyze label", Label.layout))
+         (Label.plist, Property.initRaise ("Analyze2.labelInfo", Label.layout))
       val labelArgs = #args o labelInfo
       val labelValues = #values o labelInfo
       fun loopArgs args =
@@ -51,50 +51,50 @@ fun 'a analyze
           let
              val {args, name, raises, returns, ...} = Function.dest f
           in
-             setFunc (name, {args = loopArgs args,
-                             raises = Option.map (raises, fn ts =>
-                                                  Vector.map (ts, fromType)),
-                             returns = Option.map (returns, fn ts =>
-                                                   Vector.map (ts, fromType))})
+             setFuncInfo (name, {args = loopArgs args,
+                                 raises = Option.map (raises, fn ts =>
+                                                      Vector.map (ts, fromType)),
+                                 returns = Option.map (returns, fn ts =>
+                                                       Vector.map (ts, fromType))})
           end)
       fun loopTransfer (t: Transfer.t,
                         shouldReturns: 'a vector option,
                         shouldRaises: 'a vector option): unit =
         (case t of
             Arith {prim, args, overflow, success, ty} =>
-               (coerces ("arith", Vector.new0 (), labelValues overflow)
+               (coerces ("arith overflow", Vector.new0 (), labelValues overflow)
                 ; coerce {from = primApp {prim = prim,
                                           args = values args,
                                           resultType = ty,
                                           resultVar = NONE},
                           to = Vector.sub (labelValues success, 0)})
           | Bug => ()
-          | Call {func = f, args, return, ...} =>
+          | Call {func, args, return, ...} =>
                let
-                  val {args = formals, raises, returns} = func f
-                  val _ = coerces ("formals", values args, formals)
+                  val {args = formals, raises, returns} = funcInfo func
+                  val _ = coerces ("call args/formals", values args, formals)
                   fun noHandler () =
                      case (raises, shouldRaises) of
                         (NONE, NONE) => ()
                       | (NONE, SOME _) => ()
                       | (SOME _, NONE) => 
-                           Error.bug "Analyze2.loopTransfer: raise mismatch"
-                      | (SOME vs, SOME vs') => coerces ("noHandler", vs, vs')
+                           Error.bug "Analyze2.loopTransfer (raise mismatch)"
+                      | (SOME vs, SOME vs') => coerces ("call caller/raises", vs, vs')
                   datatype z = datatype Return.t
                in
                   case return of
                      Dead =>
                         if isSome returns orelse isSome raises
-                           then Error.bug "Analyze2.loopTransfer: return mismatch at Dead"
+                           then Error.bug "Analyze2.loopTransfer (return mismatch at Dead)"
                         else ()
                    | NonTail {cont, handler} => 
                         (Option.app (returns, fn vs =>
-                                     coerces ("returns", vs, labelValues cont))
+                                     coerces ("call non-tail/returns", vs, labelValues cont))
                          ; (case handler of
                                Handler.Caller => noHandler ()
                              | Handler.Dead =>
                                   if isSome raises
-                                     then Error.bug "Analyze2.loopTransfer: raise mismatch at NonTail"
+                                     then Error.bug "Analyze2.loopTransfer (raise mismatch at NonTail/Dead)"
                                   else ()
                              | Handler.Handle h =>
                                   let
@@ -102,8 +102,7 @@ fun 'a analyze
                                         case raises of
                                            NONE => ()
                                          | SOME vs =>
-                                              coerces ("handle", vs,
-                                                       labelValues h)
+                                              coerces ("call handle/raises", vs, labelValues h)
                                   in
                                      ()
                                   end))
@@ -115,9 +114,9 @@ fun 'a analyze
                                  (NONE, NONE) => ()
                                | (NONE, SOME _) => ()
                                | (SOME _, NONE) =>
-                                    Error.bug "Analyze2.loopTransfer: return mismatch at Tail"
+                                    Error.bug "Analyze2.loopTransfer (return mismatch at Tail)"
                                | (SOME vs, SOME vs') =>
-                                    coerces ("tail", vs, vs')
+                                    coerces ("call tail/return", vs, vs')
                         in
                            ()
                         end
@@ -129,16 +128,17 @@ fun 'a analyze
                   fun ensureSize (w, s) =
                      if WordSize.equals (s, WordX.size w)
                         then ()
-                     else Error.bug (concat ["Analyze.loopTransfer: Case:",
+                     else Error.bug (concat ["Analyze.loopTransfer (case ",
                                              WordX.toString w,
                                              " must be size ",
-                                             WordSize.toString s])
+                                             WordSize.toString s,
+                                             ")"])
                   fun ensureNullary j =
                      if 0 = Vector.length (labelValues j)
                         then ()
-                     else Error.bug (concat ["Analyze2.loopTransfer: Case:",
+                     else Error.bug (concat ["Analyze2.loopTransfer (case:",
                                              Label.toString j,
-                                             " must be nullary"])
+                                             " must be nullary)"])
                   fun doitWord (s, cs) =
                      (ignore (filterWord (test, s))
                       ; Vector.foreach (cs, fn (w, j) =>
@@ -153,7 +153,7 @@ fun 'a analyze
                             case Vector.length v of
                                0 => NONE
                              | 1 => SOME (Vector.sub (v, 0))
-                             | _ => Error.bug "Analyze2.loopTransfer: Case:conApp with >1 arg"
+                             | _ => Error.bug "Analyze2.loopTransfer (case conApp with >1 arg)"
                       in
                          filter {con = c,
                                  test = test,
@@ -170,11 +170,11 @@ fun 'a analyze
           | Goto {dst, args} => coerces ("goto", values args, labelValues dst)
           | Raise xs =>
                (case shouldRaises of
-                   NONE => Error.bug "Analyze2.loopTransfer: raise mismatch at Raise"
+                   NONE => Error.bug "Analyze2.loopTransfer (raise mismatch at Raise)"
                  | SOME vs => coerces ("raise", values xs, vs))
           | Return xs =>
                (case shouldReturns of
-                   NONE => Error.bug "Analyze2.loopTransfer: return mismatch at Return"
+                   NONE => Error.bug "Analyze2.loopTransfer (return mismatch at Return)"
                  | SOME vs => coerces ("return", values xs, vs))
           | Runtime {prim, args, return} =>
                let
@@ -196,6 +196,7 @@ fun 'a analyze
                in 
                   ()
                end)
+        handle exn => Error.reraiseSuffix (exn, concat [" in ", Layout.toString (Transfer.layout t)])
       val loopTransfer =
          Trace.trace3
          ("Analyze2.loopTransfer",
@@ -222,7 +223,7 @@ fun 'a analyze
                              fn (x, {isMutable, ...}) =>
                              {elt = value x,
                               isMutable = isMutable}))
-                      | _ => Error.bug "Analyze2.loopBind: strange object"
+                      | _ => Error.bug "Analyze2.loopBind (strange object)"
                in
                   object {args = args,
                           con = con,
@@ -261,13 +262,15 @@ fun 'a analyze
              update {base = baseValue base,
                      offset = offset,
                      value = value v})
+         handle exn => Error.reraiseSuffix (exn, concat [" in ", Layout.toString (Statement.layout s)])
       val loopStatement =
          Trace.trace ("Analyze2.loopStatement",
                       Statement.layout,
                       Unit.layout)
          loopStatement
-      val _ = coerces ("main", Vector.new0 (), #args (func main))
+      val _ = coerces ("main", Vector.new0 (), #args (funcInfo main))
       val _ = Vector.foreach (globals, loopStatement)
+              handle exn => Error.reraiseSuffix (exn, concat [" in Globals"])
       val _ =
          List.foreach
          (functions, fn f =>
@@ -280,7 +283,7 @@ fun 'a analyze
                                        block = b,
                                        values = loopArgs args,
                                        visited = ref false}))
-             val {returns, raises, ...} = func name
+             val {returns, raises, ...} = funcInfo name
              fun visit (l: Label.t) =
                 let
                    val {block, visited, ...} = labelInfo l
@@ -291,18 +294,20 @@ fun 'a analyze
                       let
                          val _ = visited := true
                          val Block.T {statements, transfer, ...} = block
+                         val _ = (Vector.foreach (statements, loopStatement)
+                                  ; loopTransfer (transfer, returns, raises))
+                                 handle exn => Error.reraiseSuffix (exn, concat [" in ", Label.toString l])
                       in
-                         Vector.foreach (statements, loopStatement)
-                         ; loopTransfer (transfer, returns, raises)
-                         ; Transfer.foreachLabel (transfer, visit)
+                         Transfer.foreachLabel (transfer, visit)
                       end
                 end
              val _ = visit start
           in
              ()
-          end)
+          end
+          handle exn => Error.reraiseSuffix (exn, concat [" in ", Func.toString (Function.name f)]))
    in
-      {func = func,
+      {func = funcInfo,
        label = labelValues,
        value = value}
    end

--- a/mlton/ssa/prepasses.fun
+++ b/mlton/ssa/prepasses.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -22,8 +22,8 @@ open Exp Transfer
  * Section 19.3 of Appel's "Modern Compiler Implementation in ML".) 
  * However, passes that require critical edges to be broken in order
  * to accomodate code motion (for example, PRE), should also break an
- * edge that connects a block with non-functional control transfer to
- * one with two or more predecessors.
+ * edge that connects a block with non-goto transfer to one with two
+ * or more predecessors.
  *)
 structure CriticalEdges =
 struct
@@ -73,10 +73,11 @@ fun breakFunction (f, {codeMotion: bool}) =
           let
              val mustBreak =
                 case transfer of
-                   Arith _ => true
-                 | Call _ => true
-                 | Runtime _ => true
-                 | _ => false
+                   Bug => false (* no successors *)
+                 | Goto _ => false
+                 | Raise _ => false (* no successors *)
+                 | Return _ => false (* no successors *)
+                 | _ => true
           in
              setLabelInfo (label, LabelInfo.new (args, mustBreak))
           end)

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2011 Matthew Fluet.
+(* Copyright (C) 2009,2011,2017 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -519,7 +519,7 @@ fun shrinkFunction {globals: Statement.t vector} =
          fun save (f, s) =
             let
                val {destroy, graph, ...} = 
-                  Function.layoutDot (f, fn _ => NONE)
+                  Function.layoutDot (f, Var.layout)
             in
                File.withOut
                (concat ["/tmp/", Func.toString (Function.name f),

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -518,13 +518,13 @@ fun shrinkFunction {globals: Statement.t vector} =
             Block.args (Vector.sub (blocks, LabelMeaning.blockIndex m))
          fun save (f, s) =
             let
-               val {destroy, graph, ...} = 
+               val {destroy, controlFlowGraph, ...} =
                   Function.layoutDot (f, Var.layout)
             in
                File.withOut
                (concat ["/tmp/", Func.toString (Function.name f),
                         ".", s, ".dot"],
-                fn out => Layout.outputl (graph, out))
+                fn out => Layout.outputl (controlFlowGraph, out))
                ; destroy ()
             end
          val _ = if true then () else save (f, "pre")

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -523,13 +523,13 @@ fun shrinkFunction {globals: Statement.t vector} =
             Block.args (Vector.sub (blocks, LabelMeaning.blockIndex m))
          fun save (f, s) =
             let
-               val {destroy, graph, ...} =
+               val {destroy, controlFlowGraph, ...} =
                   Function.layoutDot (f, Var.layout)
             in
                File.withOut
                (concat ["/tmp/", Func.toString (Function.name f),
                         ".", s, ".dot"],
-                fn out => Layout.outputl (graph, out))
+                fn out => Layout.outputl (controlFlowGraph, out))
                ; destroy ()
             end
          val () = if true then () else save (f, "pre")

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2011 Matthew Fluet.
+(* Copyright (C) 2009,2011,2017 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -524,7 +524,7 @@ fun shrinkFunction {globals: Statement.t vector} =
          fun save (f, s) =
             let
                val {destroy, graph, ...} =
-                  Function.layoutDot (f, fn _ => NONE)
+                  Function.layoutDot (f, Var.layout)
             in
                File.withOut
                (concat ["/tmp/", Func.toString (Function.name f),

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -1248,6 +1248,7 @@ structure Function =
                                open NodeOption
                             in FontColor Black :: Shape Box :: l
                             end})
+               val () = Graph.removeNode (graph, funNode)
                fun dominatorTreeLayout () =
                   let
                      val {get = nodeOptions, set = setNodeOptions, ...} =
@@ -1268,7 +1269,6 @@ structure Function =
                   in
                      dominatorTreeLayout
                   end
-               (*
                fun loopForestLayout () =
                   let
                      val {get = nodeName, set = setNodeName, ...} =
@@ -1280,18 +1280,18 @@ structure Function =
                      val loopForestLayout =
                         Graph.LoopForest.layoutDot
                         (Graph.loopForestSteensgaard (graph,
-                                                      {root = root}),
+                                                      {root = startNode}),
                          {title = concat [Func.toString name, " loop forest"],
                           options = [],
                           nodeName = nodeName})
                   in
                      loopForestLayout
                   end
-               *)
             in
                {destroy = destroy,
                 controlFlowGraph = controlFlowGraphLayout,
-                dominatorTree = dominatorTreeLayout}
+                dominatorTree = dominatorTreeLayout,
+                loopForest = loopForestLayout}
             end
       end
 
@@ -1365,7 +1365,7 @@ structure Function =
                   then ()
                else
                   let
-                     val {destroy, controlFlowGraph, dominatorTree} =
+                     val {destroy, controlFlowGraph, dominatorTree, loopForest} =
                         layoutDot (f, layoutVar)
                      val name = Func.toString name
                      fun doit (s, g) =
@@ -1380,10 +1380,8 @@ structure Function =
                         handle _ => Error.warning "SsaTree.layouts: couldn't layout cfg"
                      val _ = doit ("dom", dominatorTree ())
                         handle _ => Error.warning "SsaTree.layouts: couldn't layout dom"
-                     (*
                      val _ = doit ("lf", loopForest ())
                         handle _ => Error.warning "SsaTree.layouts: couldn't layout lf"
-                     *)
                      val () = destroy ()
                   in
                      ()

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -1236,7 +1236,7 @@ structure Function =
                   in
                      funNode
                   end
-               val graphLayout =
+               val controlFlowGraphLayout =
                   Graph.layoutDot
                   (graph, fn {nodeName} => 
                    {title = concat [Func.toString name, " control-flow graph"],
@@ -1248,7 +1248,7 @@ structure Function =
                                open NodeOption
                             in FontColor Black :: Shape Box :: l
                             end})
-               fun treeLayout () =
+               fun dominatorTreeLayout () =
                   let
                      val {get = nodeOptions, set = setNodeOptions, ...} =
                         Property.getSetOnce (Node.plist, Property.initConst [])
@@ -1257,7 +1257,7 @@ structure Function =
                         (blocks, fn Block.T {label, ...} =>
                          setNodeOptions (labelNode label,
                                          [NodeOption.label (Label.toString label)]))
-                     val treeLayout =
+                     val dominatorTreeLayout =
                         Tree.layoutDot
                         (Graph.dominatorTree (graph,
                                               {root = startNode,
@@ -1266,7 +1266,7 @@ structure Function =
                           options = [],
                           nodeOptions = nodeOptions})
                   in
-                     treeLayout
+                     dominatorTreeLayout
                   end
                (*
                fun loopForestLayout () =
@@ -1290,8 +1290,8 @@ structure Function =
                *)
             in
                {destroy = destroy,
-                graph = graphLayout,
-                tree = treeLayout}
+                controlFlowGraph = controlFlowGraphLayout,
+                dominatorTree = dominatorTreeLayout}
             end
       end
 
@@ -1365,7 +1365,7 @@ structure Function =
                   then ()
                else
                   let
-                     val {destroy, graph, tree} = 
+                     val {destroy, controlFlowGraph, dominatorTree} =
                         layoutDot (f, layoutVar)
                      val name = Func.toString name
                      fun doit (s, g) =
@@ -1376,9 +1376,9 @@ structure Function =
                            ({suffix = concat [name, ".", s, ".dot"]},
                             Dot, (), Layout (fn () => g))
                         end
-                     val _ = doit ("cfg", graph)
+                     val _ = doit ("cfg", controlFlowGraph)
                         handle _ => Error.warning "SsaTree.layouts: couldn't layout cfg"
-                     val _ = doit ("dom", tree ())
+                     val _ = doit ("dom", dominatorTree ())
                         handle _ => Error.warning "SsaTree.layouts: couldn't layout dom"
                      (*
                      val _ = doit ("lf", loopForest ())

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -182,8 +182,10 @@ structure Type =
                | Tuple ts =>
                     if Vector.isEmpty ts
                        then str "unit"
-                    else paren (seq (separate (Vector.toListMap (ts, layout),
-                                               " * ")))
+                    else seq [str "(",
+                              (mayAlign o separateRight)
+                              (Vector.toListMap (ts, layout), " *"),
+                              str ")"]
                | Vector t => seq [layout t, str " vector"]
                | Weak t => seq [layout t, str " weak"]
                | Word s => str (concat ["word", WordSize.toString s])))
@@ -296,29 +298,6 @@ structure Cases =
       fun foreach (c, f) = fold (c, (), fn (x, ()) => f x)
    end
 
-local open Layout
-in
-   fun layoutTuple xs = Vector.layout Var.layout xs
-end
-
-structure Var =
-   struct
-      open Var
-
-      fun pretty (x, global) =
-         case global x of
-            NONE => toString x
-          | SOME s => s
-
-      fun prettys (xs: Var.t vector, global: Var.t -> string option) =
-         Layout.toString (Vector.layout
-                          (fn x =>
-                           case global x of
-                              NONE => layout x
-                            | SOME s => Layout.str s)
-                          xs)
-   end
-
 structure Exp =
    struct
       datatype t =
@@ -366,13 +345,17 @@ structure Exp =
              | Var x => Var (fx x)
          end
 
-      fun layout e =
+      fun layout' (e, layoutVar) =
          let
             open Layout
+            fun layoutArgs xs = Vector.layout layoutVar xs
          in
             case e of
                ConApp {con, args} =>
-                  seq [Con.layout con, str " ", layoutTuple args]
+                  seq [Con.layout con,
+                       if Vector.isEmpty args
+                          then empty
+                          else seq [str " ", layoutArgs args]]
              | Const c => Const.layout c
              | PrimApp {prim, targs, args} =>
                   seq [Prim.layout prim,
@@ -380,15 +363,17 @@ structure Exp =
                           then if 0 = Vector.length targs
                                   then empty
                                else Vector.layout Type.layout targs
-                       else empty,
-                       seq [str " ", layoutTuple args]]
+                          else empty,
+                       str " ",
+                       layoutArgs args]
              | Profile p => ProfileExp.layout p
              | Select {tuple, offset} =>
                   seq [str "#", Int.layout offset, str " ",
-                       Var.layout tuple]
-             | Tuple xs => layoutTuple xs
-             | Var x => Var.layout x
+                       paren (layoutVar tuple)]
+             | Tuple xs => layoutArgs xs
+             | Var x => layoutVar x
          end
+      fun layout e = layout' (e, Var.layout)
 
       fun maySideEffect (e: t): bool =
          case e of
@@ -438,23 +423,6 @@ structure Exp =
       end
 
       val hash = Trace.trace ("SsaTree.Exp.hash", layout, Word.layout) hash
-
-      fun toPretty (e: t, global: Var.t -> string option): string =
-         case e of
-            ConApp {con, args} =>
-               concat [Con.toString con, " ", Var.prettys (args, global)]
-          | Const c => Const.toString c
-          | PrimApp {prim, args, ...} =>
-               Layout.toString
-               (Prim.layoutApp (prim, args, fn x =>
-                                case global x of
-                                   NONE => Var.layout x
-                                 | SOME s => Layout.str s))
-          | Profile p => ProfileExp.toString p
-          | Select {tuple, offset} =>
-               concat ["#", Int.toString offset, " ", Var.toString tuple]
-          | Tuple xs => Var.prettys (xs, global)
-          | Var x => Var.toString x
    end
 datatype z = datatype Exp.t
 
@@ -471,20 +439,22 @@ structure Statement =
          val exp = make #exp
       end
 
-      fun layout (T {var, ty, exp}) =
+      fun layout' (T {var, ty, exp}, layoutVar) =
          let
             open Layout
+            val (sep, ty) =
+               if !Control.showTypes
+                  then (str ":", indent (seq [Type.layout ty, str " ="], 2))
+                  else (str " =", empty)
          in
-            seq [seq [case var of
-                         NONE => empty
-                       | SOME var =>
-                            seq [Var.layout var,
-                                 if !Control.showTypes
-                                    then seq [str ": ", Type.layout ty]
-                                 else empty,
-                                 str " = "]],
-                 Exp.layout exp]
+            mayAlign [mayAlign [seq [case var of
+                                        NONE => str "_"
+                                      | SOME var => Var.layout var,
+                                     sep],
+                                ty],
+                      indent (Exp.layout' (exp, layoutVar), 2)]
          end
+      fun layout e = layout' (e, Var.layout)
 
       local
          fun make f x =
@@ -497,33 +467,39 @@ structure Statement =
 
       fun clear s = Option.app (var s, Var.clear)
 
-      fun prettifyGlobals (v: t vector): Var.t -> string option =
+      fun prettifyGlobals (v: t vector): Var.t -> Layout.t =
          let
-            val {get = global: Var.t -> string option, set = setGlobal, ...} =
-               Property.getSet (Var.plist, Property.initConst NONE)
+            val {get = global: Var.t -> Layout.t, set = setGlobal, ...} =
+               Property.getSet (Var.plist, Property.initFun Var.layout)
             val _ = 
                Vector.foreach
                (v, fn T {var, exp, ...} =>
                 Option.app
                 (var, fn var =>
                  let
-                    fun set s =
+                    fun set () =
                        let
-                          val maxSize = 10
+                          val s = Layout.toString (Exp.layout' (exp, global))
+                          val maxSize = 20
+                          val dots = " ... "
+                          val dotsSize = String.size dots
+                          val frontSize = 2 * (maxSize - dotsSize) div 3
+                          val backSize = maxSize - dotsSize - frontSize
                           val s = 
                              if String.size s > maxSize
-                                then concat [String.prefix (s, maxSize), "..."]
+                                then concat [String.prefix (s, frontSize),
+                                             dots,
+                                             String.suffix (s, backSize)]
                              else s
                        in
-                          setGlobal (var, SOME s)
+                          setGlobal (var, Layout.seq [Var.layout var,
+                                                      Layout.str (" (*" ^ s ^ "*)")])
                        end
                  in
                     case exp of
-                       Const c => set (Layout.toString (Const.layout c))
-                     | ConApp {con, args, ...} =>
-                          if Vector.isEmpty args
-                             then set (Con.toString con)
-                          else set (concat [Con.toString con, "(...)"])
+                       Const _ => set ()
+                     | ConApp _ => set ()
+                     | Tuple xs => if Vector.isEmpty xs then set () else ()
                      | _ => ()
                  end))
          in
@@ -765,10 +741,10 @@ structure Transfer =
       fun replaceLabel (t, f) = replaceLabelVar (t, f, fn x => x)
       fun replaceVar (t, f) = replaceLabelVar (t, fn l => l, f)
 
-      local open Layout
-      in
-         fun layoutCase {test, cases, default} =
+      local
+         fun layoutCase ({test, cases, default}, layoutVar) =
             let
+               open Layout
                fun doit (l, layout) =
                   Vector.toListMap
                   (l, fn (i, l) =>
@@ -784,33 +760,54 @@ structure Transfer =
                    | SOME j =>
                         cases @ [seq [str "_ => ", Label.layout j]]
             in
-               align [seq [str "case ", Var.layout test, str " of"],
+               align [seq [str "case ", layoutVar test, str " of"],
                       indent (alignPrefix (cases, "| "), 2)]
             end
-
-         val layout =
-            fn Arith {prim, args, overflow, success, ...} =>
-                  seq [Label.layout success, str " ",
-                       tuple [Prim.layoutApp (prim, args, Var.layout)],
-                       str " Overflow => ",
-                       Label.layout overflow, str " ()"]
-             | Bug => str "Bug"
-             | Call {func, args, return} =>
-                  seq [Func.layout func, str " ", layoutTuple args,
-                       str " ", Return.layout return]
-             | Case arg => layoutCase arg
-             | Goto {dst, args} =>
-                  seq [Label.layout dst, str " ", layoutTuple args]
-             | Raise xs => seq [str "raise ", layoutTuple xs]
-             | Return xs =>
-                  seq [str "return ",
-                       if 1 = Vector.length xs
-                          then Var.layout (Vector.sub (xs, 0))
-                       else layoutTuple xs]
-             | Runtime {prim, args, return} =>
-                  seq [Label.layout return, str " ", 
-                       tuple [Prim.layoutApp (prim, args, Var.layout)]]
+      in
+         fun layout' (t, layoutVar) =
+            let
+               open Layout
+               fun layoutArgs xs = Vector.layout layoutVar xs
+               fun layoutPrim {prim, args} =
+                  Exp.layout'
+                  (Exp.PrimApp {prim = prim,
+                                targs = Vector.new0 (),
+                                args = args},
+                   layoutVar)
+            in
+               case t of
+                  Arith {prim, args, overflow, success, ...} =>
+                     seq [Label.layout success, str " ",
+                          tuple [layoutPrim {prim = prim, args = args}],
+                          str " handle Overflow => ", Label.layout overflow]
+                | Bug => str "Bug"
+                | Call {func, args, return} =>
+                     let
+                        val call = seq [Func.layout func, str " ", layoutArgs args]
+                     in
+                        case return of
+                           Return.Dead => seq [str "dead ", paren call]
+                         | Return.NonTail {cont, handler} =>
+                              seq [Label.layout cont, str " ",
+                                   paren call,
+                                   str " handle _ => ",
+                                   case handler of
+                                      Handler.Caller => str "raise"
+                                    | Handler.Dead => str "dead"
+                                    | Handler.Handle l => Label.layout l]
+                         | Return.Tail => seq [str "return ", paren call]
+                     end
+                | Case arg => layoutCase (arg, layoutVar)
+                | Goto {dst, args} =>
+                     seq [Label.layout dst, str " ", layoutArgs args]
+                | Raise xs => seq [str "raise ", layoutArgs xs]
+                | Return xs => seq [str "return ", layoutArgs xs]
+                | Runtime {prim, args, return} =>
+                     seq [Label.layout return, str " ",
+                          tuple [layoutPrim {prim = prim, args = args}]]
+            end
       end
+      fun layout t = layout' (t, Var.layout)
 
       fun varsEquals (xs, xs') = Vector.equals (xs, xs', Var.equals)
 
@@ -913,22 +910,21 @@ structure Block =
          val transfer = make #transfer
       end
 
-      fun layout (T {label, args, statements, transfer}) =
+      fun layout' (T {label, args, statements, transfer}, layoutVar) =
          let
             open Layout
+            fun layoutStatement s = Statement.layout' (s, layoutVar)
+            fun layoutTransfer t = Transfer.layout' (t, layoutVar)
          in
             align [seq [Label.layout label, str " ",
-                        Vector.layout (fn (x, t) =>
-                                       if !Control.showTypes
-                                          then seq [Var.layout x, str ": ",
-                                                    Type.layout t]
-                                       else Var.layout x) args],
+                        layoutFormals args],
                    indent (align
                            [align
-                            (Vector.toListMap (statements, Statement.layout)),
-                            Transfer.layout transfer],
+                            (Vector.toListMap (statements, layoutStatement)),
+                            layoutTransfer transfer],
                            2)]
          end
+      fun layout b = layout' (b, Var.layout)
 
       fun clear (T {label, args, statements, ...}) =
          (Label.clear label
@@ -1116,25 +1112,18 @@ structure Function =
                 nodeBlock = #block o nodeInfo}
             end
 
-         fun layoutDot (f, global: Var.t -> string option) =
+         fun layoutDot (f, layoutVar) =
             let
-               val {name, start, blocks, ...} = dest f
-               fun makeName (name: string,
-                             formals: (Var.t * Type.t) vector): string =
-                  concat [name, " ",
-                          let
-                             open Layout
-                          in
-                             toString
-                             (Vector.layout
-                              (fn (var, ty) =>
-                               if !Control.showTypes
-                                  then seq [Var.layout var,
-                                            str ": ",
-                                            Type.layout ty]
-                               else Var.layout var)
-                              formals)
-                          end]
+               fun toStringStatement s = Layout.toString (Statement.layout' (s, layoutVar))
+               fun toStringTransfer t =
+                  Layout.toString
+                  (case t of
+                      Case {test, ...} =>
+                         Layout.seq [Layout.str "case ", layoutVar test]
+                    | _ => Transfer.layout' (t, layoutVar))
+               fun toStringFormals args = Layout.toString (layoutFormals args)
+               fun toStringHeader (name, args) = concat [name, " ", toStringFormals args]
+               val {name, args, start, blocks, returns, raises, ...} = dest f
                open Dot
                val graph = Graph.new ()
                val {get = nodeOptions, ...} =
@@ -1147,36 +1136,30 @@ structure Function =
                                     Property.initFun (fn _ => newNode ()))
                val {get = edgeOptions, set = setEdgeOptions, ...} =
                   Property.getSetOnce (Edge.plist, Property.initConst [])
+               fun edge (from, to, label: string, style: style): unit =
+                  let
+                     val e = Graph.addEdge (graph, {from = from,
+                                                    to = to})
+                     val _ = setEdgeOptions (e, [EdgeOption.label label,
+                                                 EdgeOption.Style style])
+                  in
+                     ()
+                  end
                val _ =
                   Vector.foreach
                   (blocks, fn Block.T {label, args, statements, transfer} =>
                    let
                       val from = labelNode label
-                      fun edge (to: Label.t,
-                                label: string,
-                                style: style): unit =
-                         let
-                            val e = Graph.addEdge (graph, {from = from,
-                                                           to = labelNode to})
-                            val _ = setEdgeOptions (e, [EdgeOption.label label,
-                                                        EdgeOption.Style style])
-                         in
-                            ()
-                         end
-                      val rest =
+                      val edge = fn (to, label, style) =>
+                         edge (from, labelNode to, label, style)
+                      val () =
                          case transfer of
-                            Arith {prim, args, overflow, success, ...} =>
+                            Arith {overflow, success, ...} =>
                                (edge (success, "", Solid)
-                                ; edge (overflow, "Overflow", Dashed)
-                                ; [Layout.toString
-                                   (Prim.layoutApp (prim, args, fn x =>
-                                                    Layout.str
-                                                    (Var.pretty (x, global))))])
-                          | Bug => ["bug"]
-                          | Call {func, args, return} =>
+                                ; edge (overflow, "Overflow", Dashed))
+                          | Bug => ()
+                          | Call {return, ...} =>
                                let
-                                  val f = Func.toString func
-                                  val args = Var.prettys (args, global)
                                   val _ =
                                      case return of
                                         Return.Dead => ()
@@ -1184,12 +1167,12 @@ structure Function =
                                            (edge (cont, "", Dotted)
                                             ; (Handler.foreachLabel
                                                (handler, fn l =>
-                                                edge (l, "", Dashed))))
+                                                edge (l, "Handle", Dashed))))
                                       | Return.Tail => ()
                                in
-                                  [f, " ", args]
+                                  ()
                                end
-                          | Case {test, cases, default, ...} =>
+                          | Case {cases, default, ...} =>
                                let
                                   fun doit (v, toString) =
                                      Vector.foreach
@@ -1197,63 +1180,67 @@ structure Function =
                                       edge (j, toString x, Solid))
                                   val _ =
                                      case cases of
-                                        Cases.Con v => doit (v, Con.toString)
+                                        Cases.Con v =>
+                                           doit (v, Con.toString)
                                       | Cases.Word (_, v) =>
                                            doit (v, WordX.toString)
                                   val _ = 
                                      case default of
                                         NONE => ()
                                       | SOME j =>
-                                           edge (j, "default", Solid)
+                                           edge (j, "Default", Solid)
                                in
-                                  ["case ", Var.toString test]
+                                  ()
                                end
-                          | Goto {dst, args} =>
-                               (edge (dst, "", Solid)
-                                ; [Label.toString dst, " ",
-                                   Var.prettys (args, global)])
-                          | Raise xs => ["raise ", Var.prettys (xs, global)]
-                          | Return xs => ["return ", Var.prettys (xs, global)]
-                          | Runtime {prim, args, return} =>
-                               (edge (return, "", Solid)
-                                ; [Layout.toString
-                                   (Prim.layoutApp (prim, args, fn x =>
-                                                    Layout.str
-                                                    (Var.pretty (x, global))))])
+                          | Goto {dst, ...} => edge (dst, "", Solid)
+                          | Raise _ => ()
+                          | Return _ => ()
+                          | Runtime {return, ...} => edge (return, "", Dotted)
+                      val lab =
+                         [(toStringTransfer transfer, Left)]
                       val lab =
                          Vector.foldr
-                         (statements, [(concat rest, Left)],
-                          fn (Statement.T {var, ty, exp, ...}, ac) =>
-                          let
-                             val exp = Exp.toPretty (exp, global)
-                             val s =
-                                if Type.isUnit ty
-                                   then exp
-                                else
-                                   case var of
-                                      NONE => exp
-                                    | SOME var =>
-                                         concat [Var.toString var,
-                                                 if !Control.showTypes
-                                                    then concat [": ",
-                                                                 Layout.toString
-                                                                 (Type.layout ty)]
-                                                 else "",
-                                                    " = ", exp]
-                          in
-                             (s, Left) :: ac
-                          end)
-                      val name = makeName (Label.toString label, args)
-                      val _ = setNodeText (from, (name, Left) :: lab)
+                         (statements, lab, fn (s, ac) =>
+                          (toStringStatement s, Left) :: ac)
+                      val lab =
+                         (toStringHeader (Label.toString label, args), Left)::lab
+                      val _ = setNodeText (from, lab)
                    in
                       ()
                    end)
-               val root = labelNode start
+               val startNode = labelNode start
+               val funNode =
+                  let
+                     val funNode = newNode ()
+                     val _ = edge (funNode, startNode, "Start", Solid)
+                     val lab =
+                        [(toStringTransfer (Transfer.Goto {dst = start, args = Vector.new0 ()}), Left)]
+                     val lab =
+                        if !Control.showTypes
+                           then ((Layout.toString o Layout.seq)
+                                 [Layout.str ": ",
+                                  Layout.record [("returns",
+                                                  Option.layout
+                                                  (Vector.layout Type.layout)
+                                                  returns),
+                                                 ("raises",
+                                                  Option.layout
+                                                  (Vector.layout Type.layout)
+                                                  raises)]],
+                                 Left)::lab
+                           else lab
+                     val lab =
+                        (toStringHeader ("fun " ^ Func.toString name, args), Left)::
+                        lab
+                     val _ = setNodeText (funNode, lab)
+                  in
+                     funNode
+                  end
                val graphLayout =
                   Graph.layoutDot
                   (graph, fn {nodeName} => 
                    {title = concat [Func.toString name, " control-flow graph"],
-                    options = [GraphOption.Rank (Min, [{nodeName = nodeName root}])],
+                    options = [GraphOption.Rank (Min, [{nodeName = nodeName funNode}])],
                     edgeOptions = edgeOptions,
                     nodeOptions =
                     fn n => let
@@ -1273,7 +1260,7 @@ structure Function =
                      val treeLayout =
                         Tree.layoutDot
                         (Graph.dominatorTree (graph,
-                                              {root = root,
+                                              {root = startNode,
                                                nodeValue = fn n => n}),
                          {title = concat [Func.toString name, " dominator tree"],
                           options = [],
@@ -1330,45 +1317,56 @@ structure Function =
          let
             val {args, name, raises, returns, start, ...} = dest f
             open Layout
+            val (sep, rty) =
+               if !Control.showTypes
+                  then (str ":",
+                        indent (seq [record [("returns",
+                                              Option.layout
+                                              (Vector.layout Type.layout)
+                                              returns),
+                                             ("raises",
+                                              Option.layout
+                                              (Vector.layout Type.layout)
+                                              raises)],
+                                     str " ="],
+                                2))
+                  else (str " =", empty)
          in
-            seq [str "fun ",
-                 Func.layout name,
-                 str " ",
-                 layoutFormals args,
-                 if !Control.showTypes
-                    then seq [str ": ",
-                              record [("raises",
-                                       Option.layout
-                                       (Vector.layout Type.layout) raises),
-                                      ("returns",
-                                       Option.layout
-                                       (Vector.layout Type.layout) returns)]]
-                 else empty,
-                    str " = ", Label.layout start, str " ()"]
+            mayAlign [mayAlign [seq [str "fun ",
+                                     Func.layout name,
+                                     str " ",
+                                     layoutFormals args,
+                                     sep],
+                                rty],
+                      Transfer.layout (Transfer.Goto {dst = start, args = Vector.new0 ()})]
          end
 
-      fun layout (f: t) =
+      fun layout' (f: t, layoutVar) =
          let
             val {blocks, ...} = dest f
             open Layout
+            fun layoutBlock b = Block.layout' (b, layoutVar)
          in
             align [layoutHeader f,
-                   indent (align (Vector.toListMap (blocks, Block.layout)), 2)]
+                   indent (align (Vector.toListMap (blocks, layoutBlock)), 2)]
          end
+      fun layout f = layout' (f, Var.layout)
 
-      fun layouts (f: t, global, output: Layout.t -> unit): unit =
+      fun layouts (f: t, layoutVar, output: Layout.t -> unit): unit =
          let
             val {blocks, name, ...} = dest f
             val _ = output (layoutHeader f)
-            val _ = Vector.foreach (blocks, fn b =>
-                                    output (Layout.indent (Block.layout b, 2)))
+            val _ =
+               Vector.foreach
+               (blocks, fn b =>
+                output (Layout.indent (Block.layout' (b, layoutVar), 2)))
             val _ =
                if not (!Control.keepDot)
                   then ()
                else
                   let
                      val {destroy, graph, tree} = 
-                        layoutDot (f, global)
+                        layoutDot (f, layoutVar)
                      val name = Func.toString name
                      fun doit (s, g) =
                         let
@@ -1702,7 +1700,7 @@ structure Program =
       fun layouts (p as T {datatypes, globals, functions, main},
                    output': Layout.t -> unit) =
          let
-            val global = Statement.prettifyGlobals globals
+            val layoutVar = Statement.prettifyGlobals globals
             open Layout
             (* Layout includes an output function, so we need to rebind output
              * to the one above.
@@ -1712,11 +1710,11 @@ structure Program =
             output (str "\n\nDatatypes:")
             ; Vector.foreach (datatypes, output o Datatype.layout)
             ; output (str "\n\nGlobals:")
-            ; Vector.foreach (globals, output o Statement.layout)
+            ; Vector.foreach (globals, output o (fn s => Statement.layout' (s, layoutVar)))
             ; output (seq [str "\n\nMain: ", Func.layout main])
             ; output (str "\n\nFunctions:")
             ; List.foreach (functions, fn f =>
-                            Function.layouts (f, global, output))
+                            Function.layouts (f, layoutVar, output))
             ; if not (!Control.keepDot)
                  then ()
               else

--- a/mlton/ssa/ssa-tree.sig
+++ b/mlton/ssa/ssa-tree.sig
@@ -258,8 +258,8 @@ signature SSA_TREE =
             val layout: t -> Layout.t
             val layoutDot:
                t * (Var.t -> Layout.t) -> {destroy: unit -> unit,
-                                           graph: Layout.t,
-                                           tree: unit -> Layout.t}
+                                           controlFlowGraph: Layout.t,
+                                           dominatorTree: unit -> Layout.t}
             val mayInline: t -> bool
             val name: t -> Func.t
             val new: {args: (Var.t * Type.t) vector,

--- a/mlton/ssa/ssa-tree.sig
+++ b/mlton/ssa/ssa-tree.sig
@@ -259,7 +259,8 @@ signature SSA_TREE =
             val layoutDot:
                t * (Var.t -> Layout.t) -> {destroy: unit -> unit,
                                            controlFlowGraph: Layout.t,
-                                           dominatorTree: unit -> Layout.t}
+                                           dominatorTree: unit -> Layout.t,
+                                           loopForest: unit -> Layout.t}
             val mayInline: t -> bool
             val name: t -> Func.t
             val new: {args: (Var.t * Type.t) vector,

--- a/mlton/ssa/ssa-tree.sig
+++ b/mlton/ssa/ssa-tree.sig
@@ -139,7 +139,6 @@ signature SSA_TREE =
             val clear: t -> unit (* clear the var *)
             val exp: t -> Exp.t
             val layout: t -> Layout.t
-            val prettifyGlobals: t vector -> (Var.t -> string option)
             val profile: ProfileExp.t -> t
             val var: t -> Var.t option
          end
@@ -258,9 +257,9 @@ signature SSA_TREE =
             val foreachVar: t * (Var.t * Type.t -> unit) -> unit
             val layout: t -> Layout.t
             val layoutDot:
-               t * (Var.t -> string option) -> {destroy: unit -> unit,
-                                                graph: Layout.t,
-                                                tree: unit -> Layout.t}
+               t * (Var.t -> Layout.t) -> {destroy: unit -> unit,
+                                           graph: Layout.t,
+                                           tree: unit -> Layout.t}
             val mayInline: t -> bool
             val name: t -> Func.t
             val new: {args: (Var.t * Type.t) vector,

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -1487,6 +1487,7 @@ structure Function =
                                open NodeOption
                             in FontColor Black :: Shape Box :: l
                             end})
+               val () = Graph.removeNode (graph, funNode)
                fun dominatorTreeLayout () =
                   let
                      val {get = nodeOptions, set = setNodeOptions, ...} =
@@ -1507,7 +1508,6 @@ structure Function =
                   in
                      dominatorTreeLayout
                   end
-               (*
                fun loopForestLayout () =
                   let
                      val {get = nodeName, set = setNodeName, ...} =
@@ -1519,18 +1519,18 @@ structure Function =
                      val loopForestLayout =
                         Graph.LoopForest.layoutDot
                         (Graph.loopForestSteensgaard (graph,
-                                                      {root = root}),
+                                                      {root = startNode}),
                          {title = concat [Func.toString name, " loop forest"],
                           options = [],
                           nodeName = nodeName})
                   in
                      loopForestLayout
                   end
-               *)
             in
                {destroy = destroy,
                 controlFlowGraph = controlFlowGraphLayout,
-                dominatorTree = dominatorTreeLayout}
+                dominatorTree = dominatorTreeLayout,
+                loopForest = loopForestLayout}
             end
       end
 
@@ -1604,7 +1604,7 @@ structure Function =
                   then ()
                else
                   let
-                     val {destroy, controlFlowGraph, dominatorTree} =
+                     val {destroy, controlFlowGraph, dominatorTree, loopForest} =
                         layoutDot (f, layoutVar)
                      val name = Func.toString name
                      fun doit (s, g) =
@@ -1619,10 +1619,8 @@ structure Function =
                         handle _ => Error.warning "SsaTree2.layouts: couldn't layout cfg"
                      val _ = doit ("dom", dominatorTree ())
                         handle _ => Error.warning "SsaTree2.layouts: couldn't layout dom"
-                     (*
                      val _ = doit ("lf", loopForest ())
                         handle _ => Error.warning "SsaTree2.layouts: couldn't layout lf"
-                     *)
                      val () = destroy ()
                   in
                      ()

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -1475,7 +1475,7 @@ structure Function =
                   in
                      funNode
                   end
-               val graphLayout =
+               val controlFlowGraphLayout =
                   Graph.layoutDot
                   (graph, fn {nodeName} => 
                    {title = concat [Func.toString name, " control-flow graph"],
@@ -1487,7 +1487,7 @@ structure Function =
                                open NodeOption
                             in FontColor Black :: Shape Box :: l
                             end})
-               fun treeLayout () =
+               fun dominatorTreeLayout () =
                   let
                      val {get = nodeOptions, set = setNodeOptions, ...} =
                         Property.getSetOnce (Node.plist, Property.initConst [])
@@ -1496,7 +1496,7 @@ structure Function =
                         (blocks, fn Block.T {label, ...} =>
                          setNodeOptions (labelNode label,
                                          [NodeOption.label (Label.toString label)]))
-                     val treeLayout =
+                     val dominatorTreeLayout =
                         Tree.layoutDot
                         (Graph.dominatorTree (graph,
                                               {root = startNode,
@@ -1505,7 +1505,7 @@ structure Function =
                           options = [],
                           nodeOptions = nodeOptions})
                   in
-                     treeLayout
+                     dominatorTreeLayout
                   end
                (*
                fun loopForestLayout () =
@@ -1529,8 +1529,8 @@ structure Function =
                *)
             in
                {destroy = destroy,
-                graph = graphLayout,
-                tree = treeLayout}
+                controlFlowGraph = controlFlowGraphLayout,
+                dominatorTree = dominatorTreeLayout}
             end
       end
 
@@ -1604,7 +1604,8 @@ structure Function =
                   then ()
                else
                   let
-                     val {destroy, graph, tree} = layoutDot (f, layoutVar)
+                     val {destroy, controlFlowGraph, dominatorTree} =
+                        layoutDot (f, layoutVar)
                      val name = Func.toString name
                      fun doit (s, g) =
                         let
@@ -1614,9 +1615,9 @@ structure Function =
                            ({suffix = concat [name, ".", s, ".dot"]},
                             Dot, (), Layout (fn () => g))
                         end
-                     val _ = doit ("cfg", graph)
+                     val _ = doit ("cfg", controlFlowGraph)
                         handle _ => Error.warning "SsaTree2.layouts: couldn't layout cfg"
-                     val _ = doit ("dom", tree ())
+                     val _ = doit ("dom", dominatorTree ())
                         handle _ => Error.warning "SsaTree2.layouts: couldn't layout dom"
                      (*
                      val _ = doit ("lf", loopForest ())

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -44,24 +44,21 @@ structure Prod =
                             {elt = e2, isMutable = m2}) =>
                         m1 = m2 andalso equals (e1, e2))
 
-      local 
-         open Layout
-      in
-         fun layout (p, layout) =
-            paren
-            (#1 (Tycon.layoutApp
-                 (Tycon.tuple,
-                  Vector.map (dest p, fn {elt, isMutable} =>
-                              let
-                                 val lay =
-                                    if isMutable
-                                       then seq [layout elt, str " ref"]
-                                    else layout elt
-                              in
-                                 (lay, ({isChar = false},
-                                        Tycon.BindingStrength.unit))
-                              end))))
-      end
+      fun layout (p, layout) =
+         if isEmpty p
+            then Layout.str "unit"
+            else let
+                    open Layout
+                 in
+                    seq [str "(",
+                         (mayAlign o separateRight)
+                         (Vector.toListMap (dest p, fn {elt, isMutable} =>
+                                            if isMutable
+                                               then seq [layout elt, str " ref"]
+                                               else layout elt),
+                          " *"),
+                         str ")"]
+                 end
 
       val map: 'a t * ('a -> 'b) -> 'b t =
          fn (p, f) =>
@@ -453,29 +450,6 @@ structure Cases =
       fun foreach (c, f) = fold (c, (), fn (x, ()) => f x)
    end
 
-local open Layout
-in
-   fun layoutTuple xs = Vector.layout Var.layout xs
-end
-
-structure Var =
-   struct
-      open Var
-
-      fun pretty (x, global) =
-         case global x of
-            NONE => toString x
-          | SOME s => s
-
-      fun prettys (xs: Var.t vector, global: Var.t -> string option) =
-         Layout.toString (Vector.layout
-                          (fn x =>
-                           case global x of
-                              NONE => layout x
-                            | SOME s => Layout.str s)
-                          xs)
-   end
-
 structure Base =
    struct
       datatype 'a t =
@@ -490,7 +464,7 @@ structure Base =
             case b of
                Object x => layoutX x
              | VectorSub {index, vector} =>
-                  seq [layoutX vector, str "[", layoutX index, str "]"]
+                  seq [str "$", Vector.layout layoutX (Vector.new2 (vector, index))]
          end
 
       val equals: 'a t * 'a t * ('a * 'a -> bool) -> bool =
@@ -579,31 +553,26 @@ structure Exp =
       fun layout' (e, layoutVar) =
          let
             open Layout
+            fun layoutArgs xs = Vector.layout layoutVar xs
          in
             case e of
                Const c => Const.layout c
              | Inject {sum, variant} =>
-                  seq [layoutVar variant, str ": ", Tycon.layout sum]
+                  seq [paren (layoutVar variant), str ": ", Tycon.layout sum]
              | Object {con, args} =>
                   seq [(case con of
                            NONE => empty
                          | SOME c => seq [Con.layout c, str " "]),
-                       layoutTuple args]
+                       layoutArgs args]
              | PrimApp {args, prim} =>
-                  seq [Prim.layout prim, seq [str " ", layoutTuple args]]
+                  seq [Prim.layout prim, str " ", layoutArgs args]
              | Select {base, offset} =>
                   seq [str "#", Int.layout offset, str " ",
-                       Base.layout (base, layoutVar)]
+                       paren (Base.layout (base, layoutVar))]
              | Var x => layoutVar x
          end
 
       fun layout e = layout' (e, Var.layout)
-
-      fun toPretty (e, global: Var.t -> string option): string =
-         Layout.toString (layout' (e, fn x =>
-                                   case global x of
-                                      NONE => Var.layout x
-                                    | SOME s => Layout.str s))
 
       fun maySideEffect (e: t): bool =
          case e of
@@ -679,31 +648,28 @@ structure Statement =
          in
             case s of
                Bind {var, ty, exp} =>
-                  seq [seq [case var of
-                               NONE => empty
-                             | SOME var =>
-                                  seq [Var.layout var,
-                                       if !Control.showTypes
-                                          then seq [str ": ", Type.layout ty]
-                                       else empty,
-                                          str " = "]],
-                       Exp.layout' (exp, layoutVar)]
+                  let
+                     val (sep, ty) =
+                        if !Control.showTypes
+                           then (str ":", indent (seq [Type.layout ty, str " ="], 2))
+                           else (str " =", empty)
+                  in
+                     mayAlign [mayAlign [seq [case var of
+                                                 NONE => str "_"
+                                               | SOME var => Var.layout var,
+                                              sep],
+                                         ty],
+                               indent (Exp.layout' (exp, layoutVar), 2)]
+                  end
              | Profile p => ProfileExp.layout p
              | Update {base, offset, value} =>
-                  seq [(if 0 = offset
-                           then empty
-                        else seq [str "#", Int.layout offset, str " "]),
-                       Base.layout (base, layoutVar),
-                       str " := ", layoutVar value]
+                  mayAlign [seq [Exp.layout' (Exp.Select {base = base,
+                                                          offset = offset},
+                                              layoutVar),
+                                 str " :="],
+                            layoutVar value]
          end
-
       fun layout s = layout' (s, Var.layout)
-
-      fun toPretty (s: t, global: Var.t -> string option): string =
-         Layout.toString (layout' (s, fn x =>
-                                   case global x of
-                                      NONE => Var.layout x
-                                    | SOME s => Layout.str s))
 
       val profile = Profile
 
@@ -714,10 +680,10 @@ structure Statement =
 
       fun clear s = foreachDef (s, Var.clear o #1)
 
-      fun prettifyGlobals (v: t vector): Var.t -> string option =
+      fun prettifyGlobals (v: t vector): Var.t -> Layout.t =
          let
-            val {get = global: Var.t -> string option, set = setGlobal, ...} =
-               Property.getSet (Var.plist, Property.initConst NONE)
+            val {get = global: Var.t -> Layout.t, set = setGlobal, ...} =
+               Property.getSet (Var.plist, Property.initFun Var.layout)
             val _ = 
                Vector.foreach
                (v, fn s =>
@@ -726,28 +692,31 @@ structure Statement =
                       Option.app
                       (var, fn var =>
                        let
-                          fun set s =
+                          fun set () =
                              let
-                                val maxSize = 10
+                                val s = Layout.toString (Exp.layout' (exp, global))
+                                val maxSize = 20
+                                val dots = " ... "
+                                val dotsSize = String.size dots
+                                val frontSize = 2 * (maxSize - dotsSize) div 3
+                                val backSize = maxSize - dotsSize - frontSize
                                 val s = 
                                    if String.size s > maxSize
-                                      then concat [String.prefix (s, maxSize),
-                                                   "..."]
-                                   else s
+                                      then concat [String.prefix (s, frontSize),
+                                                   dots,
+                                                   String.suffix (s, backSize)]
+                                      else s
                              in
-                                setGlobal (var, SOME s)
+                                setGlobal (var, Layout.seq [Var.layout var,
+                                                            Layout.str (" (*" ^ s ^ "*)")])
                              end
                        in
                           case exp of
-                             Const c => set (Layout.toString (Const.layout c))
+                             Const _ => set ()
                            | Object {con, args, ...} =>
                                 (case con of
-                                    NONE => ()
-                                  | SOME c =>
-                                       set (if Vector.isEmpty args
-                                               then Con.toString c
-                                            else concat [Con.toString c,
-                                                         "(...)"]))
+                                    NONE => if Vector.isEmpty args then set () else ()
+                                  | SOME _ => set ())
                            | _ => ()
                        end)
                  | _ => ())
@@ -1018,10 +987,10 @@ structure Transfer =
       val _ = replaceLabel
       fun replaceVar (t, f) = replaceLabelVar (t, fn l => l, f)
 
-      local open Layout
-      in
-         fun layoutCase {test, cases, default} =
+      local
+         fun layoutCase ({test, cases, default}, layoutVar) =
             let
+               open Layout
                fun doit (l, layout) =
                   Vector.toListMap
                   (l, fn (i, l) =>
@@ -1037,33 +1006,53 @@ structure Transfer =
                    | SOME j =>
                         cases @ [seq [str "_ => ", Label.layout j]]
             in
-               align [seq [str "case ", Var.layout test, str " of"],
+               align [seq [str "case ", layoutVar test, str " of"],
                       indent (alignPrefix (cases, "| "), 2)]
             end
-
-         val layout =
-            fn Arith {prim, args, overflow, success, ...} =>
-                  seq [Label.layout success, str " ",
-                       tuple [Prim.layoutApp (prim, args, Var.layout)],
-                       str " Overflow => ",
-                       Label.layout overflow, str " ()"]
-             | Bug => str "Bug"
-             | Call {func, args, return} =>
-                  seq [Func.layout func, str " ", layoutTuple args,
-                       str " ", Return.layout return]
-             | Case arg => layoutCase arg
-             | Goto {dst, args} =>
-                  seq [Label.layout dst, str " ", layoutTuple args]
-             | Raise xs => seq [str "raise ", layoutTuple xs]
-             | Return xs =>
-                  seq [str "return ",
-                       if 1 = Vector.length xs
-                          then Var.layout (Vector.sub (xs, 0))
-                       else layoutTuple xs]
-             | Runtime {prim, args, return} =>
-                  seq [Label.layout return, str " ", 
-                       tuple [Prim.layoutApp (prim, args, Var.layout)]]
+      in
+         fun layout' (t, layoutVar) =
+            let
+               open Layout
+               fun layoutArgs xs = Vector.layout layoutVar xs
+               fun layoutPrim {prim, args} =
+                  Exp.layout'
+                  (Exp.PrimApp {prim = prim,
+                                args = args},
+                   layoutVar)
+            in
+               case t of
+                  Arith {prim, args, overflow, success, ...} =>
+                     seq [Label.layout success, str " ",
+                          tuple [layoutPrim {prim = prim, args = args}],
+                          str " handle Overflow => ", Label.layout overflow]
+                | Bug => str "Bug"
+                | Call {func, args, return} =>
+                     let
+                        val call = seq [Func.layout func, str " ", layoutArgs args]
+                     in
+                        case return of
+                           Return.Dead => seq [str "dead ", paren call]
+                         | Return.NonTail {cont, handler} =>
+                              seq [Label.layout cont, str " ",
+                                   paren call,
+                                   str " handle _ => ",
+                                   case handler of
+                                      Handler.Caller => str "raise"
+                                    | Handler.Dead => str "dead"
+                                    | Handler.Handle l => Label.layout l]
+                         | Return.Tail => seq [str "return ", paren call]
+                     end
+                | Case arg => layoutCase (arg, layoutVar)
+                | Goto {dst, args} =>
+                     seq [Label.layout dst, str " ", layoutArgs args]
+                | Raise xs => seq [str "raise ", layoutArgs xs]
+                | Return xs => seq [str "return ", layoutArgs xs]
+                | Runtime {prim, args, return} =>
+                     seq [Label.layout return, str " ",
+                          tuple [layoutPrim {prim = prim, args = args}]]
+            end
       end
+      fun layout t = layout' (t, Var.layout)
 
       fun varsEquals (xs, xs') = Vector.equals (xs, xs', Var.equals)
 
@@ -1166,22 +1155,21 @@ structure Block =
          val transfer = make #transfer
       end
 
-      fun layout (T {label, args, statements, transfer}) =
+      fun layout' (T {label, args, statements, transfer}, layoutVar) =
          let
             open Layout
+            fun layoutStatement s = Statement.layout' (s, layoutVar)
+            fun layoutTransfer t = Transfer.layout' (t, layoutVar)
          in
             align [seq [Label.layout label, str " ",
-                        Vector.layout (fn (x, t) =>
-                                       if !Control.showTypes
-                                          then seq [Var.layout x, str ": ",
-                                                    Type.layout t]
-                                       else Var.layout x) args],
+                        layoutFormals args],
                    indent (align
                            [align
-                            (Vector.toListMap (statements, Statement.layout)),
-                            Transfer.layout transfer],
+                            (Vector.toListMap (statements, layoutStatement)),
+                            layoutTransfer transfer],
                            2)]
          end
+      fun layout b = layout' (b, Var.layout)
 
       fun clear (T {label, args, statements, ...}) =
          (Label.clear label
@@ -1363,25 +1351,18 @@ structure Function =
                 nodeBlock = #block o nodeInfo}
             end
 
-         fun layoutDot (f, global: Var.t -> string option) =
+         fun layoutDot (f, layoutVar) =
             let
-               val {name, start, blocks, ...} = dest f
-               fun makeName (name: string,
-                             formals: (Var.t * Type.t) vector): string =
-                  concat [name, " ",
-                          let
-                             open Layout
-                          in
-                             toString
-                             (Vector.layout
-                              (fn (var, ty) =>
-                               if !Control.showTypes
-                                  then seq [Var.layout var,
-                                            str ": ",
-                                            Type.layout ty]
-                               else Var.layout var)
-                              formals)
-                          end]
+               fun toStringStatement s = Layout.toString (Statement.layout' (s, layoutVar))
+               fun toStringTransfer t =
+                  Layout.toString
+                  (case t of
+                      Case {test, ...} =>
+                         Layout.seq [Layout.str "case ", layoutVar test]
+                    | _ => Transfer.layout' (t, layoutVar))
+               fun toStringFormals args = Layout.toString (layoutFormals args)
+               fun toStringHeader (name, args) = concat [name, " ", toStringFormals args]
+               val {name, args, start, blocks, returns, raises, ...} = dest f
                open Dot
                val graph = Graph.new ()
                val {get = nodeOptions, ...} =
@@ -1394,36 +1375,30 @@ structure Function =
                                     Property.initFun (fn _ => newNode ()))
                val {get = edgeOptions, set = setEdgeOptions, ...} =
                   Property.getSetOnce (Edge.plist, Property.initConst [])
+               fun edge (from, to, label: string, style: style): unit =
+                  let
+                     val e = Graph.addEdge (graph, {from = from,
+                                                    to = to})
+                     val _ = setEdgeOptions (e, [EdgeOption.label label,
+                                                 EdgeOption.Style style])
+                  in
+                     ()
+                  end
                val _ =
                   Vector.foreach
                   (blocks, fn Block.T {label, args, statements, transfer} =>
                    let
                       val from = labelNode label
-                      fun edge (to: Label.t,
-                                label: string,
-                                style: style): unit =
-                         let
-                            val e = Graph.addEdge (graph, {from = from,
-                                                           to = labelNode to})
-                            val _ = setEdgeOptions (e, [EdgeOption.label label,
-                                                        EdgeOption.Style style])
-                         in
-                            ()
-                         end
-                      val rest =
+                      val edge = fn (to, label, style) =>
+                         edge (from, labelNode to, label, style)
+                      val () =
                          case transfer of
-                            Arith {prim, args, overflow, success, ...} =>
+                            Arith {overflow, success, ...} =>
                                (edge (success, "", Solid)
-                                ; edge (overflow, "Overflow", Dashed)
-                                ; [Layout.toString
-                                   (Prim.layoutApp (prim, args, fn x =>
-                                                    Layout.str
-                                                    (Var.pretty (x, global))))])
-                          | Bug => ["bug"]
-                          | Call {func, args, return} =>
+                                ; edge (overflow, "Overflow", Dashed))
+                          | Bug => ()
+                          | Call {return, ...} =>
                                let
-                                  val f = Func.toString func
-                                  val args = Var.prettys (args, global)
                                   val _ =
                                      case return of
                                         Return.Dead => ()
@@ -1431,12 +1406,12 @@ structure Function =
                                            (edge (cont, "", Dotted)
                                             ; (Handler.foreachLabel
                                                (handler, fn l =>
-                                                edge (l, "", Dashed))))
+                                                edge (l, "Handle", Dashed))))
                                       | Return.Tail => ()
                                in
-                                  [f, " ", args]
+                                  ()
                                end
-                          | Case {test, cases, default, ...} =>
+                          | Case {cases, default, ...} =>
                                let
                                   fun doit (v, toString) =
                                      Vector.foreach
@@ -1444,68 +1419,67 @@ structure Function =
                                       edge (j, toString x, Solid))
                                   val _ =
                                      case cases of
-                                        Cases.Con v => doit (v, Con.toString)
+                                        Cases.Con v =>
+                                           doit (v, Con.toString)
                                       | Cases.Word (_, v) =>
                                            doit (v, WordX.toString)
                                   val _ = 
                                      case default of
                                         NONE => ()
                                       | SOME j =>
-                                           edge (j, "default", Solid)
+                                           edge (j, "Default", Solid)
                                in
-                                  ["case ", Var.toString test]
+                                  ()
                                end
-                          | Goto {dst, args} =>
-                               (edge (dst, "", Solid)
-                                ; [Label.toString dst, " ",
-                                   Var.prettys (args, global)])
-                          | Raise xs => ["raise ", Var.prettys (xs, global)]
-                          | Return xs => ["return ", Var.prettys (xs, global)]
-                          | Runtime {prim, args, return} =>
-                               (edge (return, "", Solid)
-                                ; [Layout.toString
-                                   (Prim.layoutApp (prim, args, fn x =>
-                                                    Layout.str
-                                                    (Var.pretty (x, global))))])
+                          | Goto {dst, ...} => edge (dst, "", Solid)
+                          | Raise _ => ()
+                          | Return _ => ()
+                          | Runtime {return, ...} => edge (return, "", Dotted)
+                      val lab =
+                         [(toStringTransfer transfer, Left)]
                       val lab =
                          Vector.foldr
-                         (statements, [(concat rest, Left)], fn (s, ac) =>
-                          let
-                             val s =
-                                case s of
-                                   Bind {exp, ty, var} =>
-                                      let
-                                         val exp = Exp.toPretty (exp, global)
-                                      in
-                                         if Type.isUnit ty
-                                            then exp
-                                         else
-                                            case var of
-                                               NONE => exp
-                                             | SOME var =>
-                                                  concat [Var.toString var,
-                                                          if !Control.showTypes
-                                                             then concat [": ",
-                                                                          Layout.toString
-                                                                          (Type.layout ty)]
-                                                          else "",
-                                                             " = ", exp]
-                                      end
-                                 | _ => Statement.toPretty (s, global)
-                          in
-                             (s, Left) :: ac
-                          end)
-                      val name = makeName (Label.toString label, args)
-                      val _ = setNodeText (from, (name, Left) :: lab)
+                         (statements, lab, fn (s, ac) =>
+                          (toStringStatement s, Left) :: ac)
+                      val lab =
+                         (toStringHeader (Label.toString label, args), Left)::lab
+                      val _ = setNodeText (from, lab)
                    in
                       ()
                    end)
-               val root = labelNode start
+               val startNode = labelNode start
+               val funNode =
+                  let
+                     val funNode = newNode ()
+                     val _ = edge (funNode, startNode, "Start", Solid)
+                     val lab =
+                        [(toStringTransfer (Transfer.Goto {dst = start, args = Vector.new0 ()}), Left)]
+                     val lab =
+                        if !Control.showTypes
+                           then ((Layout.toString o Layout.seq)
+                                 [Layout.str ": ",
+                                  Layout.record [("returns",
+                                                  Option.layout
+                                                  (Vector.layout Type.layout)
+                                                  returns),
+                                                 ("raises",
+                                                  Option.layout
+                                                  (Vector.layout Type.layout)
+                                                  raises)]],
+                                 Left)::lab
+                           else lab
+                     val lab =
+                        (toStringHeader ("fun " ^ Func.toString name, args), Left)::
+                        lab
+                     val _ = setNodeText (funNode, lab)
+                  in
+                     funNode
+                  end
                val graphLayout =
                   Graph.layoutDot
                   (graph, fn {nodeName} => 
                    {title = concat [Func.toString name, " control-flow graph"],
-                    options = [GraphOption.Rank (Min, [{nodeName = nodeName root}])],
+                    options = [GraphOption.Rank (Min, [{nodeName = nodeName funNode}])],
                     edgeOptions = edgeOptions,
                     nodeOptions =
                     fn n => let
@@ -1525,7 +1499,7 @@ structure Function =
                      val treeLayout =
                         Tree.layoutDot
                         (Graph.dominatorTree (graph,
-                                              {root = root,
+                                              {root = startNode,
                                                nodeValue = fn n => n}),
                          {title = concat [Func.toString name, " dominator tree"],
                           options = [],
@@ -1582,44 +1556,55 @@ structure Function =
          let
             val {args, name, raises, returns, start, ...} = dest f
             open Layout
+            val (sep, rty) =
+               if !Control.showTypes
+                  then (str ":",
+                        indent (seq [record [("returns",
+                                              Option.layout
+                                              (Vector.layout Type.layout)
+                                              returns),
+                                             ("raises",
+                                              Option.layout
+                                              (Vector.layout Type.layout)
+                                              raises)],
+                                     str " ="],
+                                2))
+                  else (str " =", empty)
          in
-            seq [str "fun ",
-                 Func.layout name,
-                 str " ",
-                 layoutFormals args,
-                 if !Control.showTypes
-                    then seq [str ": ",
-                              record [("raises",
-                                       Option.layout
-                                       (Vector.layout Type.layout) raises),
-                                      ("returns",
-                                       Option.layout
-                                       (Vector.layout Type.layout) returns)]]
-                 else empty,
-                    str " = ", Label.layout start, str " ()"]
+            mayAlign [mayAlign [seq [str "fun ",
+                                     Func.layout name,
+                                     str " ",
+                                     layoutFormals args,
+                                     sep],
+                                rty],
+                      Transfer.layout (Transfer.Goto {dst = start, args = Vector.new0 ()})]
          end
 
-      fun layout (f: t) =
+      fun layout' (f: t, layoutVar) =
          let
             val {blocks, ...} = dest f
             open Layout
+            fun layoutBlock b = Block.layout' (b, layoutVar)
          in
             align [layoutHeader f,
-                   indent (align (Vector.toListMap (blocks, Block.layout)), 2)]
+                   indent (align (Vector.toListMap (blocks, layoutBlock)), 2)]
          end
+      fun layout f = layout' (f, Var.layout)
 
-      fun layouts (f: t, global, output: Layout.t -> unit): unit =
+      fun layouts (f: t, layoutVar, output: Layout.t -> unit): unit =
          let
             val {blocks, name, ...} = dest f
             val _ = output (layoutHeader f)
-            val _ = Vector.foreach (blocks, fn b =>
-                                    output (Layout.indent (Block.layout b, 2)))
+            val _ =
+               Vector.foreach
+               (blocks, fn b =>
+                output (Layout.indent (Block.layout' (b, layoutVar), 2)))
             val _ =
                if not (!Control.keepDot)
                   then ()
                else
                   let
-                     val {destroy, graph, tree} = layoutDot (f, global)
+                     val {destroy, graph, tree} = layoutDot (f, layoutVar)
                      val name = Func.toString name
                      fun doit (s, g) =
                         let
@@ -1945,7 +1930,7 @@ structure Program =
       fun layouts (p as T {datatypes, globals, functions, main},
                    output': Layout.t -> unit) =
          let
-            val global = Statement.prettifyGlobals globals
+            val layoutVar = Statement.prettifyGlobals globals
             open Layout
             (* Layout includes an output function, so we need to rebind output
              * to the one above.
@@ -1955,11 +1940,11 @@ structure Program =
             output (str "\n\nDatatypes:")
             ; Vector.foreach (datatypes, output o Datatype.layout)
             ; output (str "\n\nGlobals:")
-            ; Vector.foreach (globals, output o Statement.layout)
+            ; Vector.foreach (globals, output o (fn s => Statement.layout' (s, layoutVar)))
             ; output (seq [str "\n\nMain: ", Func.layout main])
             ; output (str "\n\nFunctions:")
             ; List.foreach (functions, fn f =>
-                            Function.layouts (f, global, output))
+                            Function.layouts (f, layoutVar, output))
             ; if not (!Control.keepDot)
                  then ()
               else

--- a/mlton/ssa/ssa-tree2.sig
+++ b/mlton/ssa/ssa-tree2.sig
@@ -141,7 +141,6 @@ signature SSA_TREE2 =
             val foreachDef: t * (Var.t * Type.t -> unit) -> unit
             val foreachUse: t * (Var.t -> unit) -> unit
             val layout: t -> Layout.t
-            val prettifyGlobals: t vector -> (Var.t -> string option)
             val profile: ProfileExp.t -> t
             val replaceUses: t * (Var.t -> Var.t) -> t
          end
@@ -258,9 +257,9 @@ signature SSA_TREE2 =
             val foreachVar: t * (Var.t * Type.t -> unit) -> unit
             val layout: t -> Layout.t
             val layoutDot:
-               t * (Var.t -> string option) -> {destroy: unit -> unit,
-                                                graph: Layout.t,
-                                                tree: unit -> Layout.t}
+               t * (Var.t -> Layout.t) -> {destroy: unit -> unit,
+                                           graph: Layout.t,
+                                           tree: unit -> Layout.t}
             val name: t -> Func.t
             val new: {args: (Var.t * Type.t) vector,
                       blocks: Block.t vector,

--- a/mlton/ssa/ssa-tree2.sig
+++ b/mlton/ssa/ssa-tree2.sig
@@ -259,7 +259,8 @@ signature SSA_TREE2 =
             val layoutDot:
                t * (Var.t -> Layout.t) -> {destroy: unit -> unit,
                                            controlFlowGraph: Layout.t,
-                                           dominatorTree: unit -> Layout.t}
+                                           dominatorTree: unit -> Layout.t,
+                                           loopForest: unit -> Layout.t}
             val name: t -> Func.t
             val new: {args: (Var.t * Type.t) vector,
                       blocks: Block.t vector,

--- a/mlton/ssa/ssa-tree2.sig
+++ b/mlton/ssa/ssa-tree2.sig
@@ -258,8 +258,8 @@ signature SSA_TREE2 =
             val layout: t -> Layout.t
             val layoutDot:
                t * (Var.t -> Layout.t) -> {destroy: unit -> unit,
-                                           graph: Layout.t,
-                                           tree: unit -> Layout.t}
+                                           controlFlowGraph: Layout.t,
+                                           dominatorTree: unit -> Layout.t}
             val name: t -> Func.t
             val new: {args: (Var.t * Type.t) vector,
                       blocks: Block.t vector,


### PR DESCRIPTION
Highlights:
* Display more context when reporting SSA and SSA2 IR type errors. A simple `Analyze.coerces` or `Reference to <x> not in scope` is not particularly illuminating.  Now the containing statement or transfer, the containing block label, and the containing function name are appended to the error message (6bee991).
* Add `-layout-width <n>` compile time expert option to control the target width for the pretty printer (d93db6f).
* Make cosmetic improvements to SSA and SSA2 IR display:
  * Uses of global variables bound to small constants and conapps are commented with the corresponding value (50070b6).
  * Include loop forest, along with control-flow graph and dominator tree, for functions with `-keep dot` (58502c8, 19e385d).
* Fix Ssa.PrePasses.breakCriticalEdges for codeMotion (4cfc92c).
* Make cosmetic improvements to RSSA IR display (303e2cb).
* Improve RSSA constant folding and copy propagation (36ec8ab)
* Limit Machine IR Globals to variables used outside of the main function (c562d91).
