### PR TITLE
Stream parsers + Sxml input

### DIFF
--- a/lib/mlton/basic/sources.cm
+++ b/lib/mlton/basic/sources.cm
@@ -123,6 +123,7 @@ structure Sexp
 structure Signal
 structure Socket
 structure Stream
+structure StreamParser
 structure String
 structure StringCvt
 structure Substring
@@ -161,7 +162,6 @@ functor Pair
 functor PolyEnv
 functor Ring
 functor RingWithIdentity
-functor StreamParser
 functor Sum
 functor Tree
 functor UniqueId
@@ -270,7 +270,7 @@ instream.sml
 file.sig
 file.sml
 stream-parser.sig
-stream-parser.fun
+stream-parser.sml
 signal.sml
 process.sig
 dir.sig

--- a/lib/mlton/basic/sources.cm
+++ b/lib/mlton/basic/sources.cm
@@ -24,9 +24,9 @@ signature PROMISE
 signature REAL
 signature RING
 signature RING_WITH_IDENTITY
-signature STRING
 signature STREAM
 signature STREAM_PARSER
+signature STRING
 signature SUM
 signature T
 signature UNIQUE_ID

--- a/lib/mlton/basic/sources.mlb
+++ b/lib/mlton/basic/sources.mlb
@@ -199,9 +199,9 @@ in
       signature REAL
       signature RING
       signature RING_WITH_IDENTITY
-      signature STRING
       signature STREAM
       signature STREAM_PARSER
+      signature STRING
       signature T
       signature UNIQUE_ID
       signature VECTOR

--- a/lib/mlton/basic/sources.mlb
+++ b/lib/mlton/basic/sources.mlb
@@ -113,7 +113,7 @@ in
       file.sig
       file.sml
       stream-parser.sig
-      stream-parser.fun
+      stream-parser.sml
       signal.sml
       process.sig
       dir.sig
@@ -277,6 +277,7 @@ in
       structure Sexp
       structure Signal
       structure Stream
+      structure StreamParser
       structure String
       structure StringCvt
       structure Substring
@@ -303,7 +304,6 @@ in
       functor PolyEnv
       functor Ring
       functor RingWithIdentity
-      functor StreamParser
       functor Tree
       functor UniqueId
       functor UniqueSet

--- a/lib/mlton/basic/stream-parser.fun
+++ b/lib/mlton/basic/stream-parser.fun
@@ -208,8 +208,14 @@ fun char c s = case Stream.force (#2 s)
 fun each([]) = pure []
   | each(p::ps) = (curry (op ::)) <$> p <*> (each ps)
 
-fun string str = (String.implode <$> each (List.map((String.explode str), char))) <|>
-                 (failCut str)
+
+fun matchList s1 l2 = case (Stream.force s1, l2)
+   of (_, []) => Success ((), s1)
+    | (NONE, (_::_)) => Failure []
+    | (SOME ((h, _), r), (x :: xs)) => if h = x then matchList r xs else Failure []
+fun string str s = case matchList (#2 s) (String.explode str)
+   of Success ((), r) => Success (str, r)
+    | _ => fail str s
 
 fun info (s : state) = Success (#1 s, #2 s)
 fun location (s : state) = case Stream.force (#2 s) of

--- a/lib/mlton/basic/stream-parser.fun
+++ b/lib/mlton/basic/stream-parser.fun
@@ -1,3 +1,8 @@
+(* Copyright (C) 2017 Jason Carr.
+ *
+ * MLton is released under a BSD-style license.
+ * See the file MLton-LICENSE for details.
+ *)
 
 functor StreamParser(S: STREAM_PARSER_STRUCTS):STREAM_PARSER = 
 struct
@@ -37,9 +42,6 @@ fun indexStream({line, column}, s) =
                   indexStream({line=line, column=column+1}, r)
             )
          )
-
-
-
 
 fun doFail([]) = raise Fail("Parse error")
   | doFail([msg]) = raise Fail ("Parse error: Expected " ^ msg)
@@ -199,7 +201,7 @@ fun optional t = SOME <$> t <|> pure NONE
 
 fun char c s = case Stream.force (#2 s)
    of NONE => Failure [String.fromChar c ^ " at end of file"] 
-    | SOME((h, n), r) => 
+    | SOME((h, _), r) =>
          if h = c 
             then Success (h, r)
             else fail (String.fromChar c) s

--- a/lib/mlton/basic/stream-parser.fun
+++ b/lib/mlton/basic/stream-parser.fun
@@ -95,7 +95,7 @@ fun a <|> b = fn s => case (a s)
     | Failure err1 => (case (b s) of
         Success r => Success r
       | Failure err2 => Failure (List.append(err1, err2))
-      | FailCut err2 => Failure (List.append(err1, err2)))
+      | FailCut err2 => Failure (err2))
     | FailCut err1 => Failure err1
 fun a <&> b = fn s => case (a s) 
    of Success r => (case (b s) of
@@ -197,7 +197,7 @@ fun each([]) = pure []
   | each(p::ps) = (curry (op ::)) <$> p <*> (each ps)
 
 fun string str = (String.implode <$> each (List.map((String.explode str), char))) <|>
-                 (fail str)
+                 (failCut str)
 
 fun info (s : state) = Success (#1 s, #2 s)
 fun location (s : state) = case Stream.force (#2 s) of

--- a/lib/mlton/basic/stream-parser.fun
+++ b/lib/mlton/basic/stream-parser.fun
@@ -146,7 +146,7 @@ fun uncut p s = case p s of
 fun delay p = fn s => p () s
 
 fun next (s : state)  = case Stream.force (#2 s) 
-   of NONE => Failure []
+   of NONE => Failure ["Any character at end of file"]
     | SOME((h, _), r) => Success (h, r)
 
 fun satExpects(t, p, m) s =
@@ -195,7 +195,7 @@ fun sepBy(t, sep) = uncut ((op ::) <$$> (t, many' (sep *> t)) <|> pure [])
 fun optional t = SOME <$> t <|> pure NONE
 
 fun char c s = case Stream.force (#2 s)
-   of NONE => Failure []
+   of NONE => Failure [String.fromChar c ^ " at end of file"] 
     | SOME((h, n), r) => 
          if h = c 
             then Success (h, r)
@@ -210,7 +210,7 @@ fun string str = (String.implode <$> each (List.map((String.explode str), char))
 
 fun info (s : state) = Success (#1 s, #2 s)
 fun location (s : state) = case Stream.force (#2 s) of
-       NONE => Failure []
+       NONE => Failure ["any character end of file (location)"]
      | SOME((h, n), r) => Success (n, #2 s)
 
 fun toReader (p : 'b t) (s : state) : ('b * state) option = 

--- a/lib/mlton/basic/stream-parser.fun
+++ b/lib/mlton/basic/stream-parser.fun
@@ -215,6 +215,19 @@ fun fromReader (r : state -> ('b * state) option) (s : state) =
          Success (b, #2 s')
     | NONE => fail "fromReader" s
 
-
+fun compose (p1 : char t, p2 : 'a t) (s : state) =
+   let
+      (* easiest way to escape here *)
+      exception ComposeFail of string list
+      fun makeStr s' = case Stream.force s' of
+         NONE => Stream.empty ()
+       | SOME ((_, pos), r) =>
+            (case p1 (#1 s, s') of
+                Success (b, r) => Stream.cons((b, pos), Stream.delay (fn () => makeStr r))
+              | Failure m => raise ComposeFail m
+              | FailCut m => raise ComposeFail m)
+   in
+      p2 (#1 s, makeStr (#2 s)) handle ComposeFail m => Failure m
+   end
 
 end

--- a/lib/mlton/basic/stream-parser.fun
+++ b/lib/mlton/basic/stream-parser.fun
@@ -48,14 +48,19 @@ fun doFail([]) = raise Fail("Parse error")
   | doFail(msgs) = raise Fail ("Parse error: Expected one of \n" ^
        (String.concat(List.map(msgs, fn x => x ^ "\n\n"))))
 
-fun 'b parse(p : 'b t, s) : 'b = 
-   case p ("", indexStream({line=1, column=1}, s)) 
+fun doParse(p : 'b t, info, s) = 
+   case p (info, indexStream({line=1, column=1}, s)) 
    of Success (b, _) => b
     | Failure ms => doFail ms
     | FailCut ms => doFail ms
 
+fun 'b parse(p : 'b t, s) : 'b = 
+   doParse(p, "<input>", s)
+
 fun 'b parseWithFile(p : 'b t, f, s) : 'b =
-   parse(p, s)
+   doParse(p, f, s)
+
+
 
 fun pure a (s : state)  =
   Success (a, #2 s)

--- a/lib/mlton/basic/stream-parser.fun
+++ b/lib/mlton/basic/stream-parser.fun
@@ -169,7 +169,7 @@ fun failing p s =
        | _ => Success ((), #2 s)
       
 fun notFollowedBy(p, c) =
-   fst <$> p <*> (peek (failing c))
+   p <* failing c
 
 fun any'([]) s = Failure []
   | any'(p::ps) s =
@@ -188,6 +188,9 @@ fun 'b many' (t : 'b t) s = case ((op ::) <$$> (t, fn s' => many' t s')) s of
   | FailCut z => FailCut z
 fun 'b many t = uncut (many' t)
 fun 'b many1 (t : 'b t) = uncut ((op ::) <$$> (t, many' t))
+
+fun manyFailing(p, f) = many (failing f *> p)
+fun manyCharsFailing f = many (failing f *> next)
 
 fun sepBy1(t, sep) = uncut ((op ::) <$$> (t, many' (sep *> t)))
 fun sepBy(t, sep) = uncut ((op ::) <$$> (t, many' (sep *> t)) <|> pure [])

--- a/lib/mlton/basic/stream-parser.sig
+++ b/lib/mlton/basic/stream-parser.sig
@@ -1,3 +1,9 @@
+(* Copyright (C) 2017 Jason Carr.
+ *
+ * MLton is released under a BSD-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
 signature STREAM_PARSER_STRUCTS = 
     sig
       structure Stream: STREAM
@@ -26,12 +32,17 @@ signature STREAM_PARSER =
       val >>= : 'a t * ('a -> 'b t) -> 'b t
       val <*> : ('b -> 'c) t * 'b t -> 'c t
       val <$> : ('b -> 'c) * 'b t -> 'c t
+      (* replace the result of a parser witih a constant *)
       val <$ : 'c * 'b t -> 'c t
+      (* map over pairs of parsers, joining their results together *)
       val <$$> : ('b * 'c -> 'd) * ('b t * 'c t) -> 'd t
       val <$$$> : ('b * 'c * 'd -> 'e) * ('b t * 'c t * 'd t) -> 'e t
+      (* match both parsers, and discard the right or left result respectively *)
       val <* : 'b t * 'c t -> 'b t
       val *> : 'b t * 'c t -> 'c t
+      (* try both parsers, take the result of the first success *)
       val <|> : 'b t * 'b t -> 'b t 
+      (* try both parsers, fail if either fails, or take the last success *)
       val <&> : 'b t * 'b t -> 'b t 
       structure Ops : sig
          val >>= : 'a t * ('a -> 'b t) -> 'b t

--- a/lib/mlton/basic/stream-parser.sig
+++ b/lib/mlton/basic/stream-parser.sig
@@ -76,6 +76,10 @@ signature STREAM_PARSER =
       val many: 'b t -> 'b list t
       (* as many, but one or more, rather than zero or more times *)
       val many1: 'b t -> 'b list t
+      (* as many, but with failures of the second parser before each parse from the first *)
+      val manyFailing: ('b t * 'c t) -> 'b list t
+      (* manyFailing, specialized to the case that p is next *)
+      val manyCharsFailing: 'b t -> char list t
       (* gets the next char of input *)
       val next: char t
       (* succeeds if the first parser succeeds and the second fails 

--- a/lib/mlton/basic/stream-parser.sig
+++ b/lib/mlton/basic/stream-parser.sig
@@ -4,7 +4,7 @@
  * See the file MLton-LICENSE for details.
  *)
 
-signature STREAM_PARSER = 
+signature STREAM_PARSER =
    sig
       type 'a t
       structure State:
@@ -26,7 +26,7 @@ signature STREAM_PARSER =
       (*
        * infix 1 <|> >>=
        * infix 2 <&>
-       * infix  3 <*> <* *> 
+       * infix  3 <*> <* *>
        * infixr 4 <$> <$$> <$$$> <$
        *)
       val >>= : 'a t * ('a -> 'b t) -> 'b t
@@ -41,9 +41,9 @@ signature STREAM_PARSER =
       val <* : 'a t * 'b t -> 'a t
       val *> : 'a t * 'b t -> 'b t
       (* try both parsers, take the result of the first success *)
-      val <|> : 'a t * 'a t -> 'a t 
+      val <|> : 'a t * 'a t -> 'a t
       (* try both parsers, fail if either fails, or take the last success *)
-      val <&> : 'a t * 'a t -> 'a t 
+      val <&> : 'a t * 'a t -> 'a t
       structure Ops : sig
          val >>= : 'a t * ('a -> 'b t) -> 'b t
          val <*> : ('a -> 'b) t * 'a t -> 'b t
@@ -53,29 +53,29 @@ signature STREAM_PARSER =
          val <$$$> : ('a * 'b * 'c -> 'd) * ('a t * 'b t * 'c t) -> 'd t
          val <* : 'a t * 'b t -> 'a t
          val *> : 'a t * 'b t -> 'b t
-         val <|> : 'a t * 'a t -> 'a t 
-         val <&> : 'a t * 'a t -> 'a t 
+         val <|> : 'a t * 'a t -> 'a t
+         val <&> : 'a t * 'a t -> 'a t
       end
 
       val pure: 'a -> 'a t
       (* succeeds if any of the parsers succeed *)
-      val any: 'a t list -> 'a t 
+      val any: 'a t list -> 'a t
       (* matches the given character *)
       val char: char -> char t
       (* composes two parsers in turn, the characters used for the second come
        * from the first *)
       val compose : char t * 'a t -> 'a t
       (* if the parser fails, it will fail as a cut *)
-      val cut: 'a t -> 'a t 
+      val cut: 'a t -> 'a t
       (* delays a stream lazily, for recursive combinations *)
       val delay: (unit -> 'a t) -> 'a t
       (* succeeds if all of the parsers succeed and combines their results *)
-      val each: 'a t list -> 'a list t 
+      val each: 'a t list -> 'a list t
       (* fail with a specified error message *)
       val fail: string -> 'a t
       (* as fail, but also cuts at the next choice point *)
       val failCut: string -> 'a t
-      (* succeeds if and only if its argument fails to parse*)
+      (* succeeds if and only if its argument fails to parse *)
       val failing: 'a t -> unit t
       (* return the parser representation of a given reader *)
       val fromReader: (State.t -> ('a * State.t) option)-> 'a t
@@ -93,18 +93,18 @@ signature STREAM_PARSER =
       val manyCharsFailing: 'a t -> char list t
       (* gets the next char of input *)
       val next: char t
-      (* succeeds if the first parser succeeds and the second fails 
+      (* succeeds if the first parser succeeds and the second fails
        * the second parser will never consume any input *)
       val notFollowedBy: 'a t * 'b t -> 'a t
       (* succeeds with SOME if the parser succeeded and NONE otherwise *)
       val optional: 'a t -> 'a option t
       (* run a parser but consume no input *)
       val peek: 'a t -> 'a t
-      (* succeeds if the parser succeeded with an input that passed the predicate*) 
+      (* succeeds if the parser succeeded with an input that passed the predicate *)
       val sat: 'a t * ('a -> bool) -> 'a t
-      (* as many, but an instance of the second parser separates each instance*)
+      (* as many, but an instance of the second parser separates each instance *)
       val sepBy: 'a t * 'b t -> 'a list t
-      (* as many1, but an instance of the second parser separates each instance*)
+      (* as many1, but an instance of the second parser separates each instance *)
       val sepBy1: 'a t * 'b t -> 'a list t
       (* matches the given string *)
       val string: string -> string t

--- a/lib/mlton/basic/stream-parser.sig
+++ b/lib/mlton/basic/stream-parser.sig
@@ -49,45 +49,48 @@ signature STREAM_PARSER =
 
       (* succeeds if any of the parsers succeed, effectively folding with <|> *)
       val any: 'b t list -> 'b t 
+      (* matches the given character *)
+      val char: char -> char t
+      (* if the parser fails, it will fail as a cut *)
+      val cut: 'b t -> 'b t 
       (* delays a stream lazily, for recursive combinations *)
       val delay: (unit -> 'b t) -> 'b t
       (* succeeds if all of the parsers succeed and puts them together in a list*)
       val each: 'b t list -> 'b list t 
-      (* run a parser but consume no input *)
-      val peek: 'b t -> 'b t
-      (* gets the next char of input *)
-      val next: char t
-      (* suceeds if the parser suceeded with an input that passed the predicate*) 
-      val sat: 'b t * ('b -> bool) -> 'b t
-      (* succeeds if and only if its argument fails to parse*)
-      val failing: 'b t -> unit t
-      (* succeeds if the first parser succeeds and the second fails 
-       * the second parser will never consume any input *)
-      val notFollowedBy: 'b t * 'c t -> 'b t
-      (* succeeds for each time the parser succeeds in succession *)
-      val many: 'b t -> 'b list t
-      (* as many, but one or more, rather than zero or more times *)
-      val many1: 'b t -> 'b list t
-      (* as many, but an instance of the second parser separates each instance*)
-      val sepBy: 'b t * 'c t -> 'b list t
-      (* as many1, but an instance of the second parser separates each instance*)
-      val sepBy1: 'b t * 'c t -> 'b list t
-      (* suceed with SOME if the parser succeeded and NONE otherwise *)
-      val optional: 'b t -> 'b option t
       (* fail with a specified error message *)
       val fail: string -> 'b t
-      (* matches the given character *)
-      val char: char -> char t
-      (* matches the given string *)
-      val string: string -> string t
+      (* as fail, but also cuts at the next choice point *)
+      val failCut: string -> 'b t
+      (* succeeds if and only if its argument fails to parse*)
+      val failing: 'b t -> unit t
+      (* return the parser representation of a given reader *)
+      val fromReader: (state -> ('b * state) option)-> 'b t
       (* returns the info for the parse, usually a filename *)
       val info: info t
       (* returns the current source location of the parser *)
       val location: location t
-      (* returns a reader representation of the parser. This and fromReader below
-       * expose a few internals, but it's hardly more than is already usable *)
+      (* succeeds for each time the parser succeeds in succession *)
+      val many: 'b t -> 'b list t
+      (* as many, but one or more, rather than zero or more times *)
+      val many1: 'b t -> 'b list t
+      (* gets the next char of input *)
+      val next: char t
+      (* succeeds if the first parser succeeds and the second fails 
+       * the second parser will never consume any input *)
+      val notFollowedBy: 'b t * 'c t -> 'b t
+      (* succeeds with SOME if the parser succeeded and NONE otherwise *)
+      val optional: 'b t -> 'b option t
+      (* run a parser but consume no input *)
+      val peek: 'b t -> 'b t
+      (* succeeds if the parser succeeded with an input that passed the predicate*) 
+      val sat: 'b t * ('b -> bool) -> 'b t
+      (* as many, but an instance of the second parser separates each instance*)
+      val sepBy: 'b t * 'c t -> 'b list t
+      (* as many1, but an instance of the second parser separates each instance*)
+      val sepBy1: 'b t * 'c t -> 'b list t
+      (* matches the given string *)
+      val string: string -> string t
+      (* returns a reader representation of the parser *)
       val toReader: 'b t -> state -> ('b * state) option
-      (* return the parser representation of a given reader *)
-      val fromReader: (state -> ('b * state) option)-> 'b t
 
    end

--- a/lib/mlton/basic/stream-parser.sig
+++ b/lib/mlton/basic/stream-parser.sig
@@ -51,6 +51,9 @@ signature STREAM_PARSER =
       val any: 'b t list -> 'b t 
       (* matches the given character *)
       val char: char -> char t
+      (* composes two parsers in turn, the characters used for the second come
+       * from the first *)
+      val compose : char t * 'b t -> 'b t
       (* if the parser fails, it will fail as a cut *)
       val cut: 'b t -> 'b t 
       (* delays a stream lazily, for recursive combinations *)

--- a/lib/mlton/basic/stream-parser.sig
+++ b/lib/mlton/basic/stream-parser.sig
@@ -15,7 +15,6 @@ signature STREAM_PARSER =
       type info = string
       val parse: 'b t * char Stream.t -> 'b
       val parseWithFile: 'b t * File.t * char Stream.t -> 'b
-      exception Parse of string
 
       val pure: 'b -> 'b t
       (*

--- a/lib/mlton/basic/stream.sig
+++ b/lib/mlton/basic/stream.sig
@@ -1,4 +1,5 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2017 Jason Carr.
+ * Copyright (C) 2009 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *

--- a/lib/mlton/basic/stream.sig
+++ b/lib/mlton/basic/stream.sig
@@ -25,6 +25,7 @@ signature STREAM =
       val firstN: 'a t * int -> 'a list
       val firstNSafe: 'a t * int -> 'a list
       val force: 'a t -> ('a * 'a t) option
+      val fromList: 'a list -> 'a t
       val infinite: 'a * ('a -> 'a) -> 'a t
       val isEmpty: 'a t -> bool
       val keep: 'a t * ('a -> bool) -> 'a t
@@ -34,5 +35,4 @@ signature STREAM =
       val nth: 'a t * int -> 'a
       val single: 'a -> 'a t
       val toList: 'a t -> 'a list
-      val fromList: 'a list -> 'a t
    end

--- a/lib/mlton/basic/stream.sml
+++ b/lib/mlton/basic/stream.sml
@@ -57,9 +57,11 @@ fun toList (s) =
       NONE => []
     | SOME (x, s) => x :: toList s
 
-fun fromList ([]) = empty ()
-  | fromList (x::xs) =
-       cons (x, delay (fn () => fromList xs))
+fun fromList l =
+   case l of
+      [] => empty ()
+    | x::xs =>
+         cons (x, delay (fn () => fromList xs))
 
 fun last (s) =
    let

--- a/lib/mlton/basic/stream.sml
+++ b/lib/mlton/basic/stream.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Jason Carr
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a BSD-style license.

--- a/lib/mlton/sources.cm
+++ b/lib/mlton/sources.cm
@@ -27,9 +27,9 @@ signature REAL
 signature RING
 signature RING_WITH_IDENTITY
 signature SET
-signature STRING
 signature STREAM
 signature STREAM_PARSER
+signature STRING
 signature SUM
 signature T
 signature UNIQUE_ID

--- a/lib/mlton/sources.cm
+++ b/lib/mlton/sources.cm
@@ -128,6 +128,7 @@ structure Signal
 structure SMLofNJ
 structure Socket
 structure Stream
+structure StreamParser
 structure String
 structure StringCvt
 structure Substring
@@ -175,7 +176,6 @@ functor PolyEnv
 functor Ring
 functor RingWithIdentity
 (* functor SplayMonoEnv *)
-functor StreamParser
 functor Sum
 functor Tree
 functor UniqueId

--- a/lib/mlton/sources.mlb
+++ b/lib/mlton/sources.mlb
@@ -30,9 +30,9 @@ ann "forceUsed" in
       signature RING
       signature RING_WITH_IDENTITY
       signature SET
-      signature STRING
       signature STREAM
       signature STREAM_PARSER
+      signature STRING
       signature T
       signature UNIQUE_ID
       signature VECTOR

--- a/lib/mlton/sources.mlb
+++ b/lib/mlton/sources.mlb
@@ -109,6 +109,7 @@ ann "forceUsed" in
       structure Signal
       structure SMLofNJ
       structure Stream
+      structure StreamParser
       structure String
       structure StringCvt
       structure Substring
@@ -139,7 +140,6 @@ ann "forceUsed" in
       functor PolyEnv
       functor Ring
       functor RingWithIdentity
-      functor StreamParser
       functor Tree
       functor UniqueId
       functor UniqueSet

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -87,7 +87,7 @@ structure Type =
                   var = fn a => (Tyvar.layout a,
                                  ({isChar = false},
                                   Tycon.BindingStrength.unit))})
-      
+
       fun layout(ty: t): Layout.t =
          hom {con = Tycon.layoutApp,
               ty = ty,

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -88,7 +88,7 @@ structure Type =
                                  ({isChar = false},
                                   Tycon.BindingStrength.unit))})
 
-      fun layout(ty: t): Layout.t =
+      fun layout (ty: t): Layout.t =
          hom {con = Tycon.layoutApp,
               ty = ty,
               var = Tyvar.layout}

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -82,18 +82,16 @@ structure Type =
       fun equals (t, t'): bool = PropertyList.equals (plist t, plist t')
 
       fun layout (ty: t): Layout.t =
-         #1 (hom {con = Tycon.layoutApp,
+         #1 (hom {con = Tycon.layoutAppPretty,
                   ty = ty,
                   var = fn a => (Tyvar.layout a,
                                  ({isChar = false},
                                   Tycon.BindingStrength.unit))})
       
       fun layoutFormal(ty: t): Layout.t =
-         #1 (hom {con = Tycon.layoutFormal,
-                  ty = ty,
-                  var = fn a => (Tyvar.layout a,
-                                 ({isChar = false},
-                                  Tycon.BindingStrength.unit))})
+         hom {con = Tycon.layoutApp,
+              ty = ty,
+              var = Tyvar.layout}
 
       local
          val same: tree * tree -> bool =

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -81,14 +81,14 @@ structure Type =
 
       fun equals (t, t'): bool = PropertyList.equals (plist t, plist t')
 
-      fun layout (ty: t): Layout.t =
+      fun layoutPretty (ty: t): Layout.t =
          #1 (hom {con = Tycon.layoutAppPretty,
                   ty = ty,
                   var = fn a => (Tyvar.layout a,
                                  ({isChar = false},
                                   Tycon.BindingStrength.unit))})
       
-      fun layoutFormal(ty: t): Layout.t =
+      fun layout(ty: t): Layout.t =
          hom {con = Tycon.layoutApp,
               ty = ty,
               var = Tyvar.layout}

--- a/mlton/atoms/hash-type.sig
+++ b/mlton/atoms/hash-type.sig
@@ -42,7 +42,7 @@ signature HASH_TYPE =
                 con: Tycon.t * 'a vector -> 'a} -> 'a
       val isUnit: t -> bool
       val layout: t -> Layout.t
-      val layoutFormal: t -> Layout.t
+      val layoutPretty: t -> Layout.t
       val makeHom:
          {var: t * Tyvar.t -> 'a,
           con: t * Tycon.t * 'a vector -> 'a}

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -29,7 +29,7 @@ local
    fun make s = (s, fromString s)
 in
    val array = make "array"
-   val arrow = make "->"
+   val arrow = make "arrow"
    val bool = make "bool" 
    val cpointer = make "cpointer"
    val exn = make "exn"
@@ -37,7 +37,7 @@ in
    val list = make "list"
    val reff = make "ref"
    val thread = make "thread"
-   val tuple = make "*"
+   val tuple = make "tuple"
    val vector = make "vector"
    val weak = make "weak"
 end
@@ -243,19 +243,17 @@ fun layoutApp (c: t, args: Layout.t vector) =
          val seq = seq
          val str = str
       end
+      val con =
+         if equals (c, tuple) andalso Vector.isEmpty args
+            then str "unit"
+            else (case List.peekMap (prims, fn {name, tycon, ...} =>
+                                     if equals (c, tycon) then SOME name else NONE) of
+                     SOME name => str name
+                   | _ => layout c)
       val args =
          if Vector.isEmpty args
             then empty
             else seq [Layout.tuple (Vector.toList args), str " "]
-      val con =
-         if equals (c, arrow)
-            then str "arrow"
-         else if equals (c, tuple)
-            then if Layout.isEmpty args then str "unit" else str "tuple"
-         else (case List.peekMap (prims, fn {name, tycon, ...} =>
-                                  if equals (c, tycon) then SOME name else NONE) of
-                  SOME name => str name
-                | _ => layout c)
    in
       seq [args, con]
    end

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -174,8 +174,8 @@ val isIntX = fn c => equals (c, intInf) orelse isIntX c
 val deIntX = fn c => if equals (c, intInf) then NONE else SOME (deIntX c)
 
 fun layoutAppPretty (c: t,
-               args: (Layout.t * ({isChar: bool}
-                                  * BindingStrength.t)) vector) =
+                     args: (Layout.t * ({isChar: bool}
+                                        * BindingStrength.t)) vector) =
    let
       local
          open Layout

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -248,12 +248,39 @@ fun layoutFormal (c: t, args: (Layout.t * ({isChar: bool}* BindingStrength.t)) v
          case Vector.length args of
             0 => if equals (c, tuple)
                     then (({isChar = false}, str "unit"))
-                    else ({isChar = equals (c, defaultChar ())}, layout c)
+                 else
+                    ({isChar = equals (c, defaultChar ())},
+                     (* always use canonical names, even if synonyms exist *)
+                     if equals (c, real RealSize.R32)
+                        then str "real32"
+                     else if equals(c, real RealSize.R64)
+                        then str "real64"
+                     else if equals(c, word WordSize.word8)
+                        then str "word8"
+                     else if equals(c, word WordSize.word16)
+                        then str "word16"
+                     else if equals(c, word WordSize.word32)
+                        then str "word32"
+                     else if equals(c, word WordSize.word64)
+                        then str "word64"
+                     else if equals(c, intInf)
+                        then str "intInf"
+                     else if equals(c, bool)
+                        then str "bool"
+                     else layout c)
           | 1 => ({isChar = false},
                    seq [(Layout.paren o #1) (Vector.sub (args, 0)),
                    str " ", 
                       if equals (c, tuple)
                          then str "tuple"  
+                      else if equals(c, vector)
+                         then str "vector"
+                      else if equals(c, array)
+                         then str "array"
+                      else if equals(c, reff)
+                         then str "ref"
+                      else if equals(c, weak)
+                         then str "weak"
                          else layout c])
           | _ => ({isChar = false},
                    seq [Layout.tuple

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -238,7 +238,6 @@ fun layoutApp (c: t, args: Layout.t vector) =
    let
       local
          open Layout
-         open BindingStrength
       in
          val seq = seq
          val str = str

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -258,9 +258,9 @@ fun layoutApp (c: t, args: Layout.t vector) =
                | NONE => layout c)
        | 1 =>
               seq [Layout.paren (Vector.first args),
-                 str " ", 
+                 str " ",
                     if equals (c, tuple)
-                       then str "tuple"  
+                       then str "tuple"
                     else if equals(c, vector)
                        then str "vector"
                     else if equals(c, array)
@@ -270,10 +270,10 @@ fun layoutApp (c: t, args: Layout.t vector) =
                     else if equals(c, weak)
                        then str "weak"
                     else layout c]
-          | _ => 
-              seq 
+          | _ =>
+              seq
                  [Layout.tuple (Vector.toList args),
-                  str " ", 
+                  str " ",
                      if equals (c, tuple)
                         then str "tuple"
                      else if equals (c, arrow)

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -173,7 +173,7 @@ val isCPointer = fn c => equals (c, cpointer)
 val isIntX = fn c => equals (c, intInf) orelse isIntX c
 val deIntX = fn c => if equals (c, intInf) then NONE else SOME (deIntX c)
 
-fun layoutApp (c: t,
+fun layoutAppPretty (c: t,
                args: (Layout.t * ({isChar: bool}
                                   * BindingStrength.t)) vector) =
    let
@@ -234,64 +234,44 @@ fun layoutApp (c: t,
       else normal ()
    end
 
-fun layoutFormal (c: t, args: (Layout.t * ({isChar: bool}* BindingStrength.t)) vector) =
+fun layoutApp (c: t, args: Layout.t vector) =
    let
       local
          open Layout
          open BindingStrength
       in
-         val mayAlign = mayAlign
          val seq = seq
          val str = str
       end
-      val ({isChar}, lay) =
-         case Vector.length args of
-            0 => if equals (c, tuple)
-                    then (({isChar = false}, str "unit"))
-                 else
-                    ({isChar = equals (c, defaultChar ())},
-                     (* always use canonical names, even if synonyms exist *)
-                     if equals (c, real RealSize.R32)
-                        then str "real32"
-                     else if equals(c, real RealSize.R64)
-                        then str "real64"
-                     else if equals(c, word WordSize.word8)
-                        then str "word8"
-                     else if equals(c, word WordSize.word16)
-                        then str "word16"
-                     else if equals(c, word WordSize.word32)
-                        then str "word32"
-                     else if equals(c, word WordSize.word64)
-                        then str "word64"
-                     else if equals(c, intInf)
-                        then str "intInf"
-                     else if equals(c, bool)
-                        then str "bool"
-                     else layout c)
-          | 1 => ({isChar = false},
-                   seq [(Layout.paren o #1) (Vector.sub (args, 0)),
-                   str " ", 
-                      if equals (c, tuple)
-                         then str "tuple"  
-                      else if equals(c, vector)
-                         then str "vector"
-                      else if equals(c, array)
-                         then str "array"
-                      else if equals(c, reff)
-                         then str "ref"
-                      else if equals(c, weak)
-                         then str "weak"
-                         else layout c])
-          | _ => ({isChar = false},
-                   seq [Layout.tuple
-                   (Vector.toListMap (args, #1)),
-                    str " ", 
-                       if equals (c, tuple)
-                          then str "tuple"
-                       else if equals (c, arrow)
-                         then str "arrow"
-                       else layout c])
-         in
-            (lay, ({isChar = isChar}, BindingStrength.unit))
-         end
+   in
+      case Vector.length args of
+         0 => if equals (c, tuple) 
+                 then str "unit"
+              else
+                 layout c
+       | 1 =>
+              seq [Layout.paren (Vector.first args),
+                 str " ", 
+                    if equals (c, tuple)
+                       then str "tuple"  
+                    else if equals(c, vector)
+                       then str "vector"
+                    else if equals(c, array)
+                       then str "array"
+                    else if equals(c, reff)
+                       then str "ref"
+                    else if equals(c, weak)
+                       then str "weak"
+                    else layout c]
+          | _ => 
+              seq 
+                 [Layout.tuple (Vector.toList args),
+                  str " ", 
+                     if equals (c, tuple)
+                        then str "tuple"
+                     else if equals (c, arrow)
+                        then str "arrow"
+                     else layout c]
+   end
 end
+

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -245,10 +245,17 @@ fun layoutApp (c: t, args: Layout.t vector) =
       end
    in
       case Vector.length args of
-         0 => if equals (c, tuple) 
-                 then str "unit"
-              else
-                 layout c
+         0 => (case List.peekMap
+                 ([(fn c => equals(c, tuple), fn _ => "unit"),
+                   (fn c => equals(c, intInf), fn _ => "intInf"),
+                   (fn c => equals(c, bool), fn _ => "bool"),
+                   (isWordX, fn w => "word" ^ (WordSize.toString (deWordX w))),
+                   (isRealX, fn w => "real" ^ (RealSize.toString (deRealX w))),
+                   (fn c => equals(c, exn), fn _ => "exn"),
+                   (fn c => equals(c, thread), fn _ => "thread")],
+                  fn (test, toStr) => if test c then SOME (toStr c) else NONE)
+              of SOME s => str s
+               | NONE => layout c)
        | 1 =>
               seq [Layout.paren (Vector.first args),
                  str " ", 

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -180,6 +180,7 @@ fun layoutAppPretty (c: t,
       local
          open Layout
       in
+         val mayAlign = mayAlign
          val seq = seq
          val str = str
       end

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -180,7 +180,6 @@ fun layoutAppPretty (c: t,
       local
          open Layout
       in
-         val mayAlign = mayAlign
          val seq = seq
          val str = str
       end

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -239,45 +239,25 @@ fun layoutApp (c: t, args: Layout.t vector) =
       local
          open Layout
       in
+         val empty = empty
          val seq = seq
          val str = str
       end
+      val args =
+         if Vector.isEmpty args
+            then empty
+            else seq [Layout.tuple (Vector.toList args), str " "]
+      val con =
+         if equals (c, arrow)
+            then str "arrow"
+         else if equals (c, tuple)
+            then if Layout.isEmpty args then str "unit" else str "tuple"
+         else (case List.peekMap (prims, fn {name, tycon, ...} =>
+                                  if equals (c, tycon) then SOME name else NONE) of
+                  SOME name => str name
+                | _ => layout c)
    in
-      case Vector.length args of
-         0 => (case List.peekMap
-                 ([(fn c => equals(c, tuple), fn _ => "unit"),
-                   (fn c => equals(c, intInf), fn _ => "intInf"),
-                   (fn c => equals(c, bool), fn _ => "bool"),
-                   (isWordX, fn w => "word" ^ (WordSize.toString (deWordX w))),
-                   (isRealX, fn w => "real" ^ (RealSize.toString (deRealX w))),
-                   (fn c => equals(c, exn), fn _ => "exn"),
-                   (fn c => equals(c, thread), fn _ => "thread")],
-                  fn (test, toStr) => if test c then SOME (toStr c) else NONE)
-              of SOME s => str s
-               | NONE => layout c)
-       | 1 =>
-              seq [Layout.paren (Vector.first args),
-                 str " ",
-                    if equals (c, tuple)
-                       then str "tuple"
-                    else if equals(c, vector)
-                       then str "vector"
-                    else if equals(c, array)
-                       then str "array"
-                    else if equals(c, reff)
-                       then str "ref"
-                    else if equals(c, weak)
-                       then str "weak"
-                    else layout c]
-          | _ =>
-              seq
-                 [Layout.tuple (Vector.toList args),
-                  str " ",
-                     if equals (c, tuple)
-                        then str "tuple"
-                     else if equals (c, arrow)
-                        then str "arrow"
-                     else layout c]
+      seq [args, con]
    end
-end
 
+end

--- a/mlton/atoms/prim-tycons.sig
+++ b/mlton/atoms/prim-tycons.sig
@@ -68,7 +68,7 @@ signature PRIM_TYCONS =
       val layoutAppPretty:
          tycon * (Layout.t * ({isChar: bool} * BindingStrength.t)) vector
          -> Layout.t * ({isChar: bool} * BindingStrength.t)
-      val layoutApp: tycon * Layout.t vector -> Layout.t 
+      val layoutApp: tycon * Layout.t vector -> Layout.t
       val list: tycon
       val prims: {admitsEquality: AdmitsEquality.t,
                   kind: Kind.t,

--- a/mlton/atoms/prim-tycons.sig
+++ b/mlton/atoms/prim-tycons.sig
@@ -65,10 +65,10 @@ signature PRIM_TYCONS =
       val isIntX: tycon -> bool
       val isRealX: tycon -> bool
       val isWordX: tycon -> bool
+      val layoutApp: tycon * Layout.t vector -> Layout.t
       val layoutAppPretty:
          tycon * (Layout.t * ({isChar: bool} * BindingStrength.t)) vector
          -> Layout.t * ({isChar: bool} * BindingStrength.t)
-      val layoutApp: tycon * Layout.t vector -> Layout.t
       val list: tycon
       val prims: {admitsEquality: AdmitsEquality.t,
                   kind: Kind.t,

--- a/mlton/atoms/prim-tycons.sig
+++ b/mlton/atoms/prim-tycons.sig
@@ -65,12 +65,10 @@ signature PRIM_TYCONS =
       val isIntX: tycon -> bool
       val isRealX: tycon -> bool
       val isWordX: tycon -> bool
-      val layoutApp:
+      val layoutAppPretty:
          tycon * (Layout.t * ({isChar: bool} * BindingStrength.t)) vector
          -> Layout.t * ({isChar: bool} * BindingStrength.t)
-      val layoutFormal:
-         tycon * (Layout.t * ({isChar: bool} * BindingStrength.t)) vector
-         -> Layout.t * ({isChar: bool} * BindingStrength.t)
+      val layoutApp: tycon * Layout.t vector -> Layout.t 
       val list: tycon
       val prims: {admitsEquality: AdmitsEquality.t,
                   kind: Kind.t,

--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -357,13 +357,13 @@ fun toString (n: 'a t): string =
    end
 
 fun layout p = Layout.str (toString p)
-fun layoutFull layoutX (FFI f) = Layout.seq [Layout.str "FFI ", CFunction.layout(f, layoutX)]
-  | layoutFull _ (FFI_Symbol {name, cty, symbolScope}) =
+fun layoutFull (FFI f, layoutX) = Layout.seq [Layout.str "FFI ", CFunction.layout(f, layoutX)]
+  | layoutFull (FFI_Symbol {name, cty, symbolScope}, _) =
        Layout.seq[Layout.str "FFI_Symbol ", Layout.record
        [("name", Layout.str name),
         ("cty", Option.layout CType.layout cty),
         ("symbolScope", CFunction.SymbolScope.layout symbolScope)]]
-  | layoutFull _ p = layout p
+  | layoutFull (p, _) = layout p
 
 val equals: 'a t * 'a t -> bool =
    fn (Array_length, Array_length) => true

--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -357,13 +357,16 @@ fun toString (n: 'a t): string =
    end
 
 fun layout p = Layout.str (toString p)
-fun layoutFull (FFI f, layoutX) = Layout.seq [Layout.str "FFI ", CFunction.layout(f, layoutX)]
-  | layoutFull (FFI_Symbol {name, cty, symbolScope}, _) =
-       Layout.seq[Layout.str "FFI_Symbol ", Layout.record
-       [("name", Layout.str name),
-        ("cty", Option.layout CType.layout cty),
-        ("symbolScope", CFunction.SymbolScope.layout symbolScope)]]
-  | layoutFull (p, _) = layout p
+fun layoutFull (p, layoutX) =
+   case p of
+      FFI f => Layout.seq [Layout.str "FFI ", CFunction.layout (f, layoutX)]
+    | FFI_Symbol {name, cty, symbolScope} =>
+         Layout.seq [Layout.str "FFI_Symbol ",
+                     Layout.record
+                     [("name", Layout.str name),
+                      ("cty", Option.layout CType.layout cty),
+                      ("symbolScope", CFunction.SymbolScope.layout symbolScope)]]
+    | p => layout p
 
 val equals: 'a t * 'a t -> bool =
    fn (Array_length, Array_length) => true

--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -357,6 +357,13 @@ fun toString (n: 'a t): string =
    end
 
 fun layout p = Layout.str (toString p)
+fun layoutFull layoutX (FFI f) = Layout.seq [Layout.str "FFI ", CFunction.layout(f, layoutX)]
+  | layoutFull layoutX (FFI_Symbol {name, cty, symbolScope}) =
+       Layout.seq[Layout.str "FFI_Symbol ", Layout.record
+       [("name", Layout.str name),
+        ("cty", Option.layout CType.layout cty),
+        ("symbolScope", CFunction.SymbolScope.layout symbolScope)]]
+  | layoutFull layoutX p = layout p
 
 val equals: 'a t * 'a t -> bool =
    fn (Array_length, Array_length) => true

--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -358,12 +358,12 @@ fun toString (n: 'a t): string =
 
 fun layout p = Layout.str (toString p)
 fun layoutFull layoutX (FFI f) = Layout.seq [Layout.str "FFI ", CFunction.layout(f, layoutX)]
-  | layoutFull layoutX (FFI_Symbol {name, cty, symbolScope}) =
+  | layoutFull _ (FFI_Symbol {name, cty, symbolScope}) =
        Layout.seq[Layout.str "FFI_Symbol ", Layout.record
        [("name", Layout.str name),
         ("cty", Option.layout CType.layout cty),
         ("symbolScope", CFunction.SymbolScope.layout symbolScope)]]
-  | layoutFull layoutX p = layout p
+  | layoutFull _ p = layout p
 
 val equals: 'a t * 'a t -> bool =
    fn (Array_length, Array_length) => true

--- a/mlton/atoms/prim.sig
+++ b/mlton/atoms/prim.sig
@@ -274,6 +274,7 @@ signature PRIM =
        *)
       val isFunctional: 'a t -> bool
       val layout: 'a t -> Layout.t
+      val layoutFull: ('a -> Layout.t) -> 'a t -> Layout.t
       val layoutApp: 'a t * 'b vector * ('b -> Layout.t) -> Layout.t
       val map: 'a t * ('a -> 'b) -> 'b t
       (* examples: Word_addCheck, Word_mulCheck, Word_subCheck *)

--- a/mlton/atoms/prim.sig
+++ b/mlton/atoms/prim.sig
@@ -274,8 +274,8 @@ signature PRIM =
        *)
       val isFunctional: 'a t -> bool
       val layout: 'a t -> Layout.t
-      val layoutFull: 'a t * ('a -> Layout.t) -> Layout.t
       val layoutApp: 'a t * 'b vector * ('b -> Layout.t) -> Layout.t
+      val layoutFull: 'a t * ('a -> Layout.t) -> Layout.t
       val map: 'a t * ('a -> 'b) -> 'b t
       (* examples: Word_addCheck, Word_mulCheck, Word_subCheck *)
       val mayOverflow: 'a t -> bool

--- a/mlton/atoms/prim.sig
+++ b/mlton/atoms/prim.sig
@@ -274,7 +274,7 @@ signature PRIM =
        *)
       val isFunctional: 'a t -> bool
       val layout: 'a t -> Layout.t
-      val layoutFull: ('a -> Layout.t) -> 'a t -> Layout.t
+      val layoutFull: 'a t * ('a -> Layout.t) -> Layout.t
       val layoutApp: 'a t * 'b vector * ('b -> Layout.t) -> Layout.t
       val map: 'a t * ('a -> 'b) -> 'b t
       (* examples: Word_addCheck, Word_mulCheck, Word_subCheck *)

--- a/mlton/elaborate/elaborate-env.fun
+++ b/mlton/elaborate/elaborate-env.fun
@@ -84,7 +84,7 @@ structure Type =
             fun con (c, ts) =
                let
                   fun keep {showInside: bool} =
-                     Tycon.layoutApp
+                     Tycon.layoutAppPretty
                      (c, Vector.map (ts, fn t =>
                                      if showInside
                                         then
@@ -134,7 +134,7 @@ structure Type =
                              ({isChar = false}, Tycon.BindingStrength.unit))
                          end
                     | SOME v =>
-                         Tycon.layoutApp
+                         Tycon.layoutAppPretty
                          (Tycon.tuple,
                           Vector.map (v, fn NONE => wild | SOME t => t)))
             val exp =

--- a/mlton/elaborate/interface.fun
+++ b/mlton/elaborate/interface.fun
@@ -188,7 +188,7 @@ structure Tycon =
       fun layoutApp (t: t, v) =
          case t of
             Flexible f => FlexibleTycon.layoutApp (f, v)
-          | Rigid (c, _) => Etycon.layoutApp (c, v)
+          | Rigid (c, _) => Etycon.layoutAppPretty (c, v)
 
       val tuple = Rigid (Etycon.tuple, Kind.Nary)
    end

--- a/mlton/elaborate/interface.sig
+++ b/mlton/elaborate/interface.sig
@@ -24,7 +24,7 @@ signature INTERFACE_STRUCTS =
                   val equals: t * t -> bool
                   val exn: t
                   val layout: t -> Layout.t
-                  val layoutApp:
+                  val layoutAppPretty:
                      t * (Layout.t
                           * ({isChar: bool} * BindingStrength.t)) vector
                      -> Layout.t * ({isChar: bool} * BindingStrength.t)

--- a/mlton/elaborate/type-env.fun
+++ b/mlton/elaborate/type-env.fun
@@ -425,7 +425,7 @@ in
                                  then ", ...}"
                               else "}")])
    fun layoutTuple (zs: z vector): z =
-      Tycon.layoutApp (Tycon.tuple, zs)
+      Tycon.layoutAppPretty (Tycon.tuple, zs)
 end
 
 structure Type =
@@ -634,8 +634,8 @@ structure Type =
           lay: t -> Layout.t * ({isChar: bool} * Tycon.BindingStrength.t)} =
          let
             val str = Layout.str
-            fun con (_, c, ts) = Tycon.layoutApp (c, ts)
-            fun con0 c = Tycon.layoutApp (c, Vector.new0 ())
+            fun con (_, c, ts) = Tycon.layoutAppPretty (c, ts)
+            fun con0 c = Tycon.layoutAppPretty (c, Vector.new0 ())
             fun flexRecord (_, {fields, spine}) =
                layoutRecord
                (List.fold
@@ -660,7 +660,7 @@ structure Type =
                      layoutRecord (Vector.toListMap (Srecord.toVector r,
                                                      fn (f, t) => (f, false, t)),
                                    false)
-                | SOME ts => Tycon.layoutApp (Tycon.tuple, ts)
+                | SOME ts => Tycon.layoutAppPretty (Tycon.tuple, ts)
             fun recursive _ = simple (str "<recur>")
             fun unknown _ = simple (str "???")
             val (destroy, prettyTyvar) =
@@ -1076,7 +1076,7 @@ structure Type =
                                             fn (ls, ls') =>
                                             let 
                                                fun lay ls =
-                                                  Tycon.layoutApp (c, ls)
+                                                  Tycon.layoutAppPretty (c, ls)
                                             in
                                                notUnifiable
                                                (maybe (lay ls, lay ls'))

--- a/mlton/elaborate/type-env.fun
+++ b/mlton/elaborate/type-env.fun
@@ -1419,7 +1419,7 @@ structure Scheme =
 
       fun layout s =
          case s of
-            Type t => Type.layout t
+            Type t => Type.layoutPretty t
           | General {canGeneralize, tyvars, ty, ...} =>
                Layout.record [("canGeneralize", Bool.layout canGeneralize),
                               ("tyvars", Vector.layout Tyvar.layout tyvars),

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -825,12 +825,7 @@ fun genFromSXML (input: (In.t -> Sxml.Program.t) -> Sxml.Program.t): Machine.Pro
           | NONE => Stream.empty ()
       val _ = setupConstants()
       val sxml = input (fn i => ParseSxml.parse(toStream i))
-      open Control
-      val _ =
-         if !keepSXML
-            then saveToFile ({suffix = "sxml"}, No, sxml,
-               Layouts Sxml.Program.layouts)
-            else ()
+      val sxml = simplifySxml sxml
       val ssa = makeSsa sxml
       val ssa = simplifySsa ssa
       val ssa2 = makeSsa2 ssa

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -49,9 +49,7 @@ structure Xml = Xml (open Atoms)
 structure Sxml = Sxml (open Xml)
 structure ParseSxml = ParseSxml(structure XmlTree = Xml
                                 structure Stream = Stream
-                                structure StreamParser =
-                                   StreamParser(structure Stream = Stream
-                                                structure File = File))
+                                structure StreamParser = StreamParser)
 structure Ssa = Ssa (open Atoms)
 structure Ssa2 = Ssa2 (open Atoms)
 structure Machine = Machine (open Atoms

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -48,7 +48,6 @@ structure CoreML = CoreML (open Atoms
 structure Xml = Xml (open Atoms)
 structure Sxml = Sxml (open Xml)
 structure ParseSxml = ParseSxml(structure XmlTree = Xml
-                                structure Stream = Stream
                                 structure StreamParser = StreamParser)
 structure Ssa = Ssa (open Atoms)
 structure Ssa2 = Ssa2 (open Atoms)

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -47,6 +47,11 @@ structure CoreML = CoreML (open Atoms
                               end)
 structure Xml = Xml (open Atoms)
 structure Sxml = Sxml (open Xml)
+structure ParseSxml = ParseSxml(structure XmlTree = Xml
+                                structure Stream = Stream
+                                structure StreamParser =
+                                   StreamParser(structure Stream = Stream
+                                                structure File = File))
 structure Ssa = Ssa (open Atoms)
 structure Ssa2 = Ssa2 (open Atoms)
 structure Machine = Machine (open Atoms
@@ -493,14 +498,180 @@ fun elaborate {input: MLBString.t}: Xml.Program.t =
             else ()
          end
 
-      (* Set GC_state offsets and sizes. *)
+
+      val xml =
+         Control.passTypeCheck
+         {display = Control.Layouts Xml.Program.layouts,
+          name = "defunctorize",
+          stats = Xml.Program.layoutStats,
+          style = Control.ML,
+          suffix = "xml",
+          thunk = fn () => Defunctorize.defunctorize coreML,
+          typeCheck = Xml.typeCheck}
+   in
+      xml
+   end
+
+fun simplifyXml xml =
+   let val xml =
+      Control.passTypeCheck
+      {display = Control.Layouts Xml.Program.layouts,
+       name = "xmlSimplify",
+       stats = Xml.Program.layoutStats,
+       style = Control.ML,
+       suffix = "xml",
+       thunk = fn () => Xml.simplify xml,
+       typeCheck = Xml.typeCheck}
+      open Control
+      val _ =
+         if !keepXML
+            then saveToFile ({suffix = "xml"}, No, xml,
+               Layouts Xml.Program.layouts)
+            else ()
+   in
+      xml
+   end
+
+fun makeSxml xml =
+   Control.passTypeCheck
+   {display = Control.Layouts Sxml.Program.layouts,
+    name = "monomorphise",
+    stats = Sxml.Program.layoutStats,
+    style = Control.ML,
+    suffix = "sxml",
+    thunk = fn () => Monomorphise.monomorphise xml,
+    typeCheck = Sxml.typeCheck}
+
+fun simplifySxml sxml =
+   let
+      val sxml =
+         Control.passTypeCheck
+         {display = Control.Layouts Sxml.Program.layouts,
+          name = "sxmlSimplify",
+          stats = Sxml.Program.layoutStats,
+          style = Control.ML,
+          suffix = "sxml",
+          thunk = fn () => Sxml.simplify sxml,
+          typeCheck = Sxml.typeCheck}
+      open Control
+      val _ =
+         if !keepSXML
+            then saveToFile ({suffix = "sxml"}, No, sxml,
+               Layouts Sxml.Program.layouts)
+            else ()
+   in
+      sxml
+   end
+
+fun makeSsa sxml =
+   Control.passTypeCheck
+   {display = Control.Layouts Ssa.Program.layouts,
+    name = "closureConvert",
+    stats = Ssa.Program.layoutStats,
+    style = Control.No,
+    suffix = "ssa",
+    thunk = fn () => ClosureConvert.closureConvert sxml,
+    typeCheck = Ssa.typeCheck}
+
+fun simplifySsa ssa =
+   let
+      val ssa =
+         Control.passTypeCheck
+         {display = Control.Layouts Ssa.Program.layouts,
+          name = "ssaSimplify",
+          stats = Ssa.Program.layoutStats,
+          style = Control.No,
+          suffix = "ssa",
+          thunk = fn () => Ssa.simplify ssa,
+          typeCheck = Ssa.typeCheck}
+      open Control
+      val _ =
+         if !keepSSA
+            then saveToFile ({suffix = "ssa"}, No, ssa,
+               Layouts Ssa.Program.layouts)
+         else ()
+   in
+      ssa
+   end
+
+fun makeSsa2 ssa =
+   Control.passTypeCheck
+   {display = Control.Layouts Ssa2.Program.layouts,
+    name = "toSsa2",
+    stats = Ssa2.Program.layoutStats,
+    style = Control.No,
+    suffix = "ssa2",
+    thunk = fn () => SsaToSsa2.convert ssa,
+    typeCheck = Ssa2.typeCheck}
+
+fun simplifySsa2 ssa2 =
+   let
+      val ssa2 =
+         Control.passTypeCheck
+         {display = Control.Layouts Ssa2.Program.layouts,
+          name = "ssa2Simplify",
+          stats = Ssa2.Program.layoutStats,
+          style = Control.No,
+          suffix = "ssa2",
+          thunk = fn () => Ssa2.simplify ssa2,
+          typeCheck = Ssa2.typeCheck}
+      open Control
+      val _ =
+         if !keepSSA2
+            then saveToFile ({suffix = "ssa2"}, No, ssa2,
+               Layouts Ssa2.Program.layouts)
+         else ()
+   in
+      ssa2
+   end
+
+fun makeMachine ssa2 =
+   let
+      val codegenImplementsPrim =
+         case !Control.codegen of
+            Control.AMD64Codegen => amd64Codegen.implementsPrim
+          | Control.CCodegen => CCodegen.implementsPrim
+          | Control.LLVMCodegen => LLVMCodegen.implementsPrim
+          | Control.X86Codegen => x86Codegen.implementsPrim
+      val machine =
+         Control.passTypeCheck
+         {display = Control.Layouts Machine.Program.layouts,
+          name = "backend",
+          stats = fn _ => Layout.empty,
+          style = Control.No,
+          suffix = "machine",
+          thunk = fn () =>
+                  (Backend.toMachine
+                   (ssa2,
+                    {codegenImplementsPrim = codegenImplementsPrim})),
+          typeCheck = fn machine =>
+                      (* For now, machine type check is too slow to run. *)
+                      (if !Control.typeCheck
+                          then Machine.Program.typeCheck machine
+                       else ())}
+      val _ =
+         let
+            open Control
+         in
+            if !keepMachine
+               then saveToFile ({suffix = "machine"}, No, machine,
+                                Layouts Machine.Program.layouts)
+            else ()
+         end
+   in
+      machine
+   end
+
+fun setupConstants() : unit = 
+   (* Set GC_state offsets and sizes. *)
+   let
       val _ =
          let
             fun get (name: string): Bytes.t =
                case lookupConstant ({default = NONE, name = name},
                                     ConstType.Word WordSize.word32) of
                   Const.Word w => Bytes.fromInt (WordX.toInt w)
-                | _ => Error.bug "Compile.elaborate: GC_state offset must be an int"
+                | _ => Error.bug "Compile.setupConstants: GC_state offset must be an int"
          in
             Runtime.GCField.setOffsets
             {
@@ -542,165 +713,35 @@ fun elaborate {input: MLBString.t}: Xml.Program.t =
                 case lookupConstant ({default = NONE, name = name},
                                      ConstType.Bool) of
                    Const.Word w => 1 = WordX.toInt w
-                 | _ => Error.bug "Compile.elaborate: endian unknown"
+                 | _ => Error.bug "Compile.setupConstants: endian unknown"
          in
             Control.Target.setBigEndian (get "MLton_Platform_Arch_bigendian")
          end
-      val xml =
-         Control.passTypeCheck
-         {display = Control.Layouts Xml.Program.layouts,
-          name = "defunctorize",
-          stats = Xml.Program.layoutStats,
-          style = Control.ML,
-          suffix = "xml",
-          thunk = fn () => Defunctorize.defunctorize coreML,
-          typeCheck = Xml.typeCheck}
    in
-      xml
+      ()
    end
 
-fun preCodegen {input: MLBString.t}: Machine.Program.t =
+
+fun preCodegen (input: MLBString.t): Machine.Program.t =
    let
+      val _  = setupConstants()
       val xml = elaborate {input = input}
-      val xml =
-          Control.passTypeCheck
-          {display = Control.Layouts Xml.Program.layouts,
-           name = "xmlSimplify",
-           stats = Xml.Program.layoutStats,
-           style = Control.ML,
-           suffix = "xml",
-           thunk = fn () => Xml.simplify xml,
-           typeCheck = Xml.typeCheck}
-      val _ =
-         let
-            open Control
-         in
-            if !keepXML
-               then saveToFile ({suffix = "xml"}, No, xml,
-                                Layouts Xml.Program.layouts)
-            else ()
-         end
-      val sxml =
-         Control.passTypeCheck
-         {display = Control.Layouts Sxml.Program.layouts,
-          name = "monomorphise",
-          stats = Sxml.Program.layoutStats,
-          style = Control.ML,
-          suffix = "sxml",
-          thunk = fn () => Monomorphise.monomorphise xml,
-          typeCheck = Sxml.typeCheck}
-      val sxml =
-         Control.passTypeCheck
-         {display = Control.Layouts Sxml.Program.layouts,
-          name = "sxmlSimplify",
-          stats = Sxml.Program.layoutStats,
-          style = Control.ML,
-          suffix = "sxml",
-          thunk = fn () => Sxml.simplify sxml,
-          typeCheck = Sxml.typeCheck}
-      val _ =
-         let
-            open Control
-         in
-            if !keepSXML
-               then saveToFile ({suffix = "sxml"}, No, sxml,
-                                Layouts Sxml.Program.layouts)
-            else ()
-         end
-      val ssa =
-         Control.passTypeCheck
-         {display = Control.Layouts Ssa.Program.layouts,
-          name = "closureConvert",
-          stats = Ssa.Program.layoutStats,
-          style = Control.No,
-          suffix = "ssa",
-          thunk = fn () => ClosureConvert.closureConvert sxml,
-          typeCheck = Ssa.typeCheck}
-      val ssa =
-         Control.passTypeCheck
-         {display = Control.Layouts Ssa.Program.layouts,
-          name = "ssaSimplify",
-          stats = Ssa.Program.layoutStats,
-          style = Control.No,
-          suffix = "ssa",
-          thunk = fn () => Ssa.simplify ssa,
-          typeCheck = Ssa.typeCheck}
-      val _ =
-         let
-            open Control
-         in
-            if !keepSSA
-               then saveToFile ({suffix = "ssa"}, No, ssa,
-                                Layouts Ssa.Program.layouts)
-            else ()
-         end
-      val ssa2 =
-         Control.passTypeCheck
-         {display = Control.Layouts Ssa2.Program.layouts,
-          name = "toSsa2",
-          stats = Ssa2.Program.layoutStats,
-          style = Control.No,
-          suffix = "ssa2",
-          thunk = fn () => SsaToSsa2.convert ssa,
-          typeCheck = Ssa2.typeCheck}
-      val ssa2 =
-         Control.passTypeCheck
-         {display = Control.Layouts Ssa2.Program.layouts,
-          name = "ssa2Simplify",
-          stats = Ssa2.Program.layoutStats,
-          style = Control.No,
-          suffix = "ssa2",
-          thunk = fn () => Ssa2.simplify ssa2,
-          typeCheck = Ssa2.typeCheck}
-      val _ =
-         let
-            open Control
-         in
-            if !keepSSA2
-               then saveToFile ({suffix = "ssa2"}, No, ssa2,
-                                Layouts Ssa2.Program.layouts)
-            else ()
-         end
-      val codegenImplementsPrim =
-         case !Control.codegen of
-            Control.AMD64Codegen => amd64Codegen.implementsPrim
-          | Control.CCodegen => CCodegen.implementsPrim
-          | Control.LLVMCodegen => LLVMCodegen.implementsPrim
-          | Control.X86Codegen => x86Codegen.implementsPrim
-      val machine =
-         Control.passTypeCheck
-         {display = Control.Layouts Machine.Program.layouts,
-          name = "backend",
-          stats = fn _ => Layout.empty,
-          style = Control.No,
-          suffix = "machine",
-          thunk = fn () =>
-                  (Backend.toMachine
-                   (ssa2,
-                    {codegenImplementsPrim = codegenImplementsPrim})),
-          typeCheck = fn machine =>
-                      (* For now, machine type check is too slow to run. *)
-                      (if !Control.typeCheck
-                          then Machine.Program.typeCheck machine
-                       else ())}
-      val _ =
-         let
-            open Control
-         in
-            if !keepMachine
-               then saveToFile ({suffix = "machine"}, No, machine,
-                                Layouts Machine.Program.layouts)
-            else ()
-         end
+      val xml = simplifyXml xml
+      val sxml = makeSxml xml
+      val sxml = simplifySxml sxml
+      val ssa = makeSsa sxml
+      val ssa = simplifySsa ssa
+      val ssa2 = makeSsa2 ssa
+      val ssa2 = simplifySsa2 ssa2
    in
-      machine
+      makeMachine ssa2
    end
 
-fun compile {input: MLBString.t, outputC, outputLL, outputS}: unit =
+fun compile {input: 'a, resolve: 'a -> Machine.Program.t, outputC, outputLL, outputS}: unit =
    let
       val machine =
          Control.trace (Control.Top, "pre codegen")
-         preCodegen {input = input}
+         resolve input
       fun clearNames () =
          (Machine.Program.clearLabelNames machine
           ; Machine.Label.printNameAlphaNumeric := true)
@@ -737,6 +778,7 @@ fun compile {input: MLBString.t, outputC, outputLL, outputS}: unit =
 
 fun compileMLB {input: File.t, outputC, outputLL, outputS}: unit =
    compile {input = MLBString.fromFile input,
+            resolve = preCodegen,
             outputC = outputC,
             outputLL = outputLL,
             outputS = outputS}
@@ -769,6 +811,7 @@ local
 in
    fun compileSML {input: File.t list, outputC, outputLL, outputS}: unit =
       compile {input = genMLB {input = input},
+               resolve = preCodegen,
                outputC = outputC,
                outputLL = outputLL,
                outputS = outputS}
@@ -777,5 +820,37 @@ in
       (ignore (elaborate {input = genMLB {input = input}}))
       handle Done => ()
 end
+
+fun genFromSXML (input: char Stream.t): Machine.Program.t =
+   let
+      val _ = setupConstants()
+      val sxml = ParseSxml.parse(input)
+      (* can't quite run simplify twice *)
+      (*val sxml = simplifySxml sxml *)
+      open Control
+      val _ =
+         if !keepSXML
+            then saveToFile ({suffix = "sxml"}, No, sxml,
+               Layouts Sxml.Program.layouts)
+            else ()
+      val ssa = makeSsa sxml
+      val ssa = simplifySsa ssa
+      val ssa2 = makeSsa2 ssa
+      val ssa2 = simplifySsa2 ssa2
+   in
+      makeMachine ssa2
+   end
+fun compileSXML {input: File.t list, outputC, outputLL, outputS}: unit =
+   let
+      val inputs = case input of [i] => File.contents i
+                               | _ => ""
+      val stream = Stream.fromList (String.explode inputs)
+   in
+      compile {input = stream,
+               resolve = genFromSXML,
+               outputC = outputC,
+               outputLL = outputLL,
+               outputS = outputS}
+   end
 
 end

--- a/mlton/main/compile.sig
+++ b/mlton/main/compile.sig
@@ -34,7 +34,7 @@ signature COMPILE =
                        outputS: unit -> {file: File.t,
                                          print: string -> unit,
                                          done: unit -> unit}} -> unit
-      val compileSXML: {input: File.t list,
+      val compileSXML: {input: File.t,
                         outputC: unit -> {file: File.t,
                                           print: string -> unit,
                                           done: unit -> unit},

--- a/mlton/main/compile.sig
+++ b/mlton/main/compile.sig
@@ -34,7 +34,17 @@ signature COMPILE =
                        outputS: unit -> {file: File.t,
                                          print: string -> unit,
                                          done: unit -> unit}} -> unit
-      val elaborateMLB: {input: File.t} -> unit
+      val compileSXML: {input: File.t list,
+                       outputC: unit -> {file: File.t,
+                                         print: string -> unit,
+                                         done: unit -> unit},
+                       outputLL: unit -> {file: File.t,
+                                          print: string -> unit,
+                                          done: unit -> unit},
+                       outputS: unit -> {file: File.t,
+                                         print: string -> unit,
+                                         done: unit -> unit}} -> unit
+       val elaborateMLB: {input: File.t} -> unit
       val elaborateSML: {input: File.t list} -> unit
       val setCommandLineConstant: {name: string, value: string} -> unit
       val sourceFilesMLB: {input: File.t} -> File.t vector

--- a/mlton/main/compile.sig
+++ b/mlton/main/compile.sig
@@ -35,16 +35,16 @@ signature COMPILE =
                                          print: string -> unit,
                                          done: unit -> unit}} -> unit
       val compileSXML: {input: File.t list,
-                       outputC: unit -> {file: File.t,
-                                         print: string -> unit,
-                                         done: unit -> unit},
-                       outputLL: unit -> {file: File.t,
+                        outputC: unit -> {file: File.t,
                                           print: string -> unit,
                                           done: unit -> unit},
-                       outputS: unit -> {file: File.t,
-                                         print: string -> unit,
-                                         done: unit -> unit}} -> unit
-       val elaborateMLB: {input: File.t} -> unit
+                        outputLL: unit -> {file: File.t,
+                                           print: string -> unit,
+                                           done: unit -> unit},
+                        outputS: unit -> {file: File.t,
+                                          print: string -> unit,
+                                          done: unit -> unit}} -> unit
+      val elaborateMLB: {input: File.t} -> unit
       val elaborateSML: {input: File.t list} -> unit
       val setCommandLineConstant: {name: string, value: string} -> unit
       val sourceFilesMLB: {input: File.t} -> File.t vector

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -16,7 +16,7 @@ structure Compile = Compile ()
 
 structure Place =
    struct
-      datatype t = Files | Generated | MLB | O | OUT | SXML | SML | TypeCheck
+      datatype t = Files | Generated | MLB | O | OUT | SML | SXML | TypeCheck
       val toInt: t -> int =
          fn MLB => 1
           | SML => 1
@@ -29,13 +29,13 @@ structure Place =
 
       val toString =
          fn Files => "files"
-          | SML => "sml"
-          | MLB => "mlb"
           | Generated => "g"
+          | MLB => "mlb"
           | O => "o"
           | OUT => "out"
-          | TypeCheck => "tc"
+          | SML => "sml"
           | SXML => "sxml"
+          | TypeCheck => "tc"
 
       fun compare (p, p') = Int.compare (toInt p, toInt p')
    end

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -16,16 +16,17 @@ structure Compile = Compile ()
 
 structure Place =
    struct
-      datatype t = Files | Generated | MLB | O | OUT | SML | TypeCheck
+      datatype t = Files | Generated | MLB | O | OUT | SML | TypeCheck | SXML
 
       val toInt: t -> int =
          fn MLB => 1
           | SML => 1
           | Files => 2
           | TypeCheck => 4
-          | Generated => 5
-          | O => 6
-          | OUT => 7
+          | SXML => 7
+          | Generated => 10
+          | O => 11
+          | OUT => 12
 
       val toString =
          fn Files => "files"
@@ -35,6 +36,7 @@ structure Place =
           | O => "o"
           | OUT => "out"
           | TypeCheck => "tc"
+          | SXMl => "sxml"
 
       fun compare (p, p') = Int.compare (toInt p, toInt p')
    end
@@ -1203,6 +1205,7 @@ fun commandLine (args: string list): unit =
                in
                   loop [(".mlb", MLB, false),
                         (".sml", SML, false),
+                        (".sxml", SXML, false),
                         (".c", Generated, true),
                         (".o", O, true)]
                end
@@ -1553,12 +1556,17 @@ fun commandLine (args: string list): unit =
                      mkCompileSrc {listFiles = Compile.sourceFilesMLB,
                                    elaborate = Compile.elaborateMLB,
                                    compile = Compile.compileMLB}
+                  val compileSXML =
+                     mkCompileSrc {listFiles = fn {input} => Vector.fromList input,
+                                   elaborate = fn _ => raise Fail "Unimplemented",
+                                   compile = Compile.compileSXML}
                   fun compile () =
                      case start of
                         Place.SML => compileSML [input]
                       | Place.MLB => compileMLB input
                       | Place.Generated => compileCSO (input :: csoFiles)
                       | Place.O => compileCSO (input :: csoFiles)
+                      | Place.SXML => compileSXML [input]
                       | _ => Error.bug "invalid start"
                   val doit
                     = trace (Top, "MLton")

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -16,8 +16,7 @@ structure Compile = Compile ()
 
 structure Place =
    struct
-      datatype t = Files | Generated | MLB | O | OUT | SML | TypeCheck | SXML
-
+      datatype t = Files | Generated | MLB | O | OUT | SXML | SML | TypeCheck
       val toInt: t -> int =
          fn MLB => 1
           | SML => 1
@@ -36,7 +35,7 @@ structure Place =
           | O => "o"
           | OUT => "out"
           | TypeCheck => "tc"
-          | SXMl => "sxml"
+          | SXML => "sxml"
 
       fun compare (p, p') = Int.compare (toInt p, toInt p')
    end

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1556,7 +1556,7 @@ fun commandLine (args: string list): unit =
                                    elaborate = Compile.elaborateMLB,
                                    compile = Compile.compileMLB}
                   val compileSXML =
-                     mkCompileSrc {listFiles = fn {input} => Vector.fromList input,
+                     mkCompileSrc {listFiles = fn {input} => Vector.new1 input,
                                    elaborate = fn _ => raise Fail "Unimplemented",
                                    compile = Compile.compileSXML}
                   fun compile () =
@@ -1565,7 +1565,7 @@ fun commandLine (args: string list): unit =
                       | Place.MLB => compileMLB input
                       | Place.Generated => compileCSO (input :: csoFiles)
                       | Place.O => compileCSO (input :: csoFiles)
-                      | Place.SXML => compileSXML [input]
+                      | Place.SXML => compileSXML input
                       | _ => Error.bug "invalid start"
                   val doit
                     = trace (Top, "MLton")

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -1,3 +1,9 @@
+(* Copyright (C) 2017 Jason Carr.
+ *
+ * MLton is released under a BSD-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
 functor ParseSxml(S: PARSE_SXML_STRUCTS) = 
 struct
    open S

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -10,7 +10,6 @@ struct
    open XmlTree
    structure T = StreamParser
    open T.Ops
-   structure DE = DirectExp
    infix 1 <|> >>=
    infix 2 <&>
    infix  3 <*> <* *>

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -239,7 +239,7 @@ struct
            | makeRaise(SOME _, exn) = {exn=exn, extend=true}
          val raiseExp = token "raise" *> T.cut (makeRaise <$$> (T.optional (token "extend"), varExp <* spaces))
          fun makeHandle(try, catch, handler) = {catch=catch, handler=handler, try=try}
-         fun makeLambda((var, typ), exp) = Lambda.make {arg=var, argType=typ, body=exp, mayInline=false}
+         fun makeLambda(mayInline, (var, typ), exp) = Lambda.make {arg=var, argType=typ, body=exp, mayInline=mayInline}
 
          val parseConvention = CFunction.Convention.Cdecl <$ token "cdecl" <|>
                                     CFunction.Convention.Stdcall <$ token "stdcall"
@@ -366,8 +366,9 @@ struct
              token "handle" *> T.cut typedvar,
              T.cut (token "=>" *> T.delay exp' <* spaces)
              )
-         and lambdaExp () = token "fn" *> T.cut(makeLambda <$$>
-            (typedvar,
+         and lambdaExp () = token "fn" *> T.cut(makeLambda <$$$>
+            (false <$ (token "noinline") <|> T.pure true,
+             typedvar,
              token "=>" *> T.delay exp' <* spaces))
          and casesExp () = T.string "case" *> T.cut
             (T.optional parseInt <* T.many1 space >>= (fn size =>

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -193,9 +193,9 @@ struct
    fun makeReal s = (case (RealX.make s) of NONE => NONE | x => x) handle Fail _ => NONE
    fun parseReal sz = possibly (makeReal <$$> (String.implode <$>
          List.concat <$> T.each
-         [T.many (T.sat(T.next, Char.isDigit)),
+         [T.many (T.sat(T.next, fn c => Char.isDigit c orelse c = #"~")),
           T.char #"." *> T.pure [#"."] <|> T.pure [],
-          T.many (T.sat(T.next, fn c => Char.isDigit c orelse c = #"E" orelsec = #"~"))],
+          T.many (T.sat(T.next, fn c => Char.isDigit c orelse c = #"E" orelse c = #"~"))],
          T.pure sz))
    val parseHex = T.fromReader (IntInf.scan(StringCvt.HEX, T.toReader T.next))
    val parseBool = true <$ token "true" <|> false <$ token "false"

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -50,8 +50,7 @@ struct
       end
 
 
-   val ident = (T.failing (token "in" <|> token "exception" <|> token "val" <|> token "fn" <|> token
-   "_" <|> token "=>" <|> token "case" <|> token "prim") *>
+   val ident = (
       String.implode <$> (T.any
          [(op ::) <$$>
              (T.sat(T.next, isIdentFirst),
@@ -178,10 +177,12 @@ struct
          fun makeFunDec((var, ty), lambda) = {lambda=lambda, ty=ty, var=var}
          val var = resolveVar <$> ident <* spaces
          val typedvar = (fn (x,y) => (x,y)) <$$>
-            (resolveVar <$> ident <* spaces,
+            (var,
              symbol ":" *> (typ resolveTycon) <* spaces)
          fun makeVarExp var = VarExp.T {var=var, targs = Vector.new0 ()}
-         val varExp = makeVarExp <$> (var <* spaces)
+         val varExp =
+            T.failing (token "in" <|> token "exception" <|> token "val") *>
+            makeVarExp <$> var
          fun makeApp(func, arg) = {arg=arg, func=func}
          fun makeConApp(con, targs, arg) = {arg=arg, con=con, targs=targs}
          fun conApp v = makeConApp <$$$>

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -4,7 +4,7 @@
  * See the file MLton-LICENSE for details.
  *)
 
-functor ParseSxml(S: PARSE_SXML_STRUCTS) =
+functor ParseSxml (S: PARSE_SXML_STRUCTS): PARSE_SXML =
 struct
    open S
    open XmlTree

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -115,19 +115,9 @@ struct
       fun typ resolveTycon = typ' resolveTycon ()
    end
 
-   val ctype = T.any
-      [CType.CPointer <$ token "CPointer",
-       CType.Int8 <$ token "Int8",
-       CType.Int16 <$ token "Int16",
-       CType.Int32 <$ token "Int32",
-       CType.Int64 <$ token "Int64",
-       CType.Objptr <$ token "Objptr",
-       CType.Real32 <$ token "Real32",
-       CType.Real64 <$ token "Real64",
-       CType.Word8 <$ token "Word8",
-       CType.Word16 <$ token "Word16",
-       CType.Word32 <$ token "Word32",
-       CType.Word64 <$ token "Word64"]
+   val ctype = (T.any o List.map)
+               (CType.all, fn ct =>
+                ct <$ token (CType.toString ct))
 
    fun makeCon resolveCon (name, arg) = {con = resolveCon name, arg = arg}
 

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -227,7 +227,6 @@ struct
          fun makeVarExp var = VarExp.T {var=var, targs = Vector.new0 ()}
          val varExp = makeVarExp <$> (var <* spaces)
          fun makeApp(func, arg) = {arg=arg, func=func}
-         val appExp = makeApp <$$> (varExp, varExp)
          fun makeConApp(con, targs, arg) = {arg=arg, con=con, targs=targs}
          fun conApp v = makeConApp <$$$>
             (resolveCon <$> ident <* spaces,

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -375,11 +375,7 @@ struct
             case List.peekMap (Tycon.prims, fn {name, tycon, ...} =>
                                if ident = name then SOME tycon else NONE) of
                SOME con => con
-             | NONE => if ident = "arrow"
-                          then Tycon.arrow
-                       else if ident = "tuple"
-                          then Tycon.tuple
-                       else if ident = "unit"
+             | NONE => if ident = "unit"
                           then Tycon.tuple
                        else resolveTycon0 ident
          val resolveVar = makeNameResolver(Var.newString o strip_unique)

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -398,18 +398,21 @@ struct
    val program : Program.t StreamParser.t =
       let
          fun strip_unique s  = T.parse
-            (String.implode <$> T.manyCharsFailing(T.char #"_"),
+            (String.implode <$> T.manyCharsFailing(
+               T.char #"_" *> T.many1 (T.sat(T.next, Char.isDigit)) *> T.failing T.next),
              Stream.fromList (String.explode s))
-         val resolveCon0 = makeNameResolver(Con.fromString o strip_unique)
+         val resolveCon0 = makeNameResolver(Con.newString o strip_unique)
          fun resolveCon name = case name of
              "true" => Con.truee
            | "false" => Con.falsee
+           | "ref" => Con.reff
+           | "Overflow" => Con.overflow
            | _ => resolveCon0 name
-         val resolveTycon0 = makeNameResolver(Tycon.fromString o strip_unique)
+         val resolveTycon0 = makeNameResolver(Tycon.newString o strip_unique)
          fun resolveTycon "bool" = Tycon.bool (* special case *)
            | resolveTycon "exn" = Tycon.exn (* special case *)
            | resolveTycon name = resolveTycon0 name
-         val resolveVar = makeNameResolver(Var.fromString o strip_unique)
+         val resolveVar = makeNameResolver(Var.newString o strip_unique)
       in
          T.compose(skipComments,
          clOptions *>

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -19,6 +19,9 @@ struct
    fun isIdentFirst b = Char.isAlpha b orelse b = #"'"
    fun isIdentRest b = Char.isAlphaNum b orelse b = #"'" orelse b = #"_" orelse b = #"."
 
+   val skipComments = T.optional(
+      T.string "(*" *> T.cut (T.many (T.failing (T.string "*)") *> T.next) *> T.string "*)" <|> T.failCut "Closing comment")
+      ) *> T.next
 
    val space = T.sat(T.next, Char.isSpace) 
    val spaces = T.many(space)
@@ -314,11 +317,12 @@ struct
          val resolveTycon = makeNameResolver(Tycon.fromString o strip_unique)
          val resolveVar = makeNameResolver(Var.fromString o strip_unique)
       in
+         T.compose(skipComments,
          clOptions *>
          (makeProgram <$$$>
             (datatypes resolveCon resolveTycon,
             overflow resolveVar,
-            body resolveCon resolveTycon resolveVar))
+            body resolveCon resolveTycon resolveVar)))
 
       end
 end

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -27,7 +27,7 @@ struct
        (T.char #"_") <|> (T.sat(T.next,Char.isAlphaNum))) <* spaces
    fun symbol s = T.notFollowedBy
       (T.string s,
-       (T.sat(T.next,fn b => Char.isDigit b orelse isInfixChar b orelse b = #"_"))) <* spaces
+       (T.sat(T.next,fn b => isInfixChar b orelse b = #"_"))) <* spaces
 
    val clOptions = T.many (T.failing (T.string "Datatypes:") *> T.next)
 

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -309,8 +309,9 @@ struct
          val selectExp = symbol "#" *> T.cut(makeSelect <$$>
             (parseInt <* spaces,
              varExp))
-         val profileExp = ProfileExp.Enter <$> (token "Enter" *> SourceInfo.fromC <$> T.info) <|>
-                          ProfileExp.Leave <$> (token "Leave" *> SourceInfo.fromC <$> T.info )
+         val profileExp = (ProfileExp.Enter <$> (token "Enter" *> SourceInfo.fromC <$> T.info) <|>
+                           ProfileExp.Leave <$> (token "Leave" *> SourceInfo.fromC <$> T.info ))
+            <* T.char #"<" <* T.manyCharsFailing(T.char #">") <* T.char #">" <* spaces
          fun makeConCases var (cons, def) = 
             {test=var, 
              cases=Cases.Con cons, 

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -61,10 +61,10 @@ struct
 
    (* parse a tuple of parsers which must begin with a paren but may be unary *)
    fun tupleOf p = Vector.fromList <$>
-      (T.char #"(" *> T.sepBy(p, T.char #"," *> spaces) <* T.char #")")
+      (T.char #"(" *> T.sepBy(spaces *> p, T.char #",") <* T.char #")")
 
    fun vectorOf p = Vector.fromList <$>
-      (T.char #"[" *> T.sepBy(p, T.char #"," *> spaces) <* T.char #"]")
+      (T.char #"[" *> T.sepBy(spaces *> p, T.char #",") <* T.char #"]")
 
    fun doneRecord' () = T.char #"{" <* T.many(T.delay doneRecord' <|> T.failing(T.char #"}") *> T.next) <* T.char #"}"
    val doneRecord = doneRecord' ()

--- a/mlton/xml/parse-sxml.sig
+++ b/mlton/xml/parse-sxml.sig
@@ -1,9 +1,7 @@
 signature PARSE_SXML_STRUCTS =
    sig
       structure XmlTree: XML_TREE
-      structure Stream: STREAM
       structure StreamParser: STREAM_PARSER
-      sharing Stream = StreamParser.Stream 
    end
 
 signature PARSE_SXML = 

--- a/mlton/xml/parse-sxml.sig
+++ b/mlton/xml/parse-sxml.sig
@@ -10,7 +10,7 @@ signature PARSE_SXML_STRUCTS =
       structure StreamParser: STREAM_PARSER
    end
 
-signature PARSE_SXML = 
+signature PARSE_SXML =
    sig
       include PARSE_SXML_STRUCTS
 

--- a/mlton/xml/parse-sxml.sig
+++ b/mlton/xml/parse-sxml.sig
@@ -1,3 +1,9 @@
+(* Copyright (C) 2017 Jason Carr.
+ *
+ * MLton is released under a BSD-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
 signature PARSE_SXML_STRUCTS =
    sig
       structure XmlTree: XML_TREE

--- a/mlton/xml/sources.cm
+++ b/mlton/xml/sources.cm
@@ -11,10 +11,12 @@ Group
 signature SXML
 signature XML
 signature XML_TYPE
+signature PARSE_SXML
 
 functor Monomorphise
 functor Xml
 functor Sxml
+functor ParseSxml
 
 is
 

--- a/mlton/xml/sources.cm
+++ b/mlton/xml/sources.cm
@@ -13,9 +13,9 @@ signature XML
 signature XML_TYPE
 
 functor Monomorphise
-functor Xml
-functor Sxml
 functor ParseSxml
+functor Sxml
+functor Xml
 
 is
 

--- a/mlton/xml/sources.cm
+++ b/mlton/xml/sources.cm
@@ -11,7 +11,6 @@ Group
 signature SXML
 signature XML
 signature XML_TYPE
-signature PARSE_SXML
 
 functor Monomorphise
 functor Xml

--- a/mlton/xml/sources.mlb
+++ b/mlton/xml/sources.mlb
@@ -44,7 +44,6 @@ local
 in
    signature SXML
    signature XML
-   signature PARSE_SXML
 
    functor Monomorphise
    functor Xml

--- a/mlton/xml/sources.mlb
+++ b/mlton/xml/sources.mlb
@@ -46,7 +46,7 @@ in
    signature XML
 
    functor Monomorphise
-   functor Xml
-   functor Sxml
    functor ParseSxml
+   functor Sxml
+   functor Xml
 end

--- a/mlton/xml/sources.mlb
+++ b/mlton/xml/sources.mlb
@@ -41,12 +41,13 @@ local
    sxml.fun
    parse-sxml.sig
    parse-sxml.fun
-
 in
    signature SXML
    signature XML
+   signature PARSE_SXML
 
    functor Monomorphise
    functor Xml
    functor Sxml
+   functor ParseSxml
 end

--- a/mlton/xml/sources.mlb
+++ b/mlton/xml/sources.mlb
@@ -41,13 +41,10 @@ local
    sxml.fun
    parse-sxml.sig
    parse-sxml.fun
-   test.sml
 
 in
    signature SXML
    signature XML
-
-   structure Z
 
    functor Monomorphise
    functor Xml

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -32,7 +32,7 @@ fun maybeConstrain (x, t) =
       open Layout
    in
       if !Control.showTypes
-         then seq [x, str " : ", Type.layoutFormal t]
+         then seq [x, str " : ", Type.layout t]
       else x
    end
 
@@ -42,7 +42,7 @@ in
    fun layoutTargs (ts: Type.t vector) =
       if !Control.showTypes
          andalso 0 < Vector.length ts
-         then list (Vector.toListMap (ts, Type.layoutFormal))
+         then list (Vector.toListMap (ts, Type.layout))
       else empty
 end
 
@@ -148,7 +148,7 @@ structure VarExp =
                     if Vector.isEmpty targs
                        then Var.layout var
                     else seq [Var.layout var, str " ",
-                              Vector.layout Type.layoutFormal targs]
+                              Vector.layout Type.layout targs]
                  end
          else Var.layout var
    end
@@ -210,7 +210,7 @@ in
       seq [Con.layout con,
            case arg of
               NONE => empty
-            | SOME t => seq [str " of ", Type.layoutFormal t]]
+            | SOME t => seq [str " of ", Type.layout t]]
    fun layoutTyvars ts =
       case Vector.length ts of
          0 => empty
@@ -277,7 +277,7 @@ in
        | Lambda l => layoutLambda l
        | PrimApp {args, prim, targs} =>
             seq [str "prim ",
-                 Prim.layoutFull Type.layoutFormal prim,
+                 Prim.layoutFull Type.layout prim,
                  layoutTargs targs,
                  str " ", tuple (Vector.toListMap (args, VarExp.layout))]
        | Profile e => ProfileExp.layout e

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -32,7 +32,7 @@ fun maybeConstrain (x, t) =
       open Layout
    in
       if !Control.showTypes
-         then seq [x, str ": ", Type.layoutFormal t]
+         then seq [x, str " : ", Type.layoutFormal t]
       else x
    end
 

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -214,7 +214,6 @@ in
    fun layoutTyvars ts =
       case Vector.length ts of
          0 => empty
-       | 1 => seq [str "(", Tyvar.layout (Vector.first ts), str ") "]
        | _ => seq [tuple (Vector.toListMap (ts, Tyvar.layout)), str " "]
    fun layoutDec d =
       case d of

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -276,7 +276,7 @@ in
        | Lambda l => layoutLambda l
        | PrimApp {args, prim, targs} =>
             seq [str "prim ",
-                 Prim.layoutFull Type.layout prim,
+                 Prim.layoutFull(prim, Type.layout),
                  layoutTargs targs,
                  str " ", tuple (Vector.toListMap (args, VarExp.layout))]
        | Profile e => ProfileExp.layout e

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -277,7 +277,7 @@ in
        | Lambda l => layoutLambda l
        | PrimApp {args, prim, targs} =>
             seq [str "prim ",
-                 Prim.layout prim,
+                 Prim.layoutFull Type.layoutFormal prim,
                  layoutTargs targs,
                  str " ", tuple (Vector.toListMap (args, VarExp.layout))]
        | Profile e => ProfileExp.layout e

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -287,7 +287,15 @@ in
                  VarExp.layout exn]
        | Select {offset, tuple} =>
             seq [str "#", Int.layout offset, str " ", VarExp.layout tuple]
-       | Tuple xs => tuple (Vector.toListMap (xs, VarExp.layout))
+       | Tuple xs => tuple (Vector.toList
+            (Vector.mapi(xs, fn (i, x) => seq
+            (* very specific case to prevent open comments *)
+                [str (if i = 0 andalso
+                        (case x of (VarExp.T {var, ...}) =>
+                           String.sub(Var.toString var, 0) = #"*")
+                      then " "
+                      else ""),
+                 VarExp.layout x])))
        | Var x => VarExp.layout x
    and layoutLambda (Lam {arg, argType, body, mayInline, ...}) =
       align [seq [str "fn ",

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -289,8 +289,10 @@ in
             seq [str "#", Int.layout offset, str " ", VarExp.layout tuple]
        | Tuple xs => tuple (Vector.toListMap (xs, VarExp.layout))
        | Var x => VarExp.layout x
-   and layoutLambda (Lam {arg, argType, body, ...}) =
-      align [seq [str "fn ", maybeConstrain (Var.layout arg, argType),
+   and layoutLambda (Lam {arg, argType, body, mayInline, ...}) =
+      align [seq [str "fn ",
+                  str (if not mayInline then "noinline " else ""),
+                  maybeConstrain (Var.layout arg, argType),
                   str " => "],
              layoutExp body]
 


### PR DESCRIPTION
This branch consists of two sets of larger additions, and one minor change to MLTon (the last depending on the first two):

1. Adds the StreamParser structure
This comes with other small additions to basic
2. Changes the compilation step to be split up slightly. This is a relatively small change, but deserves scrutiny
2. Adds the ParseSxml structure and the sxml file type to the compilation.

1.This is done, but there may be improvements that can be made to the parsing interface and its interaction with files and streams. At the moment it takes a stream, but there may be a way to improve the interface between it and Instream, or between Instream and Stream. In addition to StreamParser, two functions are added to Stream, firstNSafe (that takes as many it can get if it reaches the end) and fromList, which is useful for building streams from slurped files.

2. Compilation is split up into multiple steps, rather than a single preCodeGen function. This is self-contained to compile.fun. There is a step added to compileSxml and changes in main to accommodate the addition. 

2. This succeeds without error, but seems to be behaving poorly on real code: The sxml output matches character for character in the program structure, but the ssa produced is vastly different, and the output program, at least for my simple case, fails to behave correctly. This is something I'd like to discuss in person. A number of files have had layout functionality added or modified (when confined to xml) to generate simpler output.