### PR TITLE
Drop feature macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_CONFIG_HEADERS([config.h])
 ###############################################################################
 
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,6 @@ AC_CONFIG_HEADERS([config.h])
 ###############################################################################
 
 AC_PROG_CC
-AC_PROG_CC_STDC # enforce C99 standard whenever calling CC
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -235,10 +235,9 @@ fun creturn (t: Type.t): string =
    concat ["CReturn", CType.name (Type.toCType t)]
 
 fun outputIncludes (includes, print) =
-   (print "#define _ISOC99_SOURCE\n"
-    ; List.foreach (includes, fn i => (print "#include <";
-                                       print i;
-                                       print ">\n"))
+   (List.foreach (includes, fn i => (print "#include <";
+                                     print i;
+                                     print ">\n"))
     ; print "\n")
 
 fun declareProfileLabel (l, print) =

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1426,7 +1426,7 @@ fun commandLine (args: string list): unit =
                            System.system
                             (gcc,
                              List.concat
-                             [[ "-std=gnu99", "-c" ],
+                             [[ "-c" ],
                               if !format = Executable
                               then [] else [ "-DLIBNAME=" ^ !libname ],
                               if positionIndependent

--- a/runtime/cenv.h
+++ b/runtime/cenv.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012 Matthew Fluet.
+/* Copyright (C) 2012,2017 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -10,16 +10,6 @@
 #ifndef _MLTON_CENV_H_
 #define _MLTON_CENV_H_
 
-/* GNU C Library Feature Macros */
-#define _ISOC99_SOURCE
-#define _BSD_SOURCE
-// #define _XOPEN_SOURCE 600
-/* Only enable _POSIX_C_SOURCE on platforms that don't have broken
- * system headers.
- */
-#if (defined (__linux__) || defined(__GNU__))
-#define _POSIX_C_SOURCE 200112L
-#endif
 #define _FILE_OFFSET_BITS 64
 
 #ifndef ASSERT

--- a/runtime/gen/gen-types.c
+++ b/runtime/gen/gen-types.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012 Matthew Fluet.
+/* Copyright (C) 2012,2017 Matthew Fluet.
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -23,9 +23,6 @@ static const char* mlTypesHPrefix[] = {
   "/* We need these because in header files for exported SML functions, ",
   " * types.h is included without cenv.h.",
   " */",
-  "#ifndef _ISOC99_SOURCE",
-  "#define _ISOC99_SOURCE",
-  "#endif",
   "#if (defined (_AIX) || defined (__hpux__) || defined (__OpenBSD__))",
   "#include <inttypes.h>",
   "#elif (defined (__sun__))",


### PR DESCRIPTION
Recent versions of glibc have complained about defining both `_BSD_SOURCE` and `_POSIX_C_SOURCE`, suggesting that that combination should be enabled by `_DEFAULT_SOURCE`, which is the default.  On Fedora (though, not (yet) Ubuntu), this leads to many warning messages during compilation of the runtime.

Would like to drop `-std=gnu99` and use compiler default, but MLton does require C99 (or greater) to compile the runtime system and gcc 4.8.4 on Ubuntu 14.04 (as provided by TravisCI) defaults to `-std=gnu90`.