### PR TITLE
Fix bug with compiling programs with `_export`-ed functions

### DIFF
--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -729,8 +729,8 @@ fun setupConstants() : unit =
 
 fun preCodegen (input: MLBString.t): Machine.Program.t =
    let
-      val _  = setupConstants()
       val xml = elaborate {input = input}
+      val _ = setupConstants ()
       val xml = simplifyXml xml
       val sxml = makeSxml xml
       val sxml = simplifySxml sxml


### PR DESCRIPTION
The bug was introduced by 7ca7629, which refactored some of
`main/compile.fun` to facilitate parsing and compiling with .sxml
programs.

The commit nicely factored out the code to setup runtime constants and
ran it before initiating compilation of .sml/.mlb or .sxml programs.
What is not apparent from the code in `main/compile.fun` is that
`LookupConstant.load` implicitly initializes some other constants.  In
particular, it initializes the `MLton_FFI_numExports` constant, which
in turn, is set by `Ffi.numExports ()`, which is itself a derived
value of the program being compiled (essentially, counting the number
of `_export` expressions in the program).  The laziness of CoreML
constants is precisely to support this derived constant (and,
potentially, others that might be a property of the program being
compiled, though there are no other such constants at the present
time).

The fix is simple: perform `setupConstants` after elaboration.
Technically, the `defunctorize` pass that converts the CoreML program
to an XML program will have forced the constants (and performed the
`LookupConstant.load`), but that is sufficiently late that
`Ffi.numExports ()` will return a correct value.  It is still
necessary to perform `setupConstants` to propagate values for the
runtime constants.