### PR TITLE
Added a Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - gcc
   - clang
 env:
-  - PREFIX=$HOME/opt/mlton
+  - PREFIX=/usr/local
 install:
   - sudo apt-get -qq update
   - sudo apt-get install -qq build-essential git autoconf mlton

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
 # Install the dependencies. We'll use the ubuntu provided mlton to bootstrap our local build.
-RUN apt-get update -y -qq \
- && apt-get install -y -qq git build-essential libgmp-dev libtool automake mlton mlton-tools 
+RUN apt-get update -qq \
+ && apt-get install -qq git build-essential libgmp-dev autoconf mlton mlton-tools
 
 # Copy the current directory (MLton source root) to a location within the container & move there
 COPY . /root/mlton
@@ -12,6 +12,6 @@ WORKDIR /root/mlton
 RUN autoreconf -vfi \
  && ./configure \
  && make \
- && make install PREFIX=
+ && make install
 
 ENTRYPOINT ["make", "check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:latest
+
+# Install the dependencies. We'll use the ubuntu provided mlton to bootstrap our local build.
+RUN apt-get update -y -qq \
+ && apt-get install -y -qq git build-essential libgmp-dev libtool automake mlton mlton-tools 
+
+# Copy the current directory (MLton source root) to a location within the container & move there
+COPY . /root/mlton
+WORKDIR /root/mlton
+
+# Build from source & install
+RUN autoreconf -vfi \
+ && ./configure \
+ && make \
+ && make install \
+ && rsync -a /usr/local/usr/ /usr/local/
+
+ENTRYPOINT ["make", "check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ WORKDIR /root/mlton
 RUN autoreconf -vfi \
  && ./configure \
  && make \
- && make install \
- && rsync -a /usr/local/usr/ /usr/local/
+ && make install PREFIX=
 
 ENTRYPOINT ["make", "check"]

--- a/Makefile.in
+++ b/Makefile.in
@@ -313,22 +313,14 @@ check:
 # The DESTDIR is added onto them to indicate where the Makefile actually
 # puts them.
 DESTDIR := @prefix@
-PREFIX := /usr
-ifeq ($(findstring $(TARGET_OS), darwin freebsd solaris), $(TARGET_OS))
-PREFIX := /usr/local
-endif
-ifeq ($(TARGET_OS), mingw)
-PREFIX := /mingw
-endif
-prefix := $(PREFIX)
 MAN_PREFIX_EXTRA :=
-TBIN := $(DESTDIR)$(prefix)/bin
+TBIN := $(DESTDIR)/bin
 ULIB := lib/mlton
-TLIB := $(DESTDIR)$(prefix)/$(ULIB)
-TMAN := $(DESTDIR)$(prefix)$(MAN_PREFIX_EXTRA)/man/man1
-TDOC := $(DESTDIR)$(prefix)/share/doc/mlton
+TLIB := $(DESTDIR)/$(ULIB)
+TMAN := $(DESTDIR)$(MAN_PREFIX_EXTRA)/man/man1
+TDOC := $(DESTDIR)/share/doc/mlton
 ifeq ($(findstring $(TARGET_OS), solaris mingw), $(TARGET_OS))
-TDOC := $(DESTDIR)$(prefix)/doc/mlton
+TDOC := $(DESTDIR)/doc/mlton
 endif
 TEXM := $(TDOC)/examples
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ The archive can be extracted anywhere. The MLton binary can be run with
 dependency can be found). To uninstall, simply delete the directory 
 containing the MLton installation (`<root>/mlton`).
 
+To run regression tests on `MLton` compiled locally in a Docker container, 
+execute `./bin/run-docker`.
+
 
 ## Resources
 

--- a/bin/run-docker
+++ b/bin/run-docker
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-docker rm $(docker ps -qa)
-docker rmi -f $(docker images -qa -f 'dangling=true')
-
-# build container
 NAME="mlton"
-docker build --no-cache=true -t $NAME .
 
-# run container
-docker run -i -t $NAME
+# Remove any containers which already have $NAME.
+docker image rm $NAME
+
+# build container, and assign it tag $NAME
+docker build -t $NAME .
+
+# run container with the tag $NAME.
+docker run --rm -it $NAME

--- a/bin/run-docker
+++ b/bin/run-docker
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NAME="mlton"
+NAME="mlton-run-docker"
 
 # Remove any containers which already have $NAME.
 docker image rm $NAME

--- a/bin/run-docker
+++ b/bin/run-docker
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+docker rm $(docker ps -qa)
+docker rmi -f $(docker images -qa -f 'dangling=true')
+
+# build container
+NAME="mlton"
+docker build --no-cache=true -t $NAME .
+
+# run container
+docker run -i -t $NAME


### PR DESCRIPTION
Added a simple Dockerfile which can be used to create an image with MLton built and installed on an ubuntu container. The build will be completed using the ubuntu provided **mlton** and **mlton-tools** packages.

The default entry point for the generated container image is to run the regression tests via **make check**.