### PR TITLE
Better stream transformers

### DIFF
--- a/lib/mlton/basic/stream-parser.sig
+++ b/lib/mlton/basic/stream-parser.sig
@@ -64,7 +64,7 @@ signature STREAM_PARSER =
       val char: char -> char t
       (* composes two parsers in turn, the characters used for the second come
        * from the first *)
-      val compose : char t * 'a t -> 'a t
+      val compose : char list t * 'a t -> 'a t
       (* if the parser fails, it will fail as a cut *)
       val cut: 'a t -> 'a t
       (* delays a stream lazily, for recursive combinations *)

--- a/lib/mlton/basic/stream-parser.sml
+++ b/lib/mlton/basic/stream-parser.sml
@@ -172,7 +172,7 @@ fun satExpects(t, p, m) s =
      | Failure err => Failure err
      | FailCut err => FailCut err
 
-fun sat(t, p) s = satExpects(t, p, "Syntax error") s
+fun sat(t, p) s = satExpects(t, p, "Satisfying") s
 
 
 fun peek p (s : State.t) =

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -336,8 +336,8 @@ struct
             (false <$ (token "noinline") <|> T.pure true,
              typedvar,
              token "=>" *> T.delay exp' <* spaces))
-         and casesExp () = T.string "case" *> T.cut
-            (T.optional parseInt <* T.many1 space >>= (fn size =>
+         and casesExp () = T.string "case" *>
+            T.optional parseInt <* T.many1 space >>= (fn size => T.cut(
                varExp <* token "of" <* spaces >>= (fn var =>
                   case size of
                       NONE => makeConCases var <$$>

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -24,10 +24,17 @@ struct
    fun isIdentFirst b = Char.isAlpha b orelse b = #"'"
    fun isIdentRest b = Char.isAlphaNum b orelse b = #"'" orelse b = #"_" orelse b = #"."
 
-   val skipComments = T.optional(
-      T.string "(*" *> T.cut (T.manyCharsFailing(T.string "*)") *> T.string "*)"
-         <|> T.failCut "Closing comment")
-      ) *> T.next
+  val stringToken = (fn (x, y) => [x, y]) <$$> (T.char #"\\", T.next) <|>
+                     (fn x      => [x]   ) <$> T.next
+   fun skipComments () = T.any
+      [T.string "(*" *> T.cut (T.manyCharsFailing(T.string "*)" <|> T.string "(*") *>
+            ((T.string "*)" <|> "" <$ T.delay skipComments) *> T.each [T.next]
+          <|> T.failCut "Closing comment")),
+       List.concat <$> T.each
+         [T.each [T.char #"\""],
+          List.concat <$> T.manyFailing(stringToken, T.char #"\""),
+          T.each [T.char #"\""]],
+       T.each [T.next]]
 
    val space = T.sat(T.next, Char.isSpace)
    val spaces = T.many(space)
@@ -129,8 +136,6 @@ struct
           (NONE <$ T.string "None" <* spaces))
 
 
-   val stringToken = (fn (x, y) => [x, y]) <$$> (T.char #"\\", T.next) <|>
-                           (fn x      => [x]   ) <$> T.next
    val parseString = possibly ((String.fromString o String.implode o List.concat) <$>
          (T.char #"\"" *> (T.manyFailing(stringToken, T.char #"\"")) <* T.char #"\""))
    val parseIntInf = possibly ((IntInf.fromString o String.implode) <$>
@@ -380,7 +385,7 @@ struct
                        else resolveTycon0 ident
          val resolveVar = makeNameResolver(Var.newString o strip_unique)
       in
-         T.compose(skipComments,
+         T.compose(skipComments (),
          clOptions *>
          (makeProgram <$$$>
             (datatypes resolveCon resolveTycon,


### PR DESCRIPTION
Fixes the parser so that it can successfully parse mlton. This also changes the type/semantics of stream-parser.compose (so that it can now return 0 or more characters with each parse, rather than exactly 1)