### PR TITLE
Propagate --with-gmp args for runtime linking; add check for GMP at configure time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ install:
   - sudo apt-get install -qq build-essential git autoconf mlton
 script:
   - bash -ex ./bin/travis-ci
+after_failure: "cat $(pwd)/config.log"
 notifications:
   email: true

--- a/Makefile.in
+++ b/Makefile.in
@@ -37,7 +37,7 @@ CP := /bin/cp -fpR
 GZIP := gzip --force --best
 RANLIB := @RANLIB@
 SED := @SED@
-CC := @CC@
+CC := $(shell echo "@CC@" | $(SED) 's/ .*//')
 
 
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -37,6 +37,8 @@ CP := /bin/cp -fpR
 GZIP := gzip --force --best
 RANLIB := @RANLIB@
 SED := @SED@
+CC := @CC@
+
 
 
 # Allow for custom paths to GMP include and library files
@@ -229,7 +231,7 @@ runtime:
 
 .PHONY: script
 script:
-	$(SED) -e "/^gmpIncDir=/s;.*;gmpIncDir='$(WITH_GMP_INC_DIR)';" -e "/^gmpLibDir=/s;.*;gmpLibDir='$(WITH_GMP_LIB_DIR)';"	\
+	$(SED) -e "/^CC=/s;.*;CC='$(CC)';"  -e "/^gmpIncDir=/s;.*;gmpIncDir='$(WITH_GMP_INC_DIR)';" -e "/^gmpLibDir=/s;.*;gmpLibDir='$(WITH_GMP_LIB_DIR)';"	\
 		<bin/mlton-script >"$(MLTON)"
 	chmod a+x "$(MLTON)"
 	$(CP) "$(SRC)/bin/platform" "$(LIB)"

--- a/Makefile.in
+++ b/Makefile.in
@@ -39,6 +39,14 @@ RANLIB := @RANLIB@
 SED := @SED@
 
 
+# Allow for custom paths to GMP include and library files
+ifneq (@WITH_GMP_INC_DIR@,)
+WITH_GMP_INC_DIR := @WITH_GMP_INC_DIR@
+endif
+ifneq (@WITH_GMP_LIB_DIR@,)
+WITH_GMP_LIB_DIR := @WITH_GMP_LIB_DIR@
+endif
+
 # If we're compiling with another version of MLton, then we want to do
 # another round of compilation so that we get a MLton built without
 # stubs.
@@ -221,7 +229,8 @@ runtime:
 
 .PHONY: script
 script:
-	cat bin/mlton-script >"$(MLTON)"
+	$(SED) -e "/^gmpIncDir=/s;.*;gmpIncDir='$(WITH_GMP_INC_DIR)';" -e "/^gmpLibDir=/s;.*;gmpLibDir='$(WITH_GMP_LIB_DIR)';"	\
+		<bin/mlton-script >"$(MLTON)"
 	chmod a+x "$(MLTON)"
 	$(CP) "$(SRC)/bin/platform" "$(LIB)"
 	$(CP) "$(SRC)/bin/static-library" "$(LIB)"

--- a/Makefile.in
+++ b/Makefile.in
@@ -221,7 +221,7 @@ runtime:
 
 .PHONY: script
 script:
-	cat bin/mlton-script >"/opt/mlton/build/bin/mlton"
+	cat bin/mlton-script >"$(MLTON)"
 	chmod a+x "$(MLTON)"
 	$(CP) "$(SRC)/bin/platform" "$(LIB)"
 	$(CP) "$(SRC)/bin/static-library" "$(LIB)"

--- a/Makefile.in
+++ b/Makefile.in
@@ -39,14 +39,6 @@ RANLIB := @RANLIB@
 SED := @SED@
 
 
-# Allow for custom paths to GMP include and library files
-ifneq (@WITH_GMP_INC_DIR@,)
-WITH_GMP_INC_DIR := @WITH_GMP_INC_DIR@
-endif
-ifneq (@WITH_GMP_LIB_DIR@,)
-WITH_GMP_LIB_DIR := @WITH_GMP_LIB_DIR@
-endif
-
 # If we're compiling with another version of MLton, then we want to do
 # another round of compilation so that we get a MLton built without
 # stubs.
@@ -189,8 +181,8 @@ polyml-mlton:
 	$(CP) "$(COMP)/mlton-polyml$(EXE)" "$(LIB)/"
 	$(MAKE) script basis-no-check mlbpathmap constants libraries-no-check
 	cat "$(MLTON)" \
-		| sed 's/doitMLton \"$$@\"/# doitMLton \"$$@\"/' \
-		| sed 's/doitSMLNJ \"$$@\"/# doitSMLNJ \"$$@\"/' \
+		| $(SED) 's/doitMLton \"$$@\"/# doitMLton \"$$@\"/' \
+		| $(SED) 's/doitSMLNJ \"$$@\"/# doitSMLNJ \"$$@\"/' \
 		> "$(MLTON).polyml"
 	chmod u+x "$(MLTON).polyml"
 	@echo 'Build of MLton succeeded.'
@@ -201,7 +193,7 @@ profiled:
 		$(MAKE) -C "$(COMP)" "AOUT=$(AOUT).$$t"			\
 			COMPILE_ARGS="-profile $$t";			\
 		$(CP) "$(COMP)/$(AOUT).$$t" "$(LIB)/";			\
-		sed "s/mlton-compile/mlton-compile.$$t/" 		\
+		$(SED) "s/mlton-compile/mlton-compile.$$t/" 		\
 			<"$(MLTON)" 					\
 			>"$(MLTON).$$t";				\
 		chmod a+x "$(MLTON).$$t";				\
@@ -229,8 +221,7 @@ runtime:
 
 .PHONY: script
 script:
-	sed -e "/^gmpIncDir=/s;.*;gmpIncDir='$(WITH_GMP_INC_DIR)';" -e "/^gmpLibDir=/s;.*;gmpLibDir='$(WITH_GMP_LIB_DIR)';"	\
-		<bin/mlton-script >"$(MLTON)"
+	cat bin/mlton-script >"/opt/mlton/build/bin/mlton"
 	chmod a+x "$(MLTON)"
 	$(CP) "$(SRC)/bin/platform" "$(LIB)"
 	$(CP) "$(SRC)/bin/static-library" "$(LIB)"
@@ -245,8 +236,8 @@ smlnj-mlton:
 	smlnj_heap_suffix=`echo 'TextIO.output (TextIO.stdErr, SMLofNJ.SysInfo.getHeapSuffix ());' | sml 2>&1 1> /dev/null` && $(CP) "$(COMP)/mlton-smlnj.$$smlnj_heap_suffix" "$(LIB)/"
 	$(MAKE) script basis-no-check mlbpathmap constants libraries-no-check
 	cat "$(MLTON)" \
-		| sed 's/doitMLton \"$$@\"/# doitMLton \"$$@\"/' \
-		| sed 's/doitPolyML \"$$@\"/# doitPolyML \"$$@\"/' \
+		| $(SED) 's/doitMLton \"$$@\"/# doitMLton \"$$@\"/' \
+		| $(SED) 's/doitPolyML \"$$@\"/# doitPolyML \"$$@\"/' \
 		> "$(MLTON).smlnj"
 	chmod u+x "$(MLTON).smlnj"
 	@echo 'Build of MLton succeeded.'
@@ -271,7 +262,7 @@ smlnj-mlton-x16:
 traced:
 	$(MAKE) -C "$(COMP)" "AOUT=$(AOUT).trace" COMPILE_ARGS="-const 'Exn.keepHistory true' -profile-val true -const 'MLton.debug true' -disable-pass 'deepFlatten'"
 	$(CP) "$(COMP)/$(AOUT).trace" "$(LIB)/"
-	sed 's/mlton-compile/mlton-compile.trace/' < "$(MLTON)" > "$(MLTON).trace"
+	$(SED) 's/mlton-compile/mlton-compile.trace/' < "$(MLTON)" > "$(MLTON).trace"
 	chmod a+x "$(MLTON).trace"
 
 .PHONY: tools
@@ -296,12 +287,12 @@ version:
 		doc/guide/conf/asciidoc-mlton.flags			\
 	; do								\
 		if grep -q 'MLTONVERSION' "$$f"; then			\
-			sed "s/\(.*\)MLTONVERSION\(.*\)/\1$(VERSION)\2/" <"$$f" >z && 	\
+			$(SED) "s/\(.*\)MLTONVERSION\(.*\)/\1$(VERSION)\2/" <"$$f" >z && 	\
 			mv z "$$f";							\
 		fi;							\
 	done
 	if grep -q '^Release:$$' "$(SPEC)"; then			\
-		sed <"$(SPEC)" >z "/^Release:/s;.*;Release: $(RELEASE);"; 		\
+		$(SED) <"$(SPEC)" >z "/^Release:/s;.*;Release: $(RELEASE);"; 		\
 		mv z "$(SPEC)";								\
 	fi
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ via `XCFLAGS` and `XLDFLAGS` environment variables:
 ```shell
 ./configure \
   XCFLAGS='-I/usr/local/include' \
-  XLDFLAGS='-L/usr/local/lib'
+  XLDFLAGS='-L/usr/local/lib -Wl,-rpath=/usr/local/lib'
 ```
 
 If building from source cloned from Github, first generate the `configure`

--- a/bin/mlton-script.in
+++ b/bin/mlton-script.in
@@ -80,17 +80,6 @@ xldflags="-link-opt '$XLDFLAGS'"
 fi
 
 
-# You may need to set 'gmpIncDir' so the C compiler can find gmp.h.
-gmpIncDir=
-if [ -n "$gmpIncDir" ]; then
-gmpCCOpts="-cc-opt -I$gmpIncDir"
-fi
-# You may need to set 'gmpLibDir' so the C compiler can find libgmp.
-gmpLibDir=
-if [ -n "$gmpLibDir" ]; then
-gmpLinkOpts="-link-opt -L$gmpLibDir -target-link-opt netbsd -Wl,-R$gmpLibDir"
-fi
-
 # For align-{functions,jumps,loops}, we use -m for now instead of
 # -f because old gcc's will barf on -f, while newer ones only warn
 # about -m.  Someday, when we think we won't run into older gcc's,
@@ -104,7 +93,6 @@ doit "$lib" \
         -cc-opt '-O1 -fno-common'                                \
         -cc-opt '-fno-strict-aliasing -fomit-frame-pointer -w'   \
         -link-opt '-lm -lgmp'                                    \
-        $gmpCCOpts $gmpLinkOpts                                  \
         -llvm-llc-opt '-O2'                                      \
         -llvm-opt-opt '-mem2reg -O2'                             \
         -mlb-path-map "$lib/mlb-path-map"                        \

--- a/bin/mlton-script.in
+++ b/bin/mlton-script.in
@@ -83,12 +83,12 @@ fi
 # You may need to set 'gmpIncDir' so the C compiler can find gmp.h.
 gmpIncDir=
 if [ -n "$gmpIncDir" ]; then
-gmpCCOpts="-cc-opt '-I$gmpIncDir'"
+gmpCCOpts="-cc-opt -I$gmpIncDir"
 fi
 # You may need to set 'gmpLibDir' so the C compiler can find libgmp.
 gmpLibDir=
 if [ -n "$gmpLibDir" ]; then
-gmpLinkOpts="-link-opt '-L$gmpLibDir' -target-link-opt netbsd '-Wl,-R$gmpLibDir'"
+gmpLinkOpts="-link-opt -L$gmpLibDir -target-link-opt netbsd -Wl,-R$gmpLibDir"
 fi
 
 # For align-{functions,jumps,loops}, we use -m for now instead of

--- a/bin/mlton-script.in
+++ b/bin/mlton-script.in
@@ -2,6 +2,9 @@
 
 # This script calls MLton.
 
+# gcc or clang
+CC=
+
 set -e
 
 dir=`dirname "$0"`

--- a/bin/mlton-script.in
+++ b/bin/mlton-script.in
@@ -7,7 +7,6 @@ set -e
 dir=`dirname "$0"`
 lib=`cd "$dir/../lib/mlton" && pwd`
 eval `"$lib/platform"`
-gcc='gcc'
 case "$HOST_OS" in
 mingw)
 	exe='.exe'
@@ -90,6 +89,7 @@ gmpLibDir=
 if [ -n "$gmpLibDir" ]; then
 gmpLinkOpts="-link-opt -L$gmpLibDir -link-opt -Wl,-rpath=$gmpLibDir"
 fi
+# alternatively, export LD_LIBRARY_PATH=$gmpLibDir:$LD_LIBRARY_PATH
 
 # For align-{functions,jumps,loops}, we use -m for now instead of
 # -f because old gcc's will barf on -f, while newer ones only warn
@@ -98,7 +98,7 @@ fi
 
 doit "$lib" \
         -ar-script "$lib/static-library"                         \
-        -cc "$gcc"                                               \
+        -cc "$CC"                                               \
         $xcflags $xldflags                                       \
         -cc-opt-quote "-I$lib/include"                           \
         -cc-opt '-O1 -fno-common'                                \

--- a/bin/mlton-script.in
+++ b/bin/mlton-script.in
@@ -80,6 +80,17 @@ xldflags="-link-opt '$XLDFLAGS'"
 fi
 
 
+# You may need to set 'gmpIncDir' so the C compiler can find gmp.h.
+gmpIncDir=
+if [ -n "$gmpIncDir" ]; then
+gmpCCOpts="-cc-opt -I$gmpIncDir"
+fi
+# You may need to set 'gmpLibDir' so the C compiler can find libgmp.
+gmpLibDir=
+if [ -n "$gmpLibDir" ]; then
+gmpLinkOpts="-link-opt -L$gmpLibDir -link-opt -Wl,-rpath=$gmpLibDir"
+fi
+
 # For align-{functions,jumps,loops}, we use -m for now instead of
 # -f because old gcc's will barf on -f, while newer ones only warn
 # about -m.  Someday, when we think we won't run into older gcc's,
@@ -93,6 +104,7 @@ doit "$lib" \
         -cc-opt '-O1 -fno-common'                                \
         -cc-opt '-fno-strict-aliasing -fomit-frame-pointer -w'   \
         -link-opt '-lm -lgmp'                                    \
+        $gmpCCOpts $gmpLinkOpts                                  \
         -llvm-llc-opt '-O2'                                      \
         -llvm-opt-opt '-mem2reg -O2'                             \
         -mlb-path-map "$lib/mlb-path-map"                        \

--- a/configure.ac
+++ b/configure.ac
@@ -17,16 +17,20 @@ AC_CONFIG_SRCDIR([bin/mlton-script.in])
 AC_ARG_WITH([gmp-include],
             [AS_HELP_STRING([--with-gmp-include=PATH],
                             [specify directory for the installed GMP include file (gmp.h)])],
+            [with_gmp_include="$withval"]
             [CPPFLAGS="$CPPFLAGS -I$withval"],
             [with_gmp_include='']
            )
+AC_SUBST(WITH_GMP_INC_DIR, $with_gmp_include)
 
 AC_ARG_WITH([gmp-lib],
             [AS_HELP_STRING([--with-gmp-lib=PATH],
                             [specify directory for the installed GMP library (libgmp.so or libgmp.a or libgmp.dylib)])],
+            [with_gmp_lib="$withval"]
             [LDFLAGS="$LDFLAGS -L$withval"],
             [with_gmp_lib='']
            )
+AC_SUBST(WITH_GMP_LIB_DIR, $with_gmp_lib)
 
 AC_ARG_VAR([XCFLAGS],[extra C compiler flags])
 AC_ARG_VAR([XLDFLAGS],[extra linker flags])

--- a/configure.ac
+++ b/configure.ac
@@ -17,20 +17,16 @@ AC_CONFIG_SRCDIR([bin/mlton-script.in])
 AC_ARG_WITH([gmp-include],
             [AS_HELP_STRING([--with-gmp-include=PATH],
                             [specify directory for the installed GMP include file (gmp.h)])],
-            [with_gmp_include="$withval"]
             [CPPFLAGS="$CPPFLAGS -I$withval"],
             [with_gmp_include='']
            )
-AC_SUBST(WITH_GMP_INC_DIR, $with_gmp_include)
 
 AC_ARG_WITH([gmp-lib],
             [AS_HELP_STRING([--with-gmp-lib=PATH],
                             [specify directory for the installed GMP library (libgmp.so or libgmp.a or libgmp.dylib)])],
-            [with_gmp_lib="$withval"]
             [LDFLAGS="$LDFLAGS -L$withval"],
             [with_gmp_lib='']
            )
-AC_SUBST(WITH_GMP_LIB_DIR, $with_gmp_lib)
 
 AC_ARG_VAR([XCFLAGS],[extra C compiler flags])
 AC_ARG_VAR([XLDFLAGS],[extra linker flags])

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,8 @@ AC_CONFIG_SRCDIR([bin/mlton-script.in])
 AC_ARG_WITH([gmp-include],
             [AS_HELP_STRING([--with-gmp-include=PATH],
                             [specify directory for the installed GMP include file (gmp.h)])],
-            [with_gmp_include="$withval"],
+            [with_gmp_include="$withval"]
+            [CPPFLAGS="$CPPFLAGS -I$withval"],
             [with_gmp_include='']
            )
 AC_SUBST(WITH_GMP_INC_DIR, $with_gmp_include)
@@ -25,7 +26,8 @@ AC_SUBST(WITH_GMP_INC_DIR, $with_gmp_include)
 AC_ARG_WITH([gmp-lib],
             [AS_HELP_STRING([--with-gmp-lib=PATH],
                             [specify directory for the installed GMP library (libgmp.so or libgmp.a or libgmp.dylib)])],
-            [with_gmp_lib="$withval"],
+            [with_gmp_lib="$withval"]
+            [LDFLAGS="$LDFLAGS -L$withval"],
             [with_gmp_lib='']
            )
 AC_SUBST(WITH_GMP_LIB_DIR, $with_gmp_lib)
@@ -70,11 +72,11 @@ AC_CHECK_HEADERS([fcntl.h fenv.h float.h inttypes.h limits.h netdb.h netinet/in.
 
 # GMP is a required dependency
 AC_CHECK_HEADER([gmp.h],[],[
-    AC_MSG_WARN([The 'gmp.h' header file is not on C compiler's search path.])
+    AC_MSG_ERROR([The 'gmp.h' header file is not on C compiler's search path.])
 ])
 
 AC_CHECK_LIB([gmp],[__gmpz_sqrt],[],[
-    AC_MSG_WARN([The 'libgmp' shared library is not on C compiler's search path.])
+    AC_MSG_ERROR([The 'libgmp' shared library is not on C compiler's search path.])
 ])
 
 

--- a/runtime/Makefile.in
+++ b/runtime/Makefile.in
@@ -25,13 +25,6 @@ AR := $(TARGET)-ar rc
 RANLIB := $(TARGET)-@RANLIB@
 endif
 
-ifneq (@WITH_GMP_INC_DIR@,)
-WITH_GMP_INC_DIR := @WITH_GMP_INC_DIR@
-endif
-ifneq (@WITH_GMP_LIB_DIR@,)
-WITH_GMP_LIB_DIR := @WITH_GMP_LIB_DIR@
-endif
-
 TARGET_ARCH := $(shell ../bin/host-arch)
 TARGET_OS := $(shell ../bin/host-os)
 GCC_MAJOR_VERSION :=						\
@@ -161,14 +154,6 @@ endif
 
 ifeq ($(TARGET_OS), solaris)
 XCFLAGS += -funroll-all-loops
-endif
-
-ifneq ($(WITH_GMP_INC_DIR),)
-XCFLAGS += -I$(WITH_GMP_INC_DIR)
-endif
-
-ifneq ($(WITH_GMP_LIB_DIR),)
-XCFLAGS += -L$(WITH_GMP_LIB_DIR)
 endif
 
 XCFLAGS += -I. -Iplatform

--- a/runtime/Makefile.in
+++ b/runtime/Makefile.in
@@ -25,6 +25,13 @@ AR := $(TARGET)-ar rc
 RANLIB := $(TARGET)-@RANLIB@
 endif
 
+ifneq (@WITH_GMP_INC_DIR@,)
+WITH_GMP_INC_DIR := @WITH_GMP_INC_DIR@
+endif
+ifneq (@WITH_GMP_LIB_DIR@,)
+WITH_GMP_LIB_DIR := @WITH_GMP_LIB_DIR@
+endif
+
 TARGET_ARCH := $(shell ../bin/host-arch)
 TARGET_OS := $(shell ../bin/host-os)
 GCC_MAJOR_VERSION :=						\
@@ -154,6 +161,14 @@ endif
 
 ifeq ($(TARGET_OS), solaris)
 XCFLAGS += -funroll-all-loops
+endif
+
+ifneq ($(WITH_GMP_INC_DIR),)
+XCFLAGS += -I$(WITH_GMP_INC_DIR)
+endif
+
+ifneq ($(WITH_GMP_LIB_DIR),)
+XCFLAGS += -L$(WITH_GMP_LIB_DIR)
 endif
 
 XCFLAGS += -I. -Iplatform


### PR DESCRIPTION
In response to https://github.com/MLton/mlton/issues/227:

- add user-passed `--with-gmp` arguments to search path;
- exit with error (rather than warning) at configure time if GMP not found;
- remove nested quotes from gcc shell command

Tested with this `Dockerfile`:
```
FROM debian:stretch

ENV GMPROOT=/opt/gmp
WORKDIR /opt

RUN apt-get -qq update && \
    apt-get install -qq clang \
    git autoconf make wget mlton

# install GMP under $GMPROOT
RUN wget https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2 && \
    tar -xvjf gmp-*.tar.bz2 && \
    cd gmp-6.1.2 && \
    ./configure --prefix=$GMPROOT && \
    make && make install

# fetch & build MLton from source
RUN cd /opt && \
    git clone -b issue-227 --single-branch https://github.com/myegorov/mlton.git && \
    cd mlton && autoreconf -vfi && \
    ./configure \
      --with-gmp-include=$GMPROOT/include \
      --with-gmp-lib=$GMPROOT/lib && \
    make && make check
```
with

```shell
#!/bin/bash

# build container
NAME="mlton-issue-227"
docker image rm $NAME
docker build --no-cache=true -t $NAME .

# run container
docker run --rm -it $NAME /bin/bash
```