### PR TITLE
Avoid `List.map` in some `functor Sequence` fns of Basis Library

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,10 @@ Here are the changes from version 20130715 to version YYYYMMDD.
 
 === Details
 
+* 2018-01-24
+  ** Slightly improve performance of `Vector.concat` and
+  `String.{concat,concatWith,tokens,fields}` by avoiding `List.map`-s.
+
 * 2018-01-23
   ** Restore, but deprecate, `-drop-pass` compile-time expert option.
 


### PR DESCRIPTION
Previously, `Sequence.{concat,concatWith}` operated by performing a `List.map` on the input, converting (full) sequences to slices, and `Sequence.{tokens,fields}` operated by performing a `List.map` on the output, converting slices to (full) sequences.  This unnecessarily allocated and traversed an intermediate list.

We introduce `Sequence.Slice.{concat,concatWith,tokens,fields}Gen` functions that take either a `toSlice` or a `fromSlice` function to convert the input or output.  For example, we now have:

    fun Sequence.Slice.concat sls = Sequence.Slice.concatGen (sls, fn sl => sl)
    fun Sequence.concat seqs = Sequence.Slice.concatGen (seqs, Sequence.Slice.full)

Note that the two uses of `Sequence.Slice.concatGen` are at different (polymorphic) types.  So, the two uses will be monomorphised to distinct SXML functions.  Next, ClosureConvert flow analysis will determine that the `toSlice` function for the `Sequence.Slice.concat` instance is exactly `fn sl => sl` and that the `toSlice` function for the `Sequence.concat` instance is exactly `Sequence.Slice.full`.  Thus, the `Sequence` instances of the functions should be as efficient as if they had been written directly for sequences (rather than indirecting through functions for slices).