### PR TITLE
Set relative path of library directory to binary directory  when installing mlton script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,14 @@ XARGS := xargs
 ######################################################################
 ######################################################################
 
+TGT_REL_SRC = ref="$(1)" pos="$(2)" down=; ref="$${ref%%/}" pos="$${pos%%/}"; while :; do test "$$pos" = '/' && break ; case "$$ref" in "$$pos"/*) break;; esac; down="../$$down"; pos="$${pos%/*}"; done; echo "$$down$${ref\#\#$$pos/}"
+
 SRC := $(shell pwd)
 BUILD := $(SRC)/build
 BIN := $(BUILD)/bin
 LIB := $(BUILD)/lib/mlton
 INC := $(LIB)/include
+LIB_REL_BIN := $(shell $(call TGT_REL_SRC,$(LIB),$(BIN)))
 
 PATH := $(BIN):$(shell echo $$PATH)
 
@@ -306,6 +309,7 @@ runtime:
 .PHONY: script
 script:
 	$(SED) \
+		-e "s;^LIB_REL_BIN=.*;LIB_REL_BIN=\"$(LIB_REL_BIN)\";" \
 		-e "s;^EXE=.*;EXE=\"$(EXE)\";" \
 		-e "s;^CC=.*;CC=\"$(CC)\";" \
 		-e "s;^GMP_INC_DIR=.*;GMP_INC_DIR=\"$(WITH_GMP_INC_DIR)\";" \
@@ -419,6 +423,8 @@ TMAN := $(DESTDIR)$(man1dir)
 TDOC := $(DESTDIR)$(docdir)
 TEXM := $(TDOC)/examples
 
+TLIB_REL_TBIN := $(shell $(call TGT_REL_SRC,$(TLIB),$(TBIN)))
+
 GZIP_MAN := true
 ifeq ($(findstring $(TARGET_OS), openbsd solaris), $(TARGET_OS))
 GZIP_MAN := false
@@ -438,6 +444,10 @@ MAN_PAGES :=  \
 install-no-strip:
 	$(MKDIR) "$(TBIN)" "$(TLIB)" "$(TMAN)"
 	$(CP) "$(BIN)/." "$(TBIN)/"
+	$(SED) \
+		-e "s;^LIB_REL_BIN=.*;LIB_REL_BIN=\"$(TLIB_REL_TBIN)\";" \
+		< "$(BIN)/mlton" > "$(TBIN)/mlton"
+	chmod a+x "$(TBIN)/mlton"
 	$(CP) "$(LIB)/." "$(TLIB)/"
 	cd "$(SRC)/man" && $(CP) $(MAN_PAGES) "$(TMAN)/"
 ifeq (true, $(GZIP_MAN))

--- a/Makefile.binary
+++ b/Makefile.binary
@@ -25,10 +25,14 @@ RM := rm -rf
 
 ######################################################################
 
+TGT_REL_SRC = ref="$(1)" pos="$(2)" down=; ref="$${ref%%/}" pos="$${pos%%/}"; while :; do test "$$pos" = '/' && break ; case "$$ref" in "$$pos"/*) break;; esac; down="../$$down"; pos="$${pos%/*}"; done; echo "$$down$${ref\#\#$$pos/}"
+
 SBIN := $(ROOT)/bin
 SLIB := $(ROOT)/lib/mlton
 SMAN := $(ROOT)/share/man/man1
 SDOC := $(ROOT)/share/doc/mlton
+
+SLIB_REL_SBIN := $(shell $(call TGT_REL_SRC,$(SLIB),$(SBIN)))
 
 prefix := $(PREFIX)
 exec_prefix := $(prefix)
@@ -45,10 +49,16 @@ TMAN := $(man1dir)
 TDOC := $(docdir)
 TEXM := $(TDOC)/examples
 
+TLIB_REL_TBIN := $(shell $(call TGT_REL_SRC,$(TLIB),$(TBIN)))
+
 .PHONY: install
 install:
 	$(MKDIR) "$(TBIN)" "$(TLIB)" "$(TMAN)" "$(TDOC)"
 	$(CP) "$(SBIN)/." "$(TBIN)/"
+	$(SED) \
+		-e "s;^LIB_REL_BIN=.*;LIB_REL_BIN=\"$(TLIB_REL_TBIN)\";" \
+		< "$(SBIN)/mlton" > "$(TBIN)/mlton"
+	chmod a+x "$(TBIN)/mlton"
 	$(CP) "$(SLIB)/." "$(TLIB)/"
 	$(CP) "$(SMAN)/." "$(TMAN)/"
 	if [ -d "$(SDOC)" ]; then $(CP) "$(SDOC)/." "$(TDOC)/"; fi

--- a/Makefile.binary
+++ b/Makefile.binary
@@ -21,6 +21,7 @@ ROOT := $(shell pwd)
 
 CP := cp -fpR
 MKDIR := mkdir -p
+RM := rm -rf
 
 ######################################################################
 
@@ -46,7 +47,7 @@ TEXM := $(TDOC)/examples
 
 .PHONY: install
 install:
-	mkdir -p "$(TBIN)" "$(TLIB)" "$(TMAN)" "$(TDOC)"
+	$(MKDIR) "$(TBIN)" "$(TLIB)" "$(TMAN)" "$(TDOC)"
 	$(CP) "$(SBIN)/." "$(TBIN)/"
 	$(CP) "$(SLIB)/." "$(TLIB)/"
 	$(CP) "$(SMAN)/." "$(TMAN)/"
@@ -61,4 +62,4 @@ update:
 		-e "s;^GMP_LIB_DIR=.*;GMP_LIB_DIR=\"$(WITH_GMP_LIB_DIR)\";" \
 		< "$(SBIN)/mlton.bak" > "$(SBIN)/mlton"
 	chmod a+x "$(SBIN)/mlton"
-	$(RM) "$(SBIN)/mlton.bak"
+	rm "$(SBIN)/mlton.bak"

--- a/bin/mlton-script
+++ b/bin/mlton-script
@@ -3,6 +3,8 @@
 # This script calls MLton.
 
 
+LIB_REL_BIN="../lib/mlton"
+
 EXE=
 
 CC="gcc"
@@ -16,7 +18,7 @@ GMP_LIB_DIR=
 set -e
 
 dir=`dirname "$0"`
-lib=`cd "$dir/../lib/mlton" && pwd`
+lib=`cd "$dir/$LIB_REL_BIN" && pwd`
 
 declare -a rargs
 case "$1" in

--- a/bin/mlton-script
+++ b/bin/mlton-script
@@ -2,6 +2,17 @@
 
 # This script calls MLton.
 
+
+EXE=
+
+CC="gcc"
+
+# You may need to set 'GMP_INC_DIR' so the C compiler can find gmp.h.
+GMP_INC_DIR=
+# You may need to set 'GMP_LIB_DIR' so the C compiler can find libgmp.
+GMP_LIB_DIR=
+
+
 set -e
 
 dir=`dirname "$0"`
@@ -23,8 +34,6 @@ case "$1" in
         fi
         ;;
 esac
-
-EXE=
 
 doitMLton () {
     mlton_mlton="$lib/mlton-compile$EXE"
@@ -57,15 +66,9 @@ doit () {
     exit 1
 }
 
-CC="gcc"
-
-# You may need to set 'GMP_INC_DIR' so the C compiler can find gmp.h.
-GMP_INC_DIR=
 if [ -n "$GMP_INC_DIR" ]; then
 gmpCCOpts="-cc-opt -I$GMP_INC_DIR"
 fi
-# You may need to set 'GMP_LIB_DIR' so the C compiler can find libgmp.
-GMP_LIB_DIR=
 if [ -n "$GMP_LIB_DIR" ]; then
 gmpLinkOpts="-link-opt -L$GMP_LIB_DIR -target-link-opt netbsd -Wl,-R$GMP_LIB_DIR"
 fi


### PR DESCRIPTION
Some systems (e.g., x86_64 Fedora) want to install the library files in `/usr/lib64`, rather than `/usr/lib`.  Thus, when installing it is necessary to compute and set the relative path of `TLIB` to `TBIN` when installing `$(TBIN)/mlton`. 