### PR TITLE
Restore, but deprecate, `-drop-pass` compile-time expert option.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,9 @@ Here are the changes from version 20130715 to version YYYYMMDD.
 
 === Details
 
+* 2018-01-23
+  ** Restore, but deprecate, `-drop-pass` compile-time expert option.
+
 * 2018-01-19
   ** Update SML/NJ libraries to SML/NJ 110.82.
 

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010-2011,2013-2017 Matthew Fluet.
+(* Copyright (C) 2010-2011,2013-2018 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -387,6 +387,18 @@ fun makeOptions {usage} =
        (Expert, "disable-pass", " <pass>", "disable optimization pass",
         SpaceString
         (fn s => (case Regexp.fromString s of
+                     SOME (re,_) => let val re = Regexp.compileDFA re
+                                    in List.push (executePasses, (re, false))
+                                    end
+                   | NONE => usage (concat ["invalid -disable-pass flag: ", s])))),
+       (Expert, "drop-pass", " <pass>", "disable optimization pass",
+        SpaceString
+        (fn s => (if !Control.warnDeprecated
+                     then Out.output
+                          (Out.error,
+                           "Warning: -drop-pass is deprecated.  Use -disable-pass.\n")
+                     else ();
+                  case Regexp.fromString s of
                      SOME (re,_) => let val re = Regexp.compileDFA re
                                     in List.push (executePasses, (re, false))
                                     end


### PR DESCRIPTION
Some projects use `-drop-pass` to avoid performance problems with DeepFlatten
and RefFlatten; see https://github.com/search?p=1&q=%22-drop-pass%22&type=Code.
Restoring `-drop-pass` avoids unnecessarily breaking these projects.