### PR TITLE
Delete unnecessary files

### DIFF
--- a/mllex/macros.hva
+++ b/mllex/macros.hva
@@ -1,1 +1,0 @@
-\newcommand{\parbox}[2]{#2}

--- a/mlyacc/doc/macros.hva
+++ b/mlyacc/doc/macros.hva
@@ -1,1 +1,0 @@
-\newcommand{\parbox}[2]{#2}


### PR DESCRIPTION
Commit 8c6bc7e40 dropped HTML documentation for mllex and mlyacc, but forgot to
remove the hevea macros files.