### PR TITLE
Suppress diagnostics in Restore{,2} pass

### DIFF
--- a/mlton/ssa/restore.fun
+++ b/mlton/ssa/restore.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -25,6 +25,12 @@
 
 functor Restore (S: RESTORE_STRUCTS): RESTORE =
 struct
+
+structure Control =
+   struct
+      open Control
+      fun diagnostics _ = ()
+   end
 
 open S
 open Exp Transfer

--- a/mlton/ssa/restore2.fun
+++ b/mlton/ssa/restore2.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2009,2017 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -25,6 +25,12 @@
 
 functor Restore2 (S: RESTORE2_STRUCTS): RESTORE2 =
 struct
+
+structure Control =
+   struct
+      open Control
+      fun diagnostics _ = ()
+   end
 
 open S
 open Exp Transfer


### PR DESCRIPTION
The flood of Restore diagnostics can obscure the diagnostic from the
invoking pass.