### PR TITLE
Machine shuffle

### DIFF
--- a/lib/mlton/basic/popt.sig
+++ b/lib/mlton/basic/popt.sig
@@ -29,12 +29,15 @@ signature POPT =
          (* one arg: any string, after a space *)
        | SpaceString of string -> unit
        | SpaceString2 of string * string -> unit
+         (* one arg: a word (hex), after a space *)
+       | Word of word -> unit
 
       val boolRef: bool ref -> t
       val falseRef: bool ref -> t
       val intRef: int ref -> t
       val stringRef: string ref -> t
       val trueRef: bool ref -> t
+      val wordRef: word ref -> t
 
       val trace: string * t
 

--- a/lib/mlton/basic/popt.sig
+++ b/lib/mlton/basic/popt.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -15,18 +15,18 @@ signature POPT =
       datatype t =
          (* one arg: a boolean (true, false), after a space *)
          Bool of bool -> unit
-         (* one arg: an integer, after a space *)
-       | Digit of int -> unit
-         (* one arg: an integer followed by tional k or m. *)
-       | Int of int -> unit
          (* one arg: a single digit, no space. *)
+       | Digit of int -> unit
+         (* one arg: an integer, after a space *)
+       | Int of int -> unit
+         (* one arg: an integer followed by optional k or m. *)
        | Mem of int -> unit
          (* no args *)
        | None of unit -> unit
        | Real of real -> unit
          (* Any string immediately follows the switch. *)
        | String of string -> unit
-         (* one arg: any string *)
+         (* one arg: any string, after a space *)
        | SpaceString of string -> unit
        | SpaceString2 of string * string -> unit
 

--- a/lib/mlton/basic/popt.sml
+++ b/lib/mlton/basic/popt.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -20,6 +20,7 @@ datatype t =
  | SpaceString of string -> unit
  | SpaceString2 of string * string -> unit
  | String of string -> unit
+ | Word of word -> unit
 
 local
    fun make b (r: bool ref): t = None (fn () => r := b)
@@ -33,6 +34,8 @@ fun boolRef (r: bool ref): t = Bool (fn b => r := b)
 fun intRef (r: int ref): t = Int (fn n => r := n)
 
 fun stringRef (r: string ref): t = String (fn s => r := s)
+
+fun wordRef (r: word ref): t = Word (fn w => r := w)
 
 val trace = ("trace", SpaceString (fn s =>
                                    let
@@ -143,6 +146,7 @@ fun parse {switches: string list,
                                            (f (s1, s2); loop switches)
                                       | _ => error (concat ["-", switch, " requires two arguments"]))
                                | String f => (f ""; loop switches)
+                               | Word f => next (f, Word.fromString, "a word")
                            end
                      end
                    | _ => switch :: switches

--- a/lib/mlton/basic/quick-sort.sml
+++ b/lib/mlton/basic/quick-sort.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -11,7 +11,7 @@ struct
 
 open Array
 
-val rand = Word.toIntX o MLton.Random.rand
+val rand = Word.toIntX o Random.word
 
 fun randInt (lo, hi) = lo + Int.mod (rand(), hi - lo + 1)
 

--- a/lib/mlton/basic/random.sml
+++ b/lib/mlton/basic/random.sml
@@ -20,6 +20,7 @@ in
 end
 
 val word = Trace.trace ("Random.word", Unit.layout, Word.layout) word
+val srand = Trace.trace ("Random.srand", Word.layout, Unit.layout) srand
 
 local
    val ri: int ref = ref 0

--- a/lib/mlton/basic/random.sml
+++ b/lib/mlton/basic/random.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -83,7 +83,7 @@ in
             val () =
                if w - 0w1 <= !max
                   then ()
-               else (r := MLton.Random.rand ()
+               else (r := word ()
                      ; max := Word.notb 0wx0)
             val w' = !r
             val () = r := Word.div (w', w)

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -248,7 +248,8 @@ signature CONTROL_FLAGS =
       val libname : string ref
 
       (* Number of times to loop through optimization passes. *)
-      val loopPasses: int ref
+      val loopSsaPasses: int ref
+      val loopSsa2Passes: int ref
 
       (* Limit the code growth loop unrolling/unswitching will allow. *)
       val loopUnrollLimit: int ref

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -909,9 +909,13 @@ val libTargetDir = control {name = "lib target dir",
 
 val libname = ref ""
 
-val loopPasses = control {name = "loop passes",
-                          default = 1,
-                          toString = Int.toString}
+val loopSsaPasses = control {name = "loop ssa passes",
+                             default = 1,
+                             toString = Int.toString}
+
+val loopSsa2Passes = control {name = "loop ssa2 passes",
+                              default = 1,
+                              toString = Int.toString}
 
 val loopUnrollLimit = control {name = "loop unrolling limit",
                                 default = 150,

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -565,12 +565,18 @@ fun makeOptions {usage} =
        (Expert, "llvm-opt-opt-quote", " <opt>", "pass (quoted) option to llvm optimizer",
         SpaceString
         (fn s => List.push (llvm_optOpts, {opt = s, pred = OptPred.Yes}))),
-       (Expert, "loop-passes", " <n>", "loop optimization passes (1)",
+       (Expert, "loop-ssa-passes", " <n>", "loop ssa optimization passes (1)",
         Int
         (fn i =>
          if i >= 1
-            then loopPasses := i
-            else usage (concat ["invalid -loop-passes arg: ", Int.toString i]))),
+            then loopSsaPasses := i
+            else usage (concat ["invalid -loop-ssa-passes arg: ", Int.toString i]))),
+       (Expert, "loop-ssa2-passes", " <n>", "loop ssa2 optimization passes (1)",
+        Int
+        (fn i =>
+         if i >= 1
+            then loopSsa2Passes := i
+            else usage (concat ["invalid -loop-ssa2-passes arg: ", Int.toString i]))),
        (Expert, "loop-unroll-limit", " <n>", "limit code growth by loop unrolling",
         Int
         (fn i =>

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -766,6 +766,8 @@ fun makeOptions {usage} =
         boolRef profileVal),
        (Normal, "runtime", " <arg>", "pass arg to runtime via @MLton",
         SpaceString (fn s => List.push (runtimeArgs, s))),
+       (Expert, "seed-rand", " <w>", "seed the pseudo-random number generator",
+        Word Random.srand),
        (Expert, "show", " {anns|path-map}", "print specified data and stop",
         SpaceString
         (fn s =>

--- a/mlton/ssa/simplify.fun
+++ b/mlton/ssa/simplify.fun
@@ -214,14 +214,12 @@ local
 
    val passGens = 
       inlinePassGen ::
-      (List.map([("addProfile", Profile.addProfile),
-                 ("combineConversions",  CombineConversions.transform),
+      (List.map([("combineConversions",  CombineConversions.transform),
                  ("commonArg", CommonArg.transform),
                  ("commonBlock", CommonBlock.transform),
                  ("commonSubexp", CommonSubexp.transform),
                  ("constantPropagation", ConstantPropagation.transform),
                  ("contify", Contify.transform),
-                 ("dropProfile", Profile.dropProfile),
                  ("flatten", Flatten.transform),
                  ("introduceLoops", IntroduceLoops.transform),
                  ("knownCase", KnownCase.transform),
@@ -238,12 +236,13 @@ local
                  ("shareZeroVec", ShareZeroVec.transform),
                  ("simplifyTypes", SimplifyTypes.transform),
                  ("useless", Useless.transform),
-                 ("breakCriticalEdges",fn p => 
-                  S.breakCriticalEdges (p, {codeMotion = true})),
-                 ("eliminateDeadBlocks",S.eliminateDeadBlocks),
-                 ("orderFunctions",S.orderFunctions),
-                 ("reverseFunctions",S.reverseFunctions),
-                 ("shrink", S.shrink)],
+                 ("ssaAddProfile", Profile.addProfile),
+                 ("ssaDropProfile", Profile.dropProfile),
+                 ("ssaBreakCriticalEdges", fn p => S.breakCriticalEdges (p, {codeMotion = true})),
+                 ("ssaEliminateDeadBlocks", S.eliminateDeadBlocks),
+                 ("ssaOrderFunctions", S.orderFunctions),
+                 ("ssaReverseFunctions", S.reverseFunctions),
+                 ("ssaShrink", S.shrink)],
                 mkSimplePassGen))
 in
    fun ssaPassesSetCustom s =
@@ -336,11 +335,11 @@ val simplify = fn p => let
                          val p =
                             if !Control.profile <> Control.ProfileNone
                                andalso !Control.profileIL = Control.ProfileSSA
-                               then pass ({name = "addProfile1",
+                               then pass ({name = "ssaAddProfile",
                                            doit = Profile.addProfile,
                                            midfix = ""}, p)
                             else p
-                         val p = maybePass ({name = "orderFunctions1",
+                         val p = maybePass ({name = "ssaOrderFunctions",
                                              doit = S.orderFunctions,
                                              execute = true,
                                              midfix = ""}, p)

--- a/mlton/ssa/simplify.fun
+++ b/mlton/ssa/simplify.fun
@@ -308,11 +308,11 @@ fun simplify p =
    let
       fun simplify' n p =
          let
-            val midfix = if n = 0
+            val midfix = if !Control.loopSsaPasses = 1
                             then ""
-                         else concat [Int.toString n,"."]
+                         else concat [Int.toString n, "."]
          in
-            if n = !Control.loopPasses
+            if n = !Control.loopSsaPasses
                then p
             else simplify' 
                  (n + 1)

--- a/mlton/ssa/simplify2.fun
+++ b/mlton/ssa/simplify2.fun
@@ -49,16 +49,16 @@ local
 
 
    val passGens = 
-      List.map([("addProfile", Profile2.addProfile),
-                ("deepFlatten", DeepFlatten.transform2),
-                ("dropProfile", Profile2.dropProfile),
+      List.map([("deepFlatten", DeepFlatten.transform2),
                 ("refFlatten", RefFlatten.transform2),
                 ("removeUnused", RemoveUnused2.transform2),
                 ("zone", Zone.transform2),
-                ("eliminateDeadBlocks",S.eliminateDeadBlocks),
-                ("orderFunctions",S.orderFunctions),
-                ("reverseFunctions",S.reverseFunctions),
-                ("shrink", S.shrink)],
+                ("ssa2AddProfile", Profile2.addProfile),
+                ("ssa2DropProfile", Profile2.dropProfile),
+                ("ssa2EliminateDeadBlocks", S.eliminateDeadBlocks),
+                ("ssa2OrderFunctions", S.orderFunctions),
+                ("ssa2ReverseFunctions", S.reverseFunctions),
+                ("ssa2Shrink", S.shrink)],
                mkSimplePassGen)
 in
    fun ssa2PassesSetCustom s =
@@ -151,11 +151,11 @@ val simplify = fn p => let
                          val p =
                             if !Control.profile <> Control.ProfileNone
                                andalso !Control.profileIL = Control.ProfileSSA2
-                               then pass ({name = "addProfile2",
+                               then pass ({name = "ssa2AddProfile",
                                            doit = Profile2.addProfile,
                                            midfix = ""}, p)
                             else p
-                         val p = maybePass ({name = "orderFunctions2",
+                         val p = maybePass ({name = "ssa2OrderFunctions",
                                              doit = S.orderFunctions,
                                              execute = true,
                                              midfix = ""}, p)

--- a/mlton/ssa/simplify2.fun
+++ b/mlton/ssa/simplify2.fun
@@ -124,11 +124,11 @@ fun simplify p =
    let
       fun simplify' n p =
          let
-            val midfix = if n = 0
+            val midfix = if !Control.loopSsa2Passes = 1
                             then ""
-                         else concat [Int.toString n,"."]
+                         else concat [Int.toString n, "."]
          in
-            if n = !Control.loopPasses
+            if n = !Control.loopSsa2Passes
                then p
             else simplify' 
                  (n + 1)

--- a/mlton/ssa/simplify2.fun
+++ b/mlton/ssa/simplify2.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Matthew Fluet.
+ * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -11,27 +12,10 @@ struct
 
 open S
 
-(* structure CommonArg = CommonArg (S) *)
-(* structure CommonBlock = CommonBlock (S) *)
-(* structure CommonSubexp = CommonSubexp (S) *)
-(* structure ConstantPropagation = ConstantPropagation (S) *)
-(* structure Contify = Contify (S) *)
 structure DeepFlatten = DeepFlatten (S)
-(* structure Flatten = Flatten (S) *)
-(* structure Inline = Inline (S) *)
-(* structure IntroduceLoops = IntroduceLoops (S) *)
-(* structure KnownCase = KnownCase (S) *)
-(* structure LocalFlatten = LocalFlatten (S) *)
-(* structure LocalRef = LocalRef (S) *)
-(* structure LoopInvariant = LoopInvariant (S) *)
-(* structure PolyEqual = PolyEqual (S) *)
 structure Profile2 = Profile2 (S)
-(* structure Redundant = Redundant (S) *)
-(* structure RedundantTests = RedundantTests (S) *)
 structure RefFlatten = RefFlatten (S)
 structure RemoveUnused2 = RemoveUnused2 (S)
-(* structure SimplifyTypes = SimplifyTypes (S) *)
-(* structure Useless = Useless (S) *)
 structure Zone = Zone (S)
 
 type pass = {name: string,


### PR DESCRIPTION
As has been well documented, seemingly trivial aspects of an experimental setup and/or a compiled program (for example, code placement) can have non-trivial impact on behavior (for example, run time).

A new MachineShuffle pass can be run after generating the MachineIR program.  This pass simply shuffles the collection of chunks within the program and shuffles the collection of blocks within a chunk.  Combined with a new `-seed-rand <w>` compiler option, this can yield distinct code placements.

Results in 40455fa.