### PR TITLE
Updates to -show-basis

### DIFF
--- a/lib/mlton/basic/layout.sig
+++ b/lib/mlton/basic/layout.sig
@@ -14,6 +14,8 @@ signature LAYOUT =
       val align: t list -> t
       val alignPrefix: t list * string -> t
       val array: t array -> t
+      (* layout the object on one line *)
+      val compact: t -> t
       (* Whether or not to print things in detail -
        * routines that create layouts should use this flag to decide
        * how detailed to print.

--- a/lib/mlton/basic/layout.sml
+++ b/lib/mlton/basic/layout.sml
@@ -235,8 +235,7 @@ fun alignPrefix (ts, prefix) =
    case ts of
       [] => empty
     | t :: ts =>
-         mayAlign [t, indent (mayAlign (map (fn t => seq [str prefix, t]) ts),
-                              ~ (String.size prefix))]
+         mayAlign (t::(map (fn t => indent (seq [str prefix, t], ~ (String.size prefix))) ts))
 
 local
    fun fillAux ts =

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -356,6 +356,8 @@ signature CONTROL_FLAGS =
       (* Show the basis library. *)
       val showBasis: File.t option ref
 
+      val showBasisCompact: bool ref
+      val showBasisDef: bool ref
       val showBasisFlat: bool ref
 
       (* Show def-use information. *)

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -356,6 +356,8 @@ signature CONTROL_FLAGS =
       (* Show the basis library. *)
       val showBasis: File.t option ref
 
+      val showBasisFlat: bool ref
+
       (* Show def-use information. *)
       val showDefUse: File.t option ref
 

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1121,6 +1121,10 @@ val showBasis = control {name = "show basis",
                          default = NONE,
                          toString = Option.toString File.toString}
 
+val showBasisFlat = control {name = "show basis flat",
+                             default = false,
+                             toString = Bool.toString}
+
 val showDefUse = control {name = "show def-use",
                           default = NONE,
                           toString = Option.toString File.toString}

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1121,6 +1121,12 @@ val showBasis = control {name = "show basis",
                          default = NONE,
                          toString = Option.toString File.toString}
 
+val showBasisCompact = control {name = "show basis compact",
+                                default = false,
+                                toString = Bool.toString}
+val showBasisDef = control {name = "show basis def",
+                            default = false,
+                            toString = Bool.toString}
 val showBasisFlat = control {name = "show basis flat",
                              default = false,
                              toString = Bool.toString}

--- a/mlton/elaborate/elaborate-env.fun
+++ b/mlton/elaborate/elaborate-env.fun
@@ -3195,7 +3195,7 @@ fun makeLayoutPrettyTyconAndFlexTycon (E, _, Io, {prefixUnset}) =
                                         ; layoutPrettyFlexTycon f)}
    end
 
-fun layout' (E: t, prefixUnset, keep): Layout.t =
+fun layout' (E: t, prefixUnset, keep, flat): Layout.t =
    let
       val {bass, fcts, sigs, strs, types, vals, ...} = current (E, keep)
       val bass = bass ()
@@ -3297,9 +3297,9 @@ fun layout' (E: t, prefixUnset, keep): Layout.t =
            | SOME l => l :: ls)
       val res =
          align [doit (types, SOME o layoutTypeDefn),
-                doit (vals, layoutValDefnFlat),
+                doit (vals, (if flat then layoutValDefnFlat else layoutValDefn)),
                 doit (sigs, SOME o layoutSigDefn),
-                doit (strs, SOME o layoutStrDefnFlat),
+                doit (strs, SOME o (if flat then layoutStrDefnFlat else layoutStrDefn)),
                 doit (fcts, SOME o layoutFctDefn),
                 doit (bass, SOME o layoutBasDefn)]
       val () = destroy ()
@@ -3307,13 +3307,13 @@ fun layout' (E: t, prefixUnset, keep): Layout.t =
       res
    end
 
-fun layout E = layout' (E, true, fn _ => true)
+fun layout E = layout' (E, true, fn _ => true, false)
 
-fun layoutCurrentScope (E as T {currentScope, ...}) =
+fun layoutCurrentScope (E as T {currentScope, ...}, {flat}) =
    let
       val s = !currentScope
    in
-      layout' (E, false, fn {scope, ...} => Scope.equals (s, scope))
+      layout' (E, false, fn {scope, ...} => Scope.equals (s, scope), flat)
    end
 
 (* ------------------------------------------------- *)

--- a/mlton/elaborate/elaborate-env.fun
+++ b/mlton/elaborate/elaborate-env.fun
@@ -22,6 +22,7 @@ local
    open Layout
 in
    val align = align
+   val alignPrefix = alignPrefix
    (* val empty = empty *)
    val mayAlign = mayAlign
    val seq = seq
@@ -479,12 +480,7 @@ structure TypeStr =
                         if !extra
                            then List.snoc (cons, str "...")
                            else cons
-                     val cons =
-                        (mayAlign o List.mapi)
-                        (cons, fn (i, l) =>
-                         if i = 0
-                            then Layout.indent (l, 2)
-                            else seq [str "| ", l])
+                     val cons = alignPrefix (cons, "| ")
                   in
                      cons
                   end
@@ -896,8 +892,8 @@ structure Interface =
                                  List.mapi
                                  (cons, fn (i, l) =>
                                   if i = 0
-                                     then Layout.indent (l, 2)
-                                     else seq [str "| ", l])
+                                     then l
+                                     else Layout.indent (seq [str "| ", l], ~2))
                               val rest =
                                  if repl
                                     then let
@@ -906,7 +902,7 @@ structure Interface =
                                                     lay (EtypeStr.apply (rlzStr, tyargs)),
                                                     str " *)"]
                                          in
-                                            List.snoc (cons, repl)
+                                            List.snoc (cons, Layout.indent (repl, ~2))
                                          end
                                     else cons
                            in
@@ -1109,10 +1105,6 @@ structure Interface =
                   val wheres = rev (!wheres)
                   val lay =
                      align (Ast.Sigid.layout s :: wheres)
-                  val lay =
-                     if compact
-                        then Layout.compact lay
-                        else lay
                in
                   lay
                end
@@ -3342,8 +3334,15 @@ fun layout' (E: t, {compact, def, flat, keep, prefixUnset}): Layout.t =
                   NONE => {abbrev = SOME (str "???"), full = fn () => str "???"}
                 | SOME res => let
                                  val {abbrev, full} = layoutStr (res, {compact = compact})
+                                 val abbrev =
+                                    case abbrev () of
+                                       NONE => NONE
+                                     | SOME sigg =>
+                                          SOME (if compact
+                                                   then Layout.compact sigg
+                                                   else sigg)
                               in
-                                 {abbrev = abbrev (), full = full}
+                                 {abbrev = abbrev, full = full}
                               end
             val def =
                if def
@@ -4281,12 +4280,7 @@ fun transparentCut (E: t, S: Structure.t, I: Interface.t,
                                                                    if !extra
                                                                       then List.snoc (cons, str "...")
                                                                       else cons
-                                                                val cons =
-                                                                   (mayAlign o List.mapi)
-                                                                   (cons, fn (i, l) =>
-                                                                    if i = 0
-                                                                       then Layout.indent (l, 2)
-                                                                       else seq [str "| ", l])
+                                                                val cons = alignPrefix (cons, "| ")
                                                              in
                                                                 SOME cons
                                                              end

--- a/mlton/elaborate/elaborate-env.sig
+++ b/mlton/elaborate/elaborate-env.sig
@@ -199,7 +199,7 @@ signature ELABORATE_ENV =
          * (Structure.t * string list -> Decs.t * Structure.t option)
          -> FunctorClosure.t
       val layout: t -> Layout.t
-      val layoutCurrentScope: t * {extra: bool}-> Layout.t
+      val layoutCurrentScope: t * {compact: bool, def: bool, flat: bool}-> Layout.t
       val localAll: t * (unit -> 'a) * ('a -> 'b) -> 'b
       val localCore: t * (unit -> 'a) * ('a -> 'b) -> 'b
       val localModule: t * (unit -> 'a) * ('a -> 'b) -> 'b

--- a/mlton/elaborate/elaborate-env.sig
+++ b/mlton/elaborate/elaborate-env.sig
@@ -199,7 +199,7 @@ signature ELABORATE_ENV =
          * (Structure.t * string list -> Decs.t * Structure.t option)
          -> FunctorClosure.t
       val layout: t -> Layout.t
-      val layoutCurrentScope: t -> Layout.t
+      val layoutCurrentScope: t * {flat: bool}-> Layout.t
       val localAll: t * (unit -> 'a) * ('a -> 'b) -> 'b
       val localCore: t * (unit -> 'a) * ('a -> 'b) -> 'b
       val localModule: t * (unit -> 'a) * ('a -> 'b) -> 'b

--- a/mlton/elaborate/elaborate-env.sig
+++ b/mlton/elaborate/elaborate-env.sig
@@ -199,7 +199,7 @@ signature ELABORATE_ENV =
          * (Structure.t * string list -> Decs.t * Structure.t option)
          -> FunctorClosure.t
       val layout: t -> Layout.t
-      val layoutCurrentScope: t * {flat: bool}-> Layout.t
+      val layoutCurrentScope: t * {extra: bool}-> Layout.t
       val localAll: t * (unit -> 'a) * ('a -> 'b) -> 'b
       val localCore: t * (unit -> 'a) * ('a -> 'b) -> 'b
       val localModule: t * (unit -> 'a) * ('a -> 'b) -> 'b

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -398,7 +398,13 @@ fun elaborate {input: MLBString.t}: Xml.Program.t =
           | SOME f =>
                File.withOut
                (f, fn out =>
-                Layout.outputl (Env.layoutCurrentScope (E, {extra = !Control.showBasisFlat}), out))
+                Layout.outputl
+                (Env.layoutCurrentScope
+                 (E,
+                  {compact = !Control.showBasisCompact,
+                   def = !Control.showBasisDef,
+                   flat = !Control.showBasisFlat}),
+                 out))
       val _ = Env.processDefUse E
       val _ =
          case !Control.exportHeader of

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -398,7 +398,7 @@ fun elaborate {input: MLBString.t}: Xml.Program.t =
           | SOME f =>
                File.withOut
                (f, fn out =>
-                Layout.outputl (Env.layoutCurrentScope E, out))
+                Layout.outputl (Env.layoutCurrentScope (E, {flat = !Control.showBasisFlat}), out))
       val _ = Env.processDefUse E
       val _ =
          case !Control.exportHeader of

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -398,7 +398,7 @@ fun elaborate {input: MLBString.t}: Xml.Program.t =
           | SOME f =>
                File.withOut
                (f, fn out =>
-                Layout.outputl (Env.layoutCurrentScope (E, {flat = !Control.showBasisFlat}), out))
+                Layout.outputl (Env.layoutCurrentScope (E, {extra = !Control.showBasisFlat}), out))
       val _ = Env.processDefUse E
       val _ =
          case !Control.exportHeader of

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -779,6 +779,14 @@ fun makeOptions {usage} =
                         | _ => usage (concat ["invalid -show arg: ", s])))),
        (Normal, "show-basis", " <file>", "write final basis environment",
         SpaceString (fn s => showBasis := SOME s)),
+       (Expert, "show-basis-compact", " {false|true}", "show basis environment in compact form",
+        boolRef showBasisCompact),
+       (Expert, "show-basis-def", " {false|true}", "show basis environment with definition source position",
+        boolRef showBasisDef),
+       (Expert, "show-basis-extra", " {false|true}", "meta-option for -show-basis-compact, -show-basis-def, and -show-basis-flat",
+        Bool (fn b => (showBasisCompact := b
+                       ; showBasisDef := b
+                       ; showBasisFlat := b))),
        (Expert, "show-basis-flat", " {false|true}", "show basis environment with long identifier names",
         boolRef showBasisFlat),
        (Normal, "show-def-use", " <file>", "write def-use information",

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -777,8 +777,10 @@ fun makeOptions {usage} =
                           "anns" => Show.Anns
                         | "path-map" => Show.PathMap
                         | _ => usage (concat ["invalid -show arg: ", s])))),
-       (Normal, "show-basis", " <file>", "write out the final basis environment",
+       (Normal, "show-basis", " <file>", "write final basis environment",
         SpaceString (fn s => showBasis := SOME s)),
+       (Expert, "show-basis-flat", " {false|true}", "show basis environment with long identifier names",
+        boolRef showBasisFlat),
        (Normal, "show-def-use", " <file>", "write def-use information",
         SpaceString (fn s => showDefUse := SOME s)),
        (Expert, "show-types", " {true|false}", "show types in ILs",


### PR DESCRIPTION
New functionality for `-show-basis`:

- `-show-basis-flat`: Recursively expand structures in environment, displaying components with long identifiers.  For example,
```
structure Z:
   sig
      datatype t = Z1 | Z2 of Z.t (* = datatype Z.t *)
      val toString: Z.t -> string
   end
datatype Z.t = Z1 | Z2 of Z.t (* = datatype Z.t *)
con Z.Z1: Z.t
con Z.Z2: Z.t -> Z.t
val Z.toString: Z.t -> string
```
Note that with `-show-basis-flat true`, value identifiers with constructor status are show as `con <vid>: <ty>` (rather than being omitted), and value identifiers with exception status are show as `exn <vid>: [<ty> ->] exn` (rather than as `exception <vid> [of <ty>]`).

- `-show-basis-def`: Appends `(* @ <region> *)` annotations to items in shown environment.

- `-show-basis-compact`: Tries to optimize vertical space (at the expense of long lines); all value and type specifications are forced to one line and signature and structure specifications expressed as `where type` refinement of a named signature are forced to one line.

The intention is that this additional functionality can be used to drive auto-completion; `-show-basis-flat` makes it easy to extract completable long identifiers; `-show-basis-def` makes it easy to associate definition points with completable identifiers; `-show-basis-compact` makes it easier to associate annotations/metadata with completable identifiers.

@myegorov plans to develop an omni-completion plugin for Vim ; @MatthewFluet plans to develop a company-mode backend for Emacs.  Suggestions for improvement welcome.
