### PR TITLE
Add `-opt-fuel <n>` expert compile-time option

### DIFF
--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -301,6 +301,10 @@ signature CONTROL_FLAGS =
             val split: int option ref
          end
 
+      val optFuel: int option ref
+
+      val optFuelAvailAndUse: unit -> bool
+
       val optimizationPasses:
          {il: string, set: string -> unit Result.t, get: unit -> string} list ref
       

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -987,6 +987,24 @@ structure Native =
                            toString = Option.toString Int.toString}
    end
 
+val optFuel =
+   control {name = "optFuel",
+            default = NONE,
+            toString = Option.toString Int.toString}
+
+fun optFuelAvailAndUse () =
+   case !optFuel of
+      NONE => true
+    | SOME i => if i > 0
+                   then (optFuel := SOME (i - 1); true)
+                   else false
+(* Suppress unused variable warning
+ * This variable is purposefully unused in production,
+ * but is retained to make it easy to use in development of new
+ * optimization passes.
+ *)
+val _ = optFuelAvailAndUse
+
 val optimizationPasses:
    {il: string, set: string -> unit Result.t, get: unit -> string} list ref =
    control {name = "optimizationPasses",

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -625,6 +625,8 @@ fun makeOptions {usage} =
        (Expert, "native-shuffle", " {true|false}",
         "shuffle registers at C-calls",
         Bool (fn b => Native.shuffle := b)),
+       (Expert, "opt-fuel", " <n>", "optimization 'fuel'",
+        Int (fn n => optFuel := SOME n)),
        (Expert, "opt-passes", " {default|minimal}", "level of optimizations",
         SpaceString (fn s =>
                      let


### PR DESCRIPTION
A useful technique for developing optimization passes is to limit the
number of transformations made according to some finite "fuel".  The
particular transformation that triggers a bug or a performance change
can be found by binary-searching through the space of
fuels (`-opt-fuel 0` when the bug does not occur and `-opt-fuel 1000`
when the bug does occur).

A `val Control.optFuelAvailAndUse: unit -> bool` is also provided.

By default, if `-opt-fuel` is not given, then "infinite" fuel is
assumed.