### PR TITLE
Force PIC generation on AMD64.

### DIFF
--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -950,6 +950,8 @@ fun commandLine (args: string list): unit =
             (* Windows is never position independent *)
             (MinGW, _, _) => false
           | (Cygwin, _, _) => false
+            (* GCC on AMD64 now produces PIC by default in many Linux distros. *)
+          | (Linux, AMD64, _) => true
             (* Technically, Darwin should always be PIC.
              * However, PIC on i386/darwin is unimplemented so we avoid it.
              * PowerPC PIC is bad too, but the C codegen will use PIC behind


### PR DESCRIPTION
Because it is relatively cheap to support PIC in AMD64, it has become the default in many Linux distros. Given that there is no way to turn on or off PIC generation in MLton through command lines or mlb files (yet), I think it makes more sense to force PIC generation on AMD64.