### PR TITLE
Fix heap invariant predicates

### DIFF
--- a/runtime/gc/heap_predicates.c
+++ b/runtime/gc/heap_predicates.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012 Matthew Fluet.
+/* Copyright (C) 2012,2017 Matthew Fluet.
  * Copyright (C) 2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -9,12 +9,13 @@
 bool isPointerInOldGen (GC_state s, pointer p) {
   return (not (isPointer (p))
           or (s->heap.start <= p 
-              and p < s->heap.start + s->heap.oldGenSize));
+              and p + sizeofObjectNoMetaData (s, p) <= s->heap.start + s->heap.oldGenSize));
 }
 
 bool isPointerInNursery (GC_state s, pointer p) {
   return (not (isPointer (p))
-          or (s->heap.nursery <= p and p < s->frontier));
+          or (s->heap.nursery <= p
+              and p + sizeofObjectNoMetaData (s, p) <= s->frontier));
 }
 
 #if ASSERT

--- a/runtime/gc/heap_predicates.c
+++ b/runtime/gc/heap_predicates.c
@@ -9,13 +9,13 @@
 bool isPointerInOldGen (GC_state s, pointer p) {
   return (not (isPointer (p))
           or (s->heap.start <= p 
-              and p + sizeofObjectNoMetaData (s, p) <= s->heap.start + s->heap.oldGenSize));
+              and p <= s->heap.start + s->heap.oldGenSize));
 }
 
 bool isPointerInNursery (GC_state s, pointer p) {
   return (not (isPointer (p))
           or (s->heap.nursery <= p
-              and p + sizeofObjectNoMetaData (s, p) <= s->frontier));
+              and p <= s->frontier));
 }
 
 #if ASSERT

--- a/runtime/gc/invariant.c
+++ b/runtime/gc/invariant.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011-2012 Matthew Fluet.
+/* Copyright (C) 2011-2012,2017 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -10,11 +10,13 @@
 #if ASSERT
 void assertIsObjptrInFromSpace (GC_state s, objptr *opp) {
   assert (isObjptrInFromSpace (s, *opp));
-  unless (isObjptrInFromSpace (s, *opp))
+  unless (isObjptrInFromSpace (s, *opp)) {
+    displayGCState (s, stderr);
     die ("gc.c: assertIsObjptrInFromSpace "
          "opp = "FMTPTR"  "
          "*opp = "FMTOBJPTR"\n",
          (uintptr_t)opp, *opp);
+  }
   /* The following checks that intergenerational pointers have the
    * appropriate card marked.  Unfortunately, it doesn't work because
    * for stacks, the card containing the beginning of the stack is

--- a/runtime/gc/object-size.h
+++ b/runtime/gc/object-size.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Matthew Fluet.
+/* Copyright (C) 2016-2017 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -13,6 +13,11 @@ static inline size_t sizeofArrayNoMetaData (GC_state s, GC_arrayLength numElemen
                                             uint16_t bytesNonObjptrs, uint16_t numObjptrs);
 static inline size_t sizeofStackNoMetaData (GC_state s, GC_stack stack);
 
+static inline void sizeofObjectAux (GC_state s, pointer p,
+                                    size_t* metaDataBytes, size_t* objectBytes);
+
 static inline size_t sizeofObject (GC_state s, pointer p);
+
+static inline size_t sizeofObjectNoMetaData (GC_state s, pointer p);
 
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */

--- a/runtime/gc/virtual-memory.c
+++ b/runtime/gc/virtual-memory.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010 Matthew Fluet.
+/* Copyright (C) 2010,2017 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -23,9 +23,6 @@ static inline void GC_memcpy (pointer src, pointer dst, size_t size) {
   if (DEBUG_DETAILED)
     fprintf (stderr, "GC_memcpy ("FMTPTR", "FMTPTR", %"PRIuMAX")\n",
              (uintptr_t)src, (uintptr_t)dst, (uintmax_t)size);
-  assert (isAligned ((size_t)src, sizeof(unsigned int)));
-  assert (isAligned ((size_t)dst, sizeof(unsigned int)));
-  assert (isAligned (size, sizeof(unsigned int)));
   assert (! (src <= dst and dst < src + size));
   assert (! (dst <= src and src < dst + size));
   memcpy (dst, src, size);
@@ -35,9 +32,6 @@ static inline void GC_memmove (pointer src, pointer dst, size_t size) {
   if (DEBUG_DETAILED)
     fprintf (stderr, "GC_memmove ("FMTPTR", "FMTPTR", %"PRIuMAX")\n",
              (uintptr_t)src, (uintptr_t)dst, (uintmax_t)size);
-  assert (isAligned ((size_t)src, sizeof(unsigned int)));
-  assert (isAligned ((size_t)dst, sizeof(unsigned int)));
-  assert (isAligned (size, sizeof(unsigned int)));
   if (src == dst)
     return;
   memmove (dst, src, size);


### PR DESCRIPTION
Previously, the `isPointerInOldGen` and `isPointerInNursery`
predicates checked that the object pointer is strictly less than
`s->heap.start + s->heap.oldGenSize` and `s->frontier`, respectively.

With MLton/mlton#219 (forward pointer in header), 0-byte objects are
allowed and the above checks are insufficient.  In particular,
immediately after allocating a 0-byte object, the object pointer is
equal to the frontier.

Now, the `isPointerInOldGen` and `isPointerInNursery` predicates are
revised to check that the end of the object is less than or equal to
`s->heap.start + s->heap.oldGenSize` and `s->frontier`, respectively.