### PR TITLE
License characterization

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ Here are the changes from versoin 20180206 to version YYYYMMDD.
 
 === Details
 
+* 2018-04-28
+  ** Characterize MLton-LICENSE as an instance of the Historical Permission
+     Notice and Disclaimer (HPND) license, rather than BSD-style.
+
 * 2018-04-04
   ** Added support for RISC-V architecture.  Thanks to Adam Goode for the pull
      request.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 This is the license for MLton, a whole-program optimizing compiler for
-the Standard ML programming language.  Send comments and questions to
-MLton@mlton.org.
+the Standard ML programming language.  The license is an instance of
+the Historical Permission Notice and Disclaimer (HPND) license, which
+is an open source (https://opensource.org/licenses/HPND) and
+free software (https://www.gnu.org/licenses/license-list.en.html#HPND)
+license.  Send comments and questions to MLton@mlton.org.
 
 MLton COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/basis-library/Makefile
+++ b/basis-library/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/basis-library/arrays-and-vectors/array.sml
+++ b/basis-library/arrays-and-vectors/array.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/array2.sml
+++ b/basis-library/arrays-and-vectors/array2.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/mono-array.fun
+++ b/basis-library/arrays-and-vectors/mono-array.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/mono-array2.fun
+++ b/basis-library/arrays-and-vectors/mono-array2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/mono-vector.fun
+++ b/basis-library/arrays-and-vectors/mono-vector.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/mono.sml
+++ b/basis-library/arrays-and-vectors/mono.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/sequence.fun
+++ b/basis-library/arrays-and-vectors/sequence.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/sequence.sig
+++ b/basis-library/arrays-and-vectors/sequence.sig
@@ -4,7 +4,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/sequence0.sig
+++ b/basis-library/arrays-and-vectors/sequence0.sig
@@ -4,7 +4,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
  

--- a/basis-library/arrays-and-vectors/sequence0.sml
+++ b/basis-library/arrays-and-vectors/sequence0.sml
@@ -5,7 +5,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/slice.sig
+++ b/basis-library/arrays-and-vectors/slice.sig
@@ -4,7 +4,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/slice0.sig
+++ b/basis-library/arrays-and-vectors/slice0.sig
@@ -4,7 +4,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/arrays-and-vectors/vector.sml
+++ b/basis-library/arrays-and-vectors/vector.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/basis-1997.mlb
+++ b/basis-library/basis-1997.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/basis-2002.mlb
+++ b/basis-library/basis-2002.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/basis-none.mlb
+++ b/basis-library/basis-none.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/basis.mlb
+++ b/basis-library/basis.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/build/sources.mlb
+++ b/basis-library/build/sources.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/c-types.mlb
+++ b/basis-library/c-types.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/c/pointer.sig
+++ b/basis-library/c/pointer.sig
@@ -1,6 +1,6 @@
 (* Copyright (C) 2010 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/c/pointer.sml
+++ b/basis-library/c/pointer.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2010 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/char-prim.sml
+++ b/basis-library/config/bind/char-prim.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/int-inf-prim.sml
+++ b/basis-library/config/bind/int-inf-prim.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/int-inf-top.sml
+++ b/basis-library/config/bind/int-inf-top.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/int-prim.sml
+++ b/basis-library/config/bind/int-prim.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/int-top.sml
+++ b/basis-library/config/bind/int-top.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/pointer-mlton.sml
+++ b/basis-library/config/bind/pointer-mlton.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/pointer-prim.sml
+++ b/basis-library/config/bind/pointer-prim.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/real-prim.sml
+++ b/basis-library/config/bind/real-prim.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/real-top.sml
+++ b/basis-library/config/bind/real-top.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/string-prim.sml
+++ b/basis-library/config/bind/string-prim.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/word-prim.sml
+++ b/basis-library/config/bind/word-prim.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/bind/word-top.sml
+++ b/basis-library/config/bind/word-top.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/c/errno.sml
+++ b/basis-library/config/c/errno.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/c/position.sml
+++ b/basis-library/config/c/position.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/c/sys-types.sml
+++ b/basis-library/config/c/sys-types.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/c/sys-word.sml
+++ b/basis-library/config/c/sys-word.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/c/word-to-bool.sml
+++ b/basis-library/config/c/word-to-bool.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/choose-char.sml
+++ b/basis-library/config/choose-char.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/choose-int.sml
+++ b/basis-library/config/choose-int.sml
@@ -2,7 +2,7 @@
 * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/choose-real.sml
+++ b/basis-library/config/choose-real.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/choose-string.sml
+++ b/basis-library/config/choose-string.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/choose-word.sml
+++ b/basis-library/config/choose-word.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-char8.sml
+++ b/basis-library/config/default/default-char8.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-int32.sml
+++ b/basis-library/config/default/default-int32.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-int64.sml
+++ b/basis-library/config/default/default-int64.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-intinf.sml
+++ b/basis-library/config/default/default-intinf.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-real32.sml
+++ b/basis-library/config/default/default-real32.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-real64.sml
+++ b/basis-library/config/default/default-real64.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-widechar16.sml
+++ b/basis-library/config/default/default-widechar16.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-widechar32.sml
+++ b/basis-library/config/default/default-widechar32.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-word32.sml
+++ b/basis-library/config/default/default-word32.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/default-word64.sml
+++ b/basis-library/config/default/default-word64.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/fixed-int.sml
+++ b/basis-library/config/default/fixed-int.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/large-int.sml
+++ b/basis-library/config/default/large-int.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/large-real.sml
+++ b/basis-library/config/default/large-real.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/default/large-word.sml
+++ b/basis-library/config/default/large-word.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/metadata/array-metadata-size128.sml
+++ b/basis-library/config/metadata/array-metadata-size128.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/metadata/array-metadata-size192.sml
+++ b/basis-library/config/metadata/array-metadata-size192.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/metadata/array-metadata-size256.sml
+++ b/basis-library/config/metadata/array-metadata-size256.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/metadata/array-metadata-size96.sml
+++ b/basis-library/config/metadata/array-metadata-size96.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/metadata/normal-metadata-size128.sml
+++ b/basis-library/config/metadata/normal-metadata-size128.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2016-2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/metadata/normal-metadata-size32.sml
+++ b/basis-library/config/metadata/normal-metadata-size32.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2016-2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/metadata/normal-metadata-size64.sml
+++ b/basis-library/config/metadata/normal-metadata-size64.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2016-2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/objptr/objptr-rep32.sml
+++ b/basis-library/config/objptr/objptr-rep32.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/objptr/objptr-rep64.sml
+++ b/basis-library/config/objptr/objptr-rep64.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/seqindex/seqindex-int32.sml
+++ b/basis-library/config/seqindex/seqindex-int32.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/config/seqindex/seqindex-int64.sml
+++ b/basis-library/config/seqindex/seqindex-int64.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/default.mlb
+++ b/basis-library/default.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/equal.mlb
+++ b/basis-library/equal.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/general/bool.sml
+++ b/basis-library/general/bool.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/general/general.sml
+++ b/basis-library/general/general.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/general/option.sml
+++ b/basis-library/general/option.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/general/sml90.sml
+++ b/basis-library/general/sml90.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/infixes.mlb
+++ b/basis-library/infixes.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/embed-int.sml
+++ b/basis-library/integer/embed-int.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/embed-word.sml
+++ b/basis-library/integer/embed-word.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/int-global.sml
+++ b/basis-library/integer/int-global.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/int-inf.sml
+++ b/basis-library/integer/int-inf.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/int-inf0.sml
+++ b/basis-library/integer/int-inf0.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/int.sml
+++ b/basis-library/integer/int.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/iwconv0.sml
+++ b/basis-library/integer/iwconv0.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/num0.sml
+++ b/basis-library/integer/num0.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/num1.sml
+++ b/basis-library/integer/num1.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/pack-word.sml
+++ b/basis-library/integer/pack-word.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/word-global.sml
+++ b/basis-library/integer/word-global.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/integer/word.sml
+++ b/basis-library/integer/word.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/bin-io.sml
+++ b/basis-library/io/bin-io.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/bin-prim-io.sml
+++ b/basis-library/io/bin-prim-io.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/imperative-io.fun
+++ b/basis-library/io/imperative-io.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/io.sig
+++ b/basis-library/io/io.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/io.sml
+++ b/basis-library/io/io.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/prim-io.fun
+++ b/basis-library/io/prim-io.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/prim-io.sig
+++ b/basis-library/io/prim-io.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/stream-io.fun
+++ b/basis-library/io/stream-io.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/text-io.sml
+++ b/basis-library/io/text-io.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/io/text-prim-io.sml
+++ b/basis-library/io/text-prim-io.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/all.mlb
+++ b/basis-library/libs/all.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/arrays-and-vectors/mono-vector-array-array2-convert.fun
+++ b/basis-library/libs/basis-1997/arrays-and-vectors/mono-vector-array-array2-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/arrays-and-vectors/vector-array-convert.fun
+++ b/basis-library/libs/basis-1997/arrays-and-vectors/vector-array-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/basis-1997.mlb
+++ b/basis-library/libs/basis-1997/basis-1997.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/io/bin-io-convert.fun
+++ b/basis-library/libs/basis-1997/io/bin-io-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/io/io-convert.fun
+++ b/basis-library/libs/basis-1997/io/io-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/io/text-io-convert.fun
+++ b/basis-library/libs/basis-1997/io/text-io-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/posix/file-sys-convert.fun
+++ b/basis-library/libs/basis-1997/posix/file-sys-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/posix/flags-convert.fun
+++ b/basis-library/libs/basis-1997/posix/flags-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/posix/io-convert.fun
+++ b/basis-library/libs/basis-1997/posix/io-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/posix/posix-convert.fun
+++ b/basis-library/libs/basis-1997/posix/posix-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/posix/process-convert.fun
+++ b/basis-library/libs/basis-1997/posix/process-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/posix/tty-convert.fun
+++ b/basis-library/libs/basis-1997/posix/tty-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/real/IEEE-real-convert.fun
+++ b/basis-library/libs/basis-1997/real/IEEE-real-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/real/real-convert.fun
+++ b/basis-library/libs/basis-1997/real/real-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/system/file-sys-convert.fun
+++ b/basis-library/libs/basis-1997/system/file-sys-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/system/os-convert.fun
+++ b/basis-library/libs/basis-1997/system/os-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/system/path-convert.fun
+++ b/basis-library/libs/basis-1997/system/path-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/system/process-convert.fun
+++ b/basis-library/libs/basis-1997/system/process-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/system/timer-convert.fun
+++ b/basis-library/libs/basis-1997/system/timer-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/system/unix-convert.fun
+++ b/basis-library/libs/basis-1997/system/unix-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/text/text-convert.fun
+++ b/basis-library/libs/basis-1997/text/text-convert.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/top-level/basis-funs.sml
+++ b/basis-library/libs/basis-1997/top-level/basis-funs.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/top-level/basis-sigs.sml
+++ b/basis-library/libs/basis-1997/top-level/basis-sigs.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/top-level/basis.sml
+++ b/basis-library/libs/basis-1997/top-level/basis.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/top-level/infixes.sml
+++ b/basis-library/libs/basis-1997/top-level/infixes.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/top-level/overloads.sml
+++ b/basis-library/libs/basis-1997/top-level/overloads.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-1997/top-level/top-level.sml
+++ b/basis-library/libs/basis-1997/top-level/top-level.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002-strict/top-level/top-level.sml
+++ b/basis-library/libs/basis-2002-strict/top-level/top-level.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/basis-2002.mlb
+++ b/basis-library/libs/basis-2002/basis-2002.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/Makefile
+++ b/basis-library/libs/basis-2002/top-level/Makefile
@@ -1,7 +1,7 @@
 ## Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  #    Jagannathan, and Stephen Weeks.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/basis-library/libs/basis-2002/top-level/basis-funs.sml
+++ b/basis-library/libs/basis-2002/top-level/basis-funs.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/basis-sigs.sml
+++ b/basis-library/libs/basis-2002/top-level/basis-sigs.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/basis.sml
+++ b/basis-library/libs/basis-2002/top-level/basis.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/generate-overloads.sml
+++ b/basis-library/libs/basis-2002/top-level/generate-overloads.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/infixes.sml
+++ b/basis-library/libs/basis-2002/top-level/infixes.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/pervasive-equal.sml
+++ b/basis-library/libs/basis-2002/top-level/pervasive-equal.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/pervasive-exns.sml
+++ b/basis-library/libs/basis-2002/top-level/pervasive-exns.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/pervasive-types.sml
+++ b/basis-library/libs/basis-2002/top-level/pervasive-types.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/pervasive-vals.sml
+++ b/basis-library/libs/basis-2002/top-level/pervasive-vals.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-2002/top-level/top-level.sml
+++ b/basis-library/libs/basis-2002/top-level/top-level.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-extra/basis-extra.mlb
+++ b/basis-library/libs/basis-extra/basis-extra.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-extra/top-level/basis-funs.sml
+++ b/basis-library/libs/basis-extra/top-level/basis-funs.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-extra/top-level/basis-sigs.sml
+++ b/basis-library/libs/basis-extra/top-level/basis-sigs.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-extra/top-level/basis.sml
+++ b/basis-library/libs/basis-extra/top-level/basis.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-extra/top-level/top-level.sml
+++ b/basis-library/libs/basis-extra/top-level/top-level.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-none/top-level/basis.sml
+++ b/basis-library/libs/basis-none/top-level/basis.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-none/top-level/infixes.sml
+++ b/basis-library/libs/basis-none/top-level/infixes.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/libs/basis-none/top-level/top-level.sml
+++ b/basis-library/libs/basis-none/top-level/top-level.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/list/list-pair.sml
+++ b/basis-library/list/list-pair.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/list/list.sml
+++ b/basis-library/list/list.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton.mlb
+++ b/basis-library/mlton.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/array.sig
+++ b/basis-library/mlton/array.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/bin-io.sig
+++ b/basis-library/mlton/bin-io.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/call-stack.sig
+++ b/basis-library/mlton/call-stack.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/call-stack.sml
+++ b/basis-library/mlton/call-stack.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/cont.sig
+++ b/basis-library/mlton/cont.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/cont.sml
+++ b/basis-library/mlton/cont.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/exit.sml
+++ b/basis-library/mlton/exit.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/exn.sig
+++ b/basis-library/mlton/exn.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2001-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/exn.sml
+++ b/basis-library/mlton/exn.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2001-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/ffi.sig
+++ b/basis-library/mlton/ffi.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/ffi.sml
+++ b/basis-library/mlton/ffi.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/finalizable.sig
+++ b/basis-library/mlton/finalizable.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/finalizable.sml
+++ b/basis-library/mlton/finalizable.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/gc.sig
+++ b/basis-library/mlton/gc.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/gc.sml
+++ b/basis-library/mlton/gc.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/int-inf.sig
+++ b/basis-library/mlton/int-inf.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/io.fun
+++ b/basis-library/mlton/io.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/io.sig
+++ b/basis-library/mlton/io.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/itimer.sig
+++ b/basis-library/mlton/itimer.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/itimer.sml
+++ b/basis-library/mlton/itimer.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/mlton.sig
+++ b/basis-library/mlton/mlton.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/mlton.sml
+++ b/basis-library/mlton/mlton.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/platform.sig
+++ b/basis-library/mlton/platform.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/platform.sml
+++ b/basis-library/mlton/platform.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/pointer.sig
+++ b/basis-library/mlton/pointer.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/pointer.sml
+++ b/basis-library/mlton/pointer.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2003-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/proc-env.sig
+++ b/basis-library/mlton/proc-env.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/proc-env.sml
+++ b/basis-library/mlton/proc-env.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/process.sig
+++ b/basis-library/mlton/process.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/process.sml
+++ b/basis-library/mlton/process.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/profile.sig
+++ b/basis-library/mlton/profile.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/profile.sml
+++ b/basis-library/mlton/profile.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/ptrace.sig
+++ b/basis-library/mlton/ptrace.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/ptrace.sml
+++ b/basis-library/mlton/ptrace.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/random.sig
+++ b/basis-library/mlton/random.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/random.sml
+++ b/basis-library/mlton/random.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/real.sig
+++ b/basis-library/mlton/real.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/rlimit.sig
+++ b/basis-library/mlton/rlimit.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/rlimit.sml
+++ b/basis-library/mlton/rlimit.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/rusage.sig
+++ b/basis-library/mlton/rusage.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/rusage.sml
+++ b/basis-library/mlton/rusage.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/signal.sig
+++ b/basis-library/mlton/signal.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/signal.sml
+++ b/basis-library/mlton/signal.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/syslog.sig
+++ b/basis-library/mlton/syslog.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/syslog.sml
+++ b/basis-library/mlton/syslog.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/text-io.sig
+++ b/basis-library/mlton/text-io.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/thread.sig
+++ b/basis-library/mlton/thread.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/thread.sml
+++ b/basis-library/mlton/thread.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/vector.sig
+++ b/basis-library/mlton/vector.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/weak.sig
+++ b/basis-library/mlton/weak.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/weak.sml
+++ b/basis-library/mlton/weak.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/word.sig
+++ b/basis-library/mlton/word.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/world.sig
+++ b/basis-library/mlton/world.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/mlton/world.sml
+++ b/basis-library/mlton/world.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/generic-sock.sml
+++ b/basis-library/net/generic-sock.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/inet-sock.sml
+++ b/basis-library/net/inet-sock.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/net-host-db.sml
+++ b/basis-library/net/net-host-db.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/net-prot-db.sml
+++ b/basis-library/net/net-prot-db.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/net-serv-db.sml
+++ b/basis-library/net/net-serv-db.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/net.sig
+++ b/basis-library/net/net.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/net.sml
+++ b/basis-library/net/net.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/socket.sml
+++ b/basis-library/net/socket.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/net/unix-sock.sml
+++ b/basis-library/net/unix-sock.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/overloads.mlb
+++ b/basis-library/overloads.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/pervasive-exns.mlb
+++ b/basis-library/pervasive-exns.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/pervasive-types.mlb
+++ b/basis-library/pervasive-types.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/pervasive-vals.mlb
+++ b/basis-library/pervasive-vals.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/pervasive.mlb
+++ b/basis-library/pervasive.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/platform/cygwin.sml
+++ b/basis-library/platform/cygwin.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/platform/mingw.sml
+++ b/basis-library/platform/mingw.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/error.sml
+++ b/basis-library/posix/error.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/file-sys.sml
+++ b/basis-library/posix/file-sys.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/flags.sig
+++ b/basis-library/posix/flags.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/flags.sml
+++ b/basis-library/posix/flags.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/io.sml
+++ b/basis-library/posix/io.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/posix.sml
+++ b/basis-library/posix/posix.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/pre-posix.sml
+++ b/basis-library/posix/pre-posix.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/proc-env.sml
+++ b/basis-library/posix/proc-env.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/process.sml
+++ b/basis-library/posix/process.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/signal.sml
+++ b/basis-library/posix/signal.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/stub-mingw.sml
+++ b/basis-library/posix/stub-mingw.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/sys-db.sml
+++ b/basis-library/posix/sys-db.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/posix/tty.sml
+++ b/basis-library/posix/tty.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/check-real.sml
+++ b/basis-library/primitive/check-real.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-basis.mlb
+++ b/basis-library/primitive/prim-basis.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-basis.sml
+++ b/basis-library/primitive/prim-basis.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-char.sml
+++ b/basis-library/primitive/prim-char.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-int-inf.sml
+++ b/basis-library/primitive/prim-int-inf.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-int.sml
+++ b/basis-library/primitive/prim-int.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-iwconv.sml
+++ b/basis-library/primitive/prim-iwconv.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-mlton.sml
+++ b/basis-library/primitive/prim-mlton.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-nullstring.sml
+++ b/basis-library/primitive/prim-nullstring.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-pack-real.sml
+++ b/basis-library/primitive/prim-pack-real.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-pack-word.sml
+++ b/basis-library/primitive/prim-pack-word.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-real.sml
+++ b/basis-library/primitive/prim-real.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-seq.sml
+++ b/basis-library/primitive/prim-seq.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-string.sml
+++ b/basis-library/primitive/prim-string.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim-word.sml
+++ b/basis-library/primitive/prim-word.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim1.sml
+++ b/basis-library/primitive/prim1.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/prim2.sml
+++ b/basis-library/primitive/prim2.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/primitive/primitive.mlb
+++ b/basis-library/primitive/primitive.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/real/IEEE-real.sml
+++ b/basis-library/real/IEEE-real.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/real/pack-real.sml
+++ b/basis-library/real/pack-real.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/real/real-global.sml
+++ b/basis-library/real/real-global.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/real/real.sml
+++ b/basis-library/real/real.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2003-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/sml-nj.mlb
+++ b/basis-library/sml-nj.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/sml-nj/sml-nj.sml
+++ b/basis-library/sml-nj/sml-nj.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/sml-nj/unsafe.sml
+++ b/basis-library/sml-nj/unsafe.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/system/command-line.sml
+++ b/basis-library/system/command-line.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/system/os.sml
+++ b/basis-library/system/os.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/system/pre-os.sml
+++ b/basis-library/system/pre-os.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/system/time.sml
+++ b/basis-library/system/time.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/system/timer.sml
+++ b/basis-library/system/timer.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/system/unix.sml
+++ b/basis-library/system/unix.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/byte.sml
+++ b/basis-library/text/byte.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/char-global.sml
+++ b/basis-library/text/char-global.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/char.sml
+++ b/basis-library/text/char.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/char0.sml
+++ b/basis-library/text/char0.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/nullstring.sml
+++ b/basis-library/text/nullstring.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/string-cvt.sml
+++ b/basis-library/text/string-cvt.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/string-global.sml
+++ b/basis-library/text/string-global.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/string.sml
+++ b/basis-library/text/string.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/string0.sml
+++ b/basis-library/text/string0.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/substring-global.sml
+++ b/basis-library/text/substring-global.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/substring.sml
+++ b/basis-library/text/substring.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/text/text.sml
+++ b/basis-library/text/text.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/top-level/arithmetic.sml
+++ b/basis-library/top-level/arithmetic.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/top-level/infixes-overflow.sml
+++ b/basis-library/top-level/infixes-overflow.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/top-level/infixes-unsafe.sml
+++ b/basis-library/top-level/infixes-unsafe.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/top-level/infixes.sml
+++ b/basis-library/top-level/infixes.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/unsafe.mlb
+++ b/basis-library/unsafe.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/CUtil.sig
+++ b/basis-library/util/CUtil.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/CUtil.sml
+++ b/basis-library/util/CUtil.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/abs-rep.fun
+++ b/basis-library/util/abs-rep.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/abs-rep.sig
+++ b/basis-library/util/abs-rep.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/cleaner.sig
+++ b/basis-library/util/cleaner.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/cleaner.sml
+++ b/basis-library/util/cleaner.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/dynamic-wind.sig
+++ b/basis-library/util/dynamic-wind.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/dynamic-wind.sml
+++ b/basis-library/util/dynamic-wind.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/heap.sml
+++ b/basis-library/util/heap.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2007-2007 Wesley W. Terpstra
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/integral-comparisons.sml
+++ b/basis-library/util/integral-comparisons.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/natural.sml
+++ b/basis-library/util/natural.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/one.sml
+++ b/basis-library/util/one.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2006-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/reader.sig
+++ b/basis-library/util/reader.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/reader.sml
+++ b/basis-library/util/reader.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/real-comparisons.sml
+++ b/basis-library/util/real-comparisons.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/string-comparisons.sml
+++ b/basis-library/util/string-comparisons.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/unique-id.fun
+++ b/basis-library/util/unique-id.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/basis-library/util/unique-id.sig
+++ b/basis-library/util/unique-id.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -4,7 +4,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/benchmark/benchmark.mlb
+++ b/benchmark/benchmark.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/benchmark/call-main.sml
+++ b/benchmark/call-main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/benchmark/main.sml
+++ b/benchmark/main.sml
@@ -4,7 +4,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/benchmark/sources.mlb
+++ b/benchmark/sources.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/benchmark/tests/Makefile
+++ b/benchmark/tests/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/examples/Makefile
+++ b/doc/examples/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/examples/ffi/Makefile
+++ b/doc/examples/ffi/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/examples/finalizable/Makefile
+++ b/doc/examples/finalizable/Makefile
@@ -1,7 +1,7 @@
 ## Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  #    Jagannathan, and Stephen Weeks.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/examples/profiling/Makefile
+++ b/doc/examples/profiling/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/examples/save-world/Makefile
+++ b/doc/examples/save-world/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/guide/src/License.adoc
+++ b/doc/guide/src/License.adoc
@@ -14,11 +14,14 @@ contribution to the public domain.
 
 == Software ==
 
-As of 20050812, MLton software is licensed under the BSD-style license
-below.  By contributing code to the project, you agree to release the
-code under this license.  Contributors can retain copyright to their
-contributions by asserting copyright in their code.  Contributors may
-also add to the list of copyright holders in
+As of 20050812, MLton software is licensed under the HPND-style
+license below.  The Historical Permission Notice and Disclaimer (HPND)
+license is an https://opensource.org/licenses/HPND[open source] and
+https://www.gnu.org/licenses/license-list.en.html#HPND[free software]
+license.  By contributing code to the project, you agree to release
+the code under this license.  Contributors can retain copyright to
+their contributions by asserting copyright in their code.
+Contributors may also add to the list of copyright holders in
 `doc/license/MLton-LICENSE`, which appears below.
 
 [source,text]

--- a/doc/hacker-guide/Makefile
+++ b/doc/hacker-guide/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/library-guide/Makefile
+++ b/doc/library-guide/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/license/MLKit-LICENSE
+++ b/doc/license/MLKit-LICENSE
@@ -3,7 +3,7 @@
 
 The ML Kit compiler is distributed under the GNU Public License. See
 the file copyright for details. The runtime system (kit/src/Runtime/)
-and libraries (kit/basislib/) is distributed nder the more liberal
+and libraries (kit/basislib/) is distributed under the more liberal
 MIT License.
 
 ======================================================================

--- a/doc/license/README
+++ b/doc/license/README
@@ -1,8 +1,9 @@
 package         license                         use
 --------------  ------------------------------  ------------
-MLton           MLton-LICENSE (BSD-style)
+MLton           MLton-LICENSE (HPND-style)      all components excepting those
+                                                identified below
 
-SML/NJ          NJ-LICENSE (BSD-style)          front-end mllex specification
+SML/NJ          NJ-LICENSE (HPND-style)         front-end mllex specification
                                                 front-end mlyacc specification
                                                 precedence parser
                                                 CM lexer and parser
@@ -15,8 +16,14 @@ SML/NJ          NJ-LICENSE (BSD-style)          front-end mllex specification
                                                 MLRISC Library
                                                 ML-LPT Library
 
-SML/NJ Lib	SMLNJ-LIB-LICENSE (BSD-style) 	SML/NJ Library
+SML/NJ Lib      SMLNJ-LIB-LICENSE (HPND-style)  SML/NJ Library
 
 ML Kit          MLKit-LICENSE (MIT)             Path, Time, Date
 
-gdtoa           gdtoa-LICENSE (BSD-style)       Real binary <-> decimal conversions
+gdtoa           gdtoa-LICENSE (HPND-style)      Real binary <-> decimal conversions
+
+
+The Historical Permission Notice and Disclaimer (HPND) license is an
+open source (https://opensource.org/licenses/HPND) and
+free software (https://www.gnu.org/licenses/license-list.en.html#HPND)
+license.

--- a/doc/license/README
+++ b/doc/license/README
@@ -13,6 +13,7 @@ SML/NJ          NJ-LICENSE (BSD-style)          front-end mllex specification
                                                 CKit Library
                                                 mlnlffigen and MLNLFFI Library
                                                 MLRISC Library
+                                                ML-LPT Library
 
 SML/NJ Lib	SMLNJ-LIB-LICENSE (BSD-style) 	SML/NJ Library
 

--- a/doc/mlb-formal/Makefile
+++ b/doc/mlb-formal/Makefile
@@ -1,7 +1,7 @@
 ## Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  #    Jagannathan, and Stephen Weeks.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/doc/style-guide/Makefile
+++ b/doc/style-guide/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/ide/emacs/bg-build-mode.el
+++ b/ide/emacs/bg-build-mode.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007-2008 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'compile)

--- a/ide/emacs/bg-build-util.el
+++ b/ide/emacs/bg-build-util.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'cl)

--- a/ide/emacs/bg-job.el
+++ b/ide/emacs/bg-job.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'cl)

--- a/ide/emacs/compat.el
+++ b/ide/emacs/compat.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007-2008 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/ide/emacs/def-use-data.el
+++ b/ide/emacs/def-use-data.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'def-use-sym)

--- a/ide/emacs/def-use-mode.el
+++ b/ide/emacs/def-use-mode.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 ;; This is a minor mode to support precisely identified definitions and

--- a/ide/emacs/def-use-sym.el
+++ b/ide/emacs/def-use-sym.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'def-use-util)

--- a/ide/emacs/def-use-util.el
+++ b/ide/emacs/def-use-util.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'cl)

--- a/ide/emacs/esml-du-mlton.el
+++ b/ide/emacs/esml-du-mlton.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2007-2008 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'def-use-mode)

--- a/ide/emacs/esml-gen.el
+++ b/ide/emacs/esml-gen.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2005 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'esml-util)

--- a/ide/emacs/esml-mlb-mode.el
+++ b/ide/emacs/esml-mlb-mode.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2005-2007 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'esml-util)

--- a/ide/emacs/esml-util.el
+++ b/ide/emacs/esml-util.el
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2005 Vesa Karvonen
 ;;
-;; MLton is released under a BSD-style license.
+;; MLton is released under a HPND-style license.
 ;; See the file MLton-LICENSE for details.
 
 (require 'cl)

--- a/include/Makefile
+++ b/include/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/include/amd64-main.h
+++ b/include/amd64-main.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2000-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/include/c-chunk.h
+++ b/include/c-chunk.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/include/c-common.h
+++ b/include/c-common.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/include/c-main.h
+++ b/include/c-main.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/include/common-main.h
+++ b/include/common-main.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/include/mlton-main.h
+++ b/include/mlton-main.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/include/x86-main.h
+++ b/include/x86-main.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2000-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/ckit-lib/Makefile
+++ b/lib/ckit-lib/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/mllpt-lib/Makefile
+++ b/lib/mllpt-lib/Makefile
@@ -1,6 +1,6 @@
 ## Copyright (C) 2011,2016,2018 Matthew Fluet.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/mlrisc-lib/Makefile
+++ b/lib/mlrisc-lib/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/mlton/Makefile
+++ b/lib/mlton/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/mlton/basic/Makefile
+++ b/lib/mlton/basic/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/mlton/basic/alpha-beta.fun
+++ b/lib/mlton/basic/alpha-beta.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/alpha-beta.sig
+++ b/lib/mlton/basic/alpha-beta.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/append-list.sig
+++ b/lib/mlton/basic/append-list.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/append-list.sml
+++ b/lib/mlton/basic/append-list.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/array.fun
+++ b/lib/mlton/basic/array.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/array.sig
+++ b/lib/mlton/basic/array.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/array.sml
+++ b/lib/mlton/basic/array.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/array2.sig
+++ b/lib/mlton/basic/array2.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/array2.sml
+++ b/lib/mlton/basic/array2.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/assert.sig
+++ b/lib/mlton/basic/assert.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/assert.sml
+++ b/lib/mlton/basic/assert.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/base64.sig
+++ b/lib/mlton/basic/base64.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/base64.sml
+++ b/lib/mlton/basic/base64.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/binary-search.sig
+++ b/lib/mlton/basic/binary-search.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/binary-search.sml
+++ b/lib/mlton/basic/binary-search.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/bool.sig
+++ b/lib/mlton/basic/bool.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/bool.sml
+++ b/lib/mlton/basic/bool.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/basic/bounded-order.fun
+++ b/lib/mlton/basic/bounded-order.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*------------------------------------------------------------------*)

--- a/lib/mlton/basic/bounded-order.sig
+++ b/lib/mlton/basic/bounded-order.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/buffer.sig
+++ b/lib/mlton/basic/buffer.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/buffer.sml
+++ b/lib/mlton/basic/buffer.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char-buffer.sig
+++ b/lib/mlton/basic/char-buffer.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char-buffer.sml
+++ b/lib/mlton/basic/char-buffer.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char-pred.sig
+++ b/lib/mlton/basic/char-pred.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char-pred.sml
+++ b/lib/mlton/basic/char-pred.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char.sig
+++ b/lib/mlton/basic/char.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char.sml
+++ b/lib/mlton/basic/char.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char0.sig
+++ b/lib/mlton/basic/char0.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/char0.sml
+++ b/lib/mlton/basic/char0.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/choice-pattern.sig
+++ b/lib/mlton/basic/choice-pattern.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/choice-pattern.sml
+++ b/lib/mlton/basic/choice-pattern.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/circular-list.fun
+++ b/lib/mlton/basic/circular-list.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/circular-list.sig
+++ b/lib/mlton/basic/circular-list.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/clearable-promise.sig
+++ b/lib/mlton/basic/clearable-promise.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/clearable-promise.sml
+++ b/lib/mlton/basic/clearable-promise.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/computation.sig
+++ b/lib/mlton/basic/computation.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/console.sig
+++ b/lib/mlton/basic/console.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/console.sml
+++ b/lib/mlton/basic/console.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/control.fun
+++ b/lib/mlton/basic/control.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/control.sig
+++ b/lib/mlton/basic/control.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/counter.sig
+++ b/lib/mlton/basic/counter.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/counter.sml
+++ b/lib/mlton/basic/counter.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/date.sig
+++ b/lib/mlton/basic/date.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/date.sml
+++ b/lib/mlton/basic/date.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/dir.sig
+++ b/lib/mlton/basic/dir.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/dir.sml
+++ b/lib/mlton/basic/dir.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/directed-graph.sig
+++ b/lib/mlton/basic/directed-graph.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/directed-graph.sml
+++ b/lib/mlton/basic/directed-graph.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/directed-sub-graph.sig
+++ b/lib/mlton/basic/directed-sub-graph.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/directed-sub-graph.sml
+++ b/lib/mlton/basic/directed-sub-graph.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/dot-color.sml
+++ b/lib/mlton/basic/dot-color.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/dot.sig
+++ b/lib/mlton/basic/dot.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/dot.sml
+++ b/lib/mlton/basic/dot.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/doubly-linked.fun
+++ b/lib/mlton/basic/doubly-linked.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/doubly-linked.sig
+++ b/lib/mlton/basic/doubly-linked.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/dynamic-wind.sig
+++ b/lib/mlton/basic/dynamic-wind.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/dynamic-wind.sml
+++ b/lib/mlton/basic/dynamic-wind.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/engine.sig
+++ b/lib/mlton/basic/engine.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/engine.sml
+++ b/lib/mlton/basic/engine.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/env.fun
+++ b/lib/mlton/basic/env.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/env.sig
+++ b/lib/mlton/basic/env.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/error.sig
+++ b/lib/mlton/basic/error.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/error.sml
+++ b/lib/mlton/basic/error.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/escape.sig
+++ b/lib/mlton/basic/escape.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/escape.sml
+++ b/lib/mlton/basic/escape.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/euclidean-ring.fun
+++ b/lib/mlton/basic/euclidean-ring.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/euclidean-ring.sig
+++ b/lib/mlton/basic/euclidean-ring.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/exn.sig
+++ b/lib/mlton/basic/exn.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/exn.sml
+++ b/lib/mlton/basic/exn.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/exn0.sml
+++ b/lib/mlton/basic/exn0.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2005-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/export.sig
+++ b/lib/mlton/basic/export.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/export.sml
+++ b/lib/mlton/basic/export.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/field.fun
+++ b/lib/mlton/basic/field.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/field.sig
+++ b/lib/mlton/basic/field.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/file-desc.sig
+++ b/lib/mlton/basic/file-desc.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/file-desc.sml
+++ b/lib/mlton/basic/file-desc.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/file.sig
+++ b/lib/mlton/basic/file.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/file.sml
+++ b/lib/mlton/basic/file.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/fixed-point.sig
+++ b/lib/mlton/basic/fixed-point.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/fixed-point.sml
+++ b/lib/mlton/basic/fixed-point.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/fold.fun
+++ b/lib/mlton/basic/fold.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/fold.sig
+++ b/lib/mlton/basic/fold.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/format.sig
+++ b/lib/mlton/basic/format.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/format.sml
+++ b/lib/mlton/basic/format.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/function.sig
+++ b/lib/mlton/basic/function.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/function.sml
+++ b/lib/mlton/basic/function.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/hash-set.sig
+++ b/lib/mlton/basic/hash-set.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/hash-set.sml
+++ b/lib/mlton/basic/hash-set.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/het-container.fun
+++ b/lib/mlton/basic/het-container.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/het-container.sig
+++ b/lib/mlton/basic/het-container.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/html.sig
+++ b/lib/mlton/basic/html.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/html.sml
+++ b/lib/mlton/basic/html.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/http.mlb
+++ b/lib/mlton/basic/http.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/http.sig
+++ b/lib/mlton/basic/http.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/http.sml
+++ b/lib/mlton/basic/http.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/init-script.sig
+++ b/lib/mlton/basic/init-script.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/init-script.sml
+++ b/lib/mlton/basic/init-script.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/insertion-sort.sig
+++ b/lib/mlton/basic/insertion-sort.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/insertion-sort.sml
+++ b/lib/mlton/basic/insertion-sort.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/instream.sig
+++ b/lib/mlton/basic/instream.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/instream.sml
+++ b/lib/mlton/basic/instream.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/instream0.sml
+++ b/lib/mlton/basic/instream0.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/int-inf.sig
+++ b/lib/mlton/basic/int-inf.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/int-inf.sml
+++ b/lib/mlton/basic/int-inf.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/int.sml
+++ b/lib/mlton/basic/int.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/integer.fun
+++ b/lib/mlton/basic/integer.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/integer.sig
+++ b/lib/mlton/basic/integer.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/intermediate-computation.sig
+++ b/lib/mlton/basic/intermediate-computation.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/intermediate-computation.sml
+++ b/lib/mlton/basic/intermediate-computation.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/iterate.sig
+++ b/lib/mlton/basic/iterate.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/iterate.sml
+++ b/lib/mlton/basic/iterate.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/basic/itimer.sml
+++ b/lib/mlton/basic/itimer.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/justify.sig
+++ b/lib/mlton/basic/justify.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/justify.sml
+++ b/lib/mlton/basic/justify.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/large-word.sml
+++ b/lib/mlton/basic/large-word.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/layout.sig
+++ b/lib/mlton/basic/layout.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/layout.sml
+++ b/lib/mlton/basic/layout.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/lines.sig
+++ b/lib/mlton/basic/lines.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/lines.sml
+++ b/lib/mlton/basic/lines.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/linked-list.sig
+++ b/lib/mlton/basic/linked-list.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/linked-list.sml
+++ b/lib/mlton/basic/linked-list.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/list.sig
+++ b/lib/mlton/basic/list.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/list.sml
+++ b/lib/mlton/basic/list.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/mark.sig
+++ b/lib/mlton/basic/mark.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/mark.sml
+++ b/lib/mlton/basic/mark.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/max-pow-2-that-divides.fun
+++ b/lib/mlton/basic/max-pow-2-that-divides.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/merge-sort.sig
+++ b/lib/mlton/basic/merge-sort.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/merge-sort.sml
+++ b/lib/mlton/basic/merge-sort.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/mono-container.sig
+++ b/lib/mlton/basic/mono-container.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/mono-list.fun
+++ b/lib/mlton/basic/mono-list.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/mono-option.fun
+++ b/lib/mlton/basic/mono-option.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/mono-vector.fun
+++ b/lib/mlton/basic/mono-vector.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/my-dirs.sig
+++ b/lib/mlton/basic/my-dirs.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/my-dirs.sml
+++ b/lib/mlton/basic/my-dirs.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/net.sig
+++ b/lib/mlton/basic/net.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/net.sml
+++ b/lib/mlton/basic/net.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/number.fun
+++ b/lib/mlton/basic/number.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/basic/number.sig
+++ b/lib/mlton/basic/number.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/option.sig
+++ b/lib/mlton/basic/option.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/option.sml
+++ b/lib/mlton/basic/option.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/order.sig
+++ b/lib/mlton/basic/order.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/order0.sig
+++ b/lib/mlton/basic/order0.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ordered-field.fun
+++ b/lib/mlton/basic/ordered-field.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/basic/ordered-field.sig
+++ b/lib/mlton/basic/ordered-field.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ordered-ring.fun
+++ b/lib/mlton/basic/ordered-ring.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ordered-ring.sig
+++ b/lib/mlton/basic/ordered-ring.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/outstream.sig
+++ b/lib/mlton/basic/outstream.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/outstream.sml
+++ b/lib/mlton/basic/outstream.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/outstream0.sml
+++ b/lib/mlton/basic/outstream0.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/pair.fun
+++ b/lib/mlton/basic/pair.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/basic/pair.sig
+++ b/lib/mlton/basic/pair.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/parse-sexp.fun
+++ b/lib/mlton/basic/parse-sexp.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/parse-sexp.sig
+++ b/lib/mlton/basic/parse-sexp.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/parse.sig
+++ b/lib/mlton/basic/parse.sig
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Jason Carr.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/parse.sml
+++ b/lib/mlton/basic/parse.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Jason Carr.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/pid.sig
+++ b/lib/mlton/basic/pid.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/pid.sml
+++ b/lib/mlton/basic/pid.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/pointer.sig
+++ b/lib/mlton/basic/pointer.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/pointer.sml
+++ b/lib/mlton/basic/pointer.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/popt.sig
+++ b/lib/mlton/basic/popt.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/popt.sml
+++ b/lib/mlton/basic/popt.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/port.sig
+++ b/lib/mlton/basic/port.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/port.sml
+++ b/lib/mlton/basic/port.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/postscript.sig
+++ b/lib/mlton/basic/postscript.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/postscript.sml
+++ b/lib/mlton/basic/postscript.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/power.sml
+++ b/lib/mlton/basic/power.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/process.sig
+++ b/lib/mlton/basic/process.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/process.sml
+++ b/lib/mlton/basic/process.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/promise.sig
+++ b/lib/mlton/basic/promise.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/promise.sml
+++ b/lib/mlton/basic/promise.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/property-list.fun
+++ b/lib/mlton/basic/property-list.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/property-list.sig
+++ b/lib/mlton/basic/property-list.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/property.fun
+++ b/lib/mlton/basic/property.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/property.sig
+++ b/lib/mlton/basic/property.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ps.sig
+++ b/lib/mlton/basic/ps.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ps.sml
+++ b/lib/mlton/basic/ps.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/queue.sig
+++ b/lib/mlton/basic/queue.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/quick-sort.sig
+++ b/lib/mlton/basic/quick-sort.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/quick-sort.sml
+++ b/lib/mlton/basic/quick-sort.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/random.sig
+++ b/lib/mlton/basic/random.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/random.sml
+++ b/lib/mlton/basic/random.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/rational.fun
+++ b/lib/mlton/basic/rational.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/basic/rational.sig
+++ b/lib/mlton/basic/rational.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/rdb.sig
+++ b/lib/mlton/basic/rdb.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/rdb.sml
+++ b/lib/mlton/basic/rdb.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/reader.sig
+++ b/lib/mlton/basic/reader.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/reader.sml
+++ b/lib/mlton/basic/reader.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/real.sig
+++ b/lib/mlton/basic/real.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/real.sml
+++ b/lib/mlton/basic/real.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ref.sig
+++ b/lib/mlton/basic/ref.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ref.sml
+++ b/lib/mlton/basic/ref.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/regexp.sig
+++ b/lib/mlton/basic/regexp.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/regexp.sml
+++ b/lib/mlton/basic/regexp.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/relation.sig
+++ b/lib/mlton/basic/relation.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/relation.sml
+++ b/lib/mlton/basic/relation.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/relation0.sml
+++ b/lib/mlton/basic/relation0.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/resizable-array.fun
+++ b/lib/mlton/basic/resizable-array.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/resizable-array.sig
+++ b/lib/mlton/basic/resizable-array.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/result.sig
+++ b/lib/mlton/basic/result.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/result.sml
+++ b/lib/mlton/basic/result.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ring-with-identity.fun
+++ b/lib/mlton/basic/ring-with-identity.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ring-with-identity.sig
+++ b/lib/mlton/basic/ring-with-identity.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ring.fun
+++ b/lib/mlton/basic/ring.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/ring.sig
+++ b/lib/mlton/basic/ring.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/sexp.sig
+++ b/lib/mlton/basic/sexp.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/sexp.sml
+++ b/lib/mlton/basic/sexp.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/signal.sig
+++ b/lib/mlton/basic/signal.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/signal.sml
+++ b/lib/mlton/basic/signal.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/sources.cm
+++ b/lib/mlton/basic/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/sources.mlb
+++ b/lib/mlton/basic/sources.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/stream.sig
+++ b/lib/mlton/basic/stream.sig
@@ -3,7 +3,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/stream.sml
+++ b/lib/mlton/basic/stream.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/string-map.sig
+++ b/lib/mlton/basic/string-map.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/string-map.sml
+++ b/lib/mlton/basic/string-map.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/string.sig
+++ b/lib/mlton/basic/string.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/string.sml
+++ b/lib/mlton/basic/string.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/string0.sml
+++ b/lib/mlton/basic/string0.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/string1.sml
+++ b/lib/mlton/basic/string1.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/substring.sig
+++ b/lib/mlton/basic/substring.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/substring.sml
+++ b/lib/mlton/basic/substring.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/sum.fun
+++ b/lib/mlton/basic/sum.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/sum.sig
+++ b/lib/mlton/basic/sum.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/t.sig
+++ b/lib/mlton/basic/t.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/tab.sig
+++ b/lib/mlton/basic/tab.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/tab.sml
+++ b/lib/mlton/basic/tab.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/test.sml
+++ b/lib/mlton/basic/test.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/thread.sig
+++ b/lib/mlton/basic/thread.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/thread.sml
+++ b/lib/mlton/basic/thread.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/time.sig
+++ b/lib/mlton/basic/time.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/time.sml
+++ b/lib/mlton/basic/time.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/trace.sig
+++ b/lib/mlton/basic/trace.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/trace.sml
+++ b/lib/mlton/basic/trace.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/tree.sig
+++ b/lib/mlton/basic/tree.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/tree.sml
+++ b/lib/mlton/basic/tree.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/two-list-queue-mutable.sml
+++ b/lib/mlton/basic/two-list-queue-mutable.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/two-list-queue.sml
+++ b/lib/mlton/basic/two-list-queue.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unicode.sml
+++ b/lib/mlton/basic/unicode.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unimplemented.sml
+++ b/lib/mlton/basic/unimplemented.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unique-id.fun
+++ b/lib/mlton/basic/unique-id.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unique-id.sig
+++ b/lib/mlton/basic/unique-id.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unique-set.fun
+++ b/lib/mlton/basic/unique-set.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unique-set.sig
+++ b/lib/mlton/basic/unique-set.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unit.sig
+++ b/lib/mlton/basic/unit.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/unit.sml
+++ b/lib/mlton/basic/unit.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/url.sig
+++ b/lib/mlton/basic/url.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/url.sml
+++ b/lib/mlton/basic/url.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/vector.fun
+++ b/lib/mlton/basic/vector.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/vector.sig
+++ b/lib/mlton/basic/vector.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/vector.sml
+++ b/lib/mlton/basic/vector.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/word.sig
+++ b/lib/mlton/basic/word.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/word.sml
+++ b/lib/mlton/basic/word.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/basic/word8.sml
+++ b/lib/mlton/basic/word8.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/classify-edges.fun
+++ b/lib/mlton/directed-graph/classify-edges.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/classify-edges.sig
+++ b/lib/mlton/directed-graph/classify-edges.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/dijkstra.fun
+++ b/lib/mlton/directed-graph/dijkstra.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/shortest-path-check.fun
+++ b/lib/mlton/directed-graph/shortest-path-check.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/shortest-path-check.sig
+++ b/lib/mlton/directed-graph/shortest-path-check.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/shortest-path.sig
+++ b/lib/mlton/directed-graph/shortest-path.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/sources.cm
+++ b/lib/mlton/directed-graph/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/test.sml
+++ b/lib/mlton/directed-graph/test.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/directed-graph/weight.sig
+++ b/lib/mlton/directed-graph/weight.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/array-finite-function.fun
+++ b/lib/mlton/env/array-finite-function.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/array-finite-function.sig
+++ b/lib/mlton/env/array-finite-function.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/basic-env-to-env.fun
+++ b/lib/mlton/env/basic-env-to-env.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/cache.fun
+++ b/lib/mlton/env/cache.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/cache.sig
+++ b/lib/mlton/env/cache.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/finite-function.fun
+++ b/lib/mlton/env/finite-function.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/env/finite-function.sig
+++ b/lib/mlton/env/finite-function.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/mono-env.fun
+++ b/lib/mlton/env/mono-env.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/mono-env.sig
+++ b/lib/mlton/env/mono-env.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/move-to-front.fun
+++ b/lib/mlton/env/move-to-front.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/poly-cache-ref.fun
+++ b/lib/mlton/env/poly-cache-ref.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/poly-cache.fun
+++ b/lib/mlton/env/poly-cache.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/poly-cache.sig
+++ b/lib/mlton/env/poly-cache.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/sources.cm
+++ b/lib/mlton/env/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/sources.mlb
+++ b/lib/mlton/env/sources.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/env/splay-env.fun
+++ b/lib/mlton/env/splay-env.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/binary.fun
+++ b/lib/mlton/heap/binary.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/binomial.fun
+++ b/lib/mlton/heap/binomial.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/fibonacci.fun
+++ b/lib/mlton/heap/fibonacci.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/forest.fun
+++ b/lib/mlton/heap/forest.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/forest.sig
+++ b/lib/mlton/heap/forest.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/heap.sig
+++ b/lib/mlton/heap/heap.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/sources.cm
+++ b/lib/mlton/heap/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/heap/test.sml
+++ b/lib/mlton/heap/test.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/pervasive/pervasive.sml
+++ b/lib/mlton/pervasive/pervasive.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/pervasive/sources.cm
+++ b/lib/mlton/pervasive/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/pervasive/sources.mlb
+++ b/lib/mlton/pervasive/sources.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/append-reverse.fun
+++ b/lib/mlton/queue/append-reverse.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/append-reverse.sig
+++ b/lib/mlton/queue/append-reverse.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/basic-persistent.sig
+++ b/lib/mlton/queue/basic-persistent.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/bounded-ephemeral.sig
+++ b/lib/mlton/queue/bounded-ephemeral.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/circular.fun
+++ b/lib/mlton/queue/circular.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/early.fun
+++ b/lib/mlton/queue/early.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/ephemeral.fun
+++ b/lib/mlton/queue/ephemeral.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/ephemeral.sig
+++ b/lib/mlton/queue/ephemeral.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/explicit-append-reverse.fun
+++ b/lib/mlton/queue/explicit-append-reverse.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/incremental-append-reverse.fun
+++ b/lib/mlton/queue/incremental-append-reverse.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/incremental.fun
+++ b/lib/mlton/queue/incremental.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/lazy-append-reverse.fun
+++ b/lib/mlton/queue/lazy-append-reverse.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/linked-list.fun
+++ b/lib/mlton/queue/linked-list.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/list.fun
+++ b/lib/mlton/queue/list.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/persistent.fun
+++ b/lib/mlton/queue/persistent.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/persistent.sig
+++ b/lib/mlton/queue/persistent.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/queue.fun
+++ b/lib/mlton/queue/queue.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/singly-linked.fun
+++ b/lib/mlton/queue/singly-linked.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/sources.cm
+++ b/lib/mlton/queue/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/test.sml
+++ b/lib/mlton/queue/test.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/queue/two-list.fun
+++ b/lib/mlton/queue/two-list.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/queue/unbounded-ephemeral.sig
+++ b/lib/mlton/queue/unbounded-ephemeral.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/bit-vector-set.fun
+++ b/lib/mlton/set/bit-vector-set.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/disjoint-collection.fun
+++ b/lib/mlton/set/disjoint-collection.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/set/disjoint-collection.sig
+++ b/lib/mlton/set/disjoint-collection.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/disjoint-max.fun
+++ b/lib/mlton/set/disjoint-max.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/disjoint-max.sig
+++ b/lib/mlton/set/disjoint-max.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/disjoint.fun
+++ b/lib/mlton/set/disjoint.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/disjoint.sig
+++ b/lib/mlton/set/disjoint.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/hashed-unique-set.fun
+++ b/lib/mlton/set/hashed-unique-set.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/object-oriented.sml
+++ b/lib/mlton/set/object-oriented.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/ordered-unique-set.fun
+++ b/lib/mlton/set/ordered-unique-set.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/poly-set.sig
+++ b/lib/mlton/set/poly-set.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/poly-unordered.fun
+++ b/lib/mlton/set/poly-unordered.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/poly-unordered2.fun
+++ b/lib/mlton/set/poly-unordered2.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/set.sig
+++ b/lib/mlton/set/set.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/sources.cm
+++ b/lib/mlton/set/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/sources.mlb
+++ b/lib/mlton/set/sources.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/test.sml
+++ b/lib/mlton/set/test.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/type.fun
+++ b/lib/mlton/set/type.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/set/type.sig
+++ b/lib/mlton/set/type.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/universe-equal.fun
+++ b/lib/mlton/set/universe-equal.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/set/universe-type-check.fun
+++ b/lib/mlton/set/universe-type-check.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/set/universe.sig
+++ b/lib/mlton/set/universe.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/set/unordered-universe.fun
+++ b/lib/mlton/set/unordered-universe.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 (*-------------------------------------------------------------------*)

--- a/lib/mlton/set/unordered.fun
+++ b/lib/mlton/set/unordered.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/sources.cm
+++ b/lib/mlton/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlton/sources.mlb
+++ b/lib/mlton/sources.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/mlyacc-lib/mlyacc-lib.mlb
+++ b/lib/mlyacc-lib/mlyacc-lib.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/smlnj-lib/Makefile
+++ b/lib/smlnj-lib/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/stubs/Makefile
+++ b/lib/stubs/Makefile
@@ -1,6 +1,6 @@
 ## Copyright (C) 2009 Matthew Fluet.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/stubs/basis-stubs-for-polyml/int.sml
+++ b/lib/stubs/basis-stubs-for-polyml/int.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-polyml/real.sml
+++ b/lib/stubs/basis-stubs-for-polyml/real.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-polyml/unsafe.sig
+++ b/lib/stubs/basis-stubs-for-polyml/unsafe.sig
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-polyml/unsafe.sml
+++ b/lib/stubs/basis-stubs-for-polyml/unsafe.sml
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-polyml/word.sml
+++ b/lib/stubs/basis-stubs-for-polyml/word.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/Makefile
+++ b/lib/stubs/basis-stubs-for-smlnj/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/stubs/basis-stubs-for-smlnj/char.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/char.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/ieee-real.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/ieee-real.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/int-inf.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/int-inf.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/int.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/int.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/pervasive.cm
+++ b/lib/stubs/basis-stubs-for-smlnj/pervasive.cm
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/pervasive.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/pervasive.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/real.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/real.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/sources.cm
+++ b/lib/stubs/basis-stubs-for-smlnj/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/string.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/string.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/basis-stubs-for-smlnj/word.sml
+++ b/lib/stubs/basis-stubs-for-smlnj/word.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs-for-polyml/mlton.sml
+++ b/lib/stubs/mlton-stubs-for-polyml/mlton.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs-for-smlnj/Makefile
+++ b/lib/stubs/mlton-stubs-for-smlnj/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/stubs/mlton-stubs-for-smlnj/mlton.sml
+++ b/lib/stubs/mlton-stubs-for-smlnj/mlton.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs-for-smlnj/sources.cm
+++ b/lib/stubs/mlton-stubs-for-smlnj/sources.cm
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/Makefile
+++ b/lib/stubs/mlton-stubs/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/lib/stubs/mlton-stubs/array.sig
+++ b/lib/stubs/mlton-stubs/array.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/bin-io.sig
+++ b/lib/stubs/mlton-stubs/bin-io.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/cont.sig
+++ b/lib/stubs/mlton-stubs/cont.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/exn.sig
+++ b/lib/stubs/mlton-stubs/exn.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/finalizable.sig
+++ b/lib/stubs/mlton-stubs/finalizable.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/gc.sig
+++ b/lib/stubs/mlton-stubs/gc.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/io.sig
+++ b/lib/stubs/mlton-stubs/io.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/itimer.sig
+++ b/lib/stubs/mlton-stubs/itimer.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/mlton.sig
+++ b/lib/stubs/mlton-stubs/mlton.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/mlton.sml
+++ b/lib/stubs/mlton-stubs/mlton.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/platform.sig
+++ b/lib/stubs/mlton-stubs/platform.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/proc-env.sig
+++ b/lib/stubs/mlton-stubs/proc-env.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/process.sig
+++ b/lib/stubs/mlton-stubs/process.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/profile.sig
+++ b/lib/stubs/mlton-stubs/profile.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/random.sig
+++ b/lib/stubs/mlton-stubs/random.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/random.sml
+++ b/lib/stubs/mlton-stubs/random.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/rusage.sig
+++ b/lib/stubs/mlton-stubs/rusage.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/signal.sig
+++ b/lib/stubs/mlton-stubs/signal.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/sources.cm
+++ b/lib/stubs/mlton-stubs/sources.cm
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/sources.mlb
+++ b/lib/stubs/mlton-stubs/sources.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/text-io.sig
+++ b/lib/stubs/mlton-stubs/text-io.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/thread.sig
+++ b/lib/stubs/mlton-stubs/thread.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/thread.sml
+++ b/lib/stubs/mlton-stubs/thread.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/vector.sig
+++ b/lib/stubs/mlton-stubs/vector.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/weak.sig
+++ b/lib/stubs/mlton-stubs/weak.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/word.sig
+++ b/lib/stubs/mlton-stubs/word.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/lib/stubs/mlton-stubs/world.sig
+++ b/lib/stubs/mlton-stubs/world.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mllex/Makefile
+++ b/mllex/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mllex/call-main.sml
+++ b/mllex/call-main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mllex/main.sml
+++ b/mllex/main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mllex/mllex.mlb
+++ b/mllex/mllex.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlnlffigen/Makefile
+++ b/mlnlffigen/Makefile
@@ -2,7 +2,7 @@
  # Copyright (C) 2005-2009 Henry Cejtin, Matthew Fluet, Suresh
  #    Jagannathan, and Stephen Weeks.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mlnlffigen/call-main.sml
+++ b/mlnlffigen/call-main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlnlffigen/control.sig
+++ b/mlnlffigen/control.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlnlffigen/control.sml
+++ b/mlnlffigen/control.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlnlffigen/gen.sml
+++ b/mlnlffigen/gen.sml
@@ -4,7 +4,7 @@
 (* Copyright (C) 2005-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
  *)

--- a/mlnlffigen/main.sml
+++ b/mlnlffigen/main.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlnlffigen/mlnlffigen.mlb
+++ b/mlnlffigen/mlnlffigen.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlnlffigen/sources.mlb
+++ b/mlnlffigen/sources.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlprof/Makefile
+++ b/mlprof/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mlprof/call-main.sml
+++ b/mlprof/call-main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlprof/main.sml
+++ b/mlprof/main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlprof/mlprof.mlb
+++ b/mlprof/mlprof.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlprof/sources.mlb
+++ b/mlprof/sources.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/Makefile
+++ b/mlton/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mlton/ast/ast-atoms.fun
+++ b/mlton/ast/ast-atoms.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-atoms.sig
+++ b/mlton/ast/ast-atoms.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-const.fun
+++ b/mlton/ast/ast-const.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-const.sig
+++ b/mlton/ast/ast-const.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-core.fun
+++ b/mlton/ast/ast-core.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-core.sig
+++ b/mlton/ast/ast-core.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-id.fun
+++ b/mlton/ast/ast-id.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-id.sig
+++ b/mlton/ast/ast-id.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-mlbs.fun
+++ b/mlton/ast/ast-mlbs.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-mlbs.sig
+++ b/mlton/ast/ast-mlbs.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-modules.fun
+++ b/mlton/ast/ast-modules.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-modules.sig
+++ b/mlton/ast/ast-modules.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-programs.fun
+++ b/mlton/ast/ast-programs.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast-programs.sig
+++ b/mlton/ast/ast-programs.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast.fun
+++ b/mlton/ast/ast.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/ast.sig
+++ b/mlton/ast/ast.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/longid.fun
+++ b/mlton/ast/longid.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/longid.sig
+++ b/mlton/ast/longid.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/sources.cm
+++ b/mlton/ast/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ast/sources.mlb
+++ b/mlton/ast/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/admits-equality.fun
+++ b/mlton/atoms/admits-equality.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/admits-equality.sig
+++ b/mlton/atoms/admits-equality.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/atoms.fun
+++ b/mlton/atoms/atoms.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/atoms.sig
+++ b/mlton/atoms/atoms.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/c-function.fun
+++ b/mlton/atoms/c-function.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2003-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/c-function.sig
+++ b/mlton/atoms/c-function.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/c-type.fun
+++ b/mlton/atoms/c-type.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/c-type.sig
+++ b/mlton/atoms/c-type.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/cases.fun
+++ b/mlton/atoms/cases.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/cases.sig
+++ b/mlton/atoms/cases.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/char-size.fun
+++ b/mlton/atoms/char-size.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/char-size.sig
+++ b/mlton/atoms/char-size.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/con-.fun
+++ b/mlton/atoms/con-.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/con-.sig
+++ b/mlton/atoms/con-.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/const-type.fun
+++ b/mlton/atoms/const-type.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/const-type.sig
+++ b/mlton/atoms/const-type.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/const.fun
+++ b/mlton/atoms/const.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/const.sig
+++ b/mlton/atoms/const.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/ffi.fun
+++ b/mlton/atoms/ffi.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/ffi.sig
+++ b/mlton/atoms/ffi.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/field.fun
+++ b/mlton/atoms/field.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/field.sig
+++ b/mlton/atoms/field.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/func.sig
+++ b/mlton/atoms/func.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/generic-scheme.fun
+++ b/mlton/atoms/generic-scheme.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/generic-scheme.sig
+++ b/mlton/atoms/generic-scheme.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/hash-type.sig
+++ b/mlton/atoms/hash-type.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/id.fun
+++ b/mlton/atoms/id.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/id.sig
+++ b/mlton/atoms/id.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/int-size.fun
+++ b/mlton/atoms/int-size.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/int-size.sig
+++ b/mlton/atoms/int-size.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/label.sig
+++ b/mlton/atoms/label.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/layout-pretty.sml
+++ b/mlton/atoms/layout-pretty.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/prim-cons.fun
+++ b/mlton/atoms/prim-cons.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/prim-cons.sig
+++ b/mlton/atoms/prim-cons.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/prim-tycons.fun
+++ b/mlton/atoms/prim-tycons.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/prim-tycons.sig
+++ b/mlton/atoms/prim-tycons.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/prim.sig
+++ b/mlton/atoms/prim.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/profile-exp.fun
+++ b/mlton/atoms/profile-exp.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/profile-exp.sig
+++ b/mlton/atoms/profile-exp.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/profile-label.fun
+++ b/mlton/atoms/profile-label.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/profile-label.sig
+++ b/mlton/atoms/profile-label.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/real-size.fun
+++ b/mlton/atoms/real-size.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/real-size.sig
+++ b/mlton/atoms/real-size.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/real-x.fun
+++ b/mlton/atoms/real-x.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/real-x.sig
+++ b/mlton/atoms/real-x.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/record.fun
+++ b/mlton/atoms/record.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/record.sig
+++ b/mlton/atoms/record.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/source-info.fun
+++ b/mlton/atoms/source-info.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/source-info.sig
+++ b/mlton/atoms/source-info.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2003-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/sources.cm
+++ b/mlton/atoms/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/sources.mlb
+++ b/mlton/atoms/sources.mlb
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/symbol.fun
+++ b/mlton/atoms/symbol.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/symbol.sig
+++ b/mlton/atoms/symbol.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/tycon-kind.fun
+++ b/mlton/atoms/tycon-kind.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/tycon-kind.sig
+++ b/mlton/atoms/tycon-kind.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/tycon.fun
+++ b/mlton/atoms/tycon.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/tycon.sig
+++ b/mlton/atoms/tycon.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/type-ops.fun
+++ b/mlton/atoms/type-ops.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/type-ops.sig
+++ b/mlton/atoms/type-ops.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/tyvar.fun
+++ b/mlton/atoms/tyvar.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/tyvar.sig
+++ b/mlton/atoms/tyvar.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/unary-tycon.fun
+++ b/mlton/atoms/unary-tycon.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/unary-tycon.sig
+++ b/mlton/atoms/unary-tycon.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/var.fun
+++ b/mlton/atoms/var.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/var.sig
+++ b/mlton/atoms/var.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/word-size.fun
+++ b/mlton/atoms/word-size.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/word-size.sig
+++ b/mlton/atoms/word-size.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/word-x-vector.fun
+++ b/mlton/atoms/word-x-vector.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/word-x-vector.sig
+++ b/mlton/atoms/word-x-vector.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/word-x.fun
+++ b/mlton/atoms/word-x.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/atoms/word-x.sig
+++ b/mlton/atoms/word-x.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/allocate-registers.fun
+++ b/mlton/backend/allocate-registers.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/allocate-registers.sig
+++ b/mlton/backend/allocate-registers.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/backend.sig
+++ b/mlton/backend/backend.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/chunkify.fun
+++ b/mlton/backend/chunkify.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/chunkify.sig
+++ b/mlton/backend/chunkify.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/equivalence-graph.fun
+++ b/mlton/backend/equivalence-graph.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/equivalence-graph.sig
+++ b/mlton/backend/equivalence-graph.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/err.sml
+++ b/mlton/backend/err.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/implement-handlers.fun
+++ b/mlton/backend/implement-handlers.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/implement-profiling.fun
+++ b/mlton/backend/implement-profiling.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/implement-profiling.sig
+++ b/mlton/backend/implement-profiling.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/limit-check.fun
+++ b/mlton/backend/limit-check.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/live.fun
+++ b/mlton/backend/live.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *
 

--- a/mlton/backend/live.sig
+++ b/mlton/backend/live.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/machine.sig
+++ b/mlton/backend/machine.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/object-type.sig
+++ b/mlton/backend/object-type.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/objptr-tycon.fun
+++ b/mlton/backend/objptr-tycon.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/objptr-tycon.sig
+++ b/mlton/backend/objptr-tycon.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/parallel-move.fun
+++ b/mlton/backend/parallel-move.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/parallel-move.sig
+++ b/mlton/backend/parallel-move.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/rep-type.fun
+++ b/mlton/backend/rep-type.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/rep-type.sig
+++ b/mlton/backend/rep-type.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/representation.sig
+++ b/mlton/backend/representation.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/rssa-transform.sig
+++ b/mlton/backend/rssa-transform.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/rssa.sig
+++ b/mlton/backend/rssa.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/runtime.fun
+++ b/mlton/backend/runtime.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/runtime.sig
+++ b/mlton/backend/runtime.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/scale.fun
+++ b/mlton/backend/scale.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/scale.sig
+++ b/mlton/backend/scale.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/signal-check.fun
+++ b/mlton/backend/signal-check.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/sources.cm
+++ b/mlton/backend/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/sources.mlb
+++ b/mlton/backend/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/ssa-to-rssa.fun
+++ b/mlton/backend/ssa-to-rssa.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/ssa-to-rssa.sig
+++ b/mlton/backend/ssa-to-rssa.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/switch.fun
+++ b/mlton/backend/switch.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2002-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/backend/switch.sig
+++ b/mlton/backend/switch.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2002-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/call-main.sml
+++ b/mlton/call-main.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/abstract-value.fun
+++ b/mlton/closure-convert/abstract-value.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/abstract-value.sig
+++ b/mlton/closure-convert/abstract-value.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/closure-convert.fun
+++ b/mlton/closure-convert/closure-convert.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/closure-convert.sig
+++ b/mlton/closure-convert/closure-convert.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/globalize.fun
+++ b/mlton/closure-convert/globalize.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/globalize.sig
+++ b/mlton/closure-convert/globalize.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/lambda-free.fun
+++ b/mlton/closure-convert/lambda-free.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/lambda-free.sig
+++ b/mlton/closure-convert/lambda-free.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/sources.cm
+++ b/mlton/closure-convert/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/closure-convert/sources.mlb
+++ b/mlton/closure-convert/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-allocate-registers.fun
+++ b/mlton/codegen/amd64-codegen/amd64-allocate-registers.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-allocate-registers.sig
+++ b/mlton/codegen/amd64-codegen/amd64-allocate-registers.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-codegen.fun
+++ b/mlton/codegen/amd64-codegen/amd64-codegen.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-codegen.sig
+++ b/mlton/codegen/amd64-codegen/amd64-codegen.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-entry-transfer.fun
+++ b/mlton/codegen/amd64-codegen/amd64-entry-transfer.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-entry-transfer.sig
+++ b/mlton/codegen/amd64-codegen/amd64-entry-transfer.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-generate-transfers.fun
+++ b/mlton/codegen/amd64-codegen/amd64-generate-transfers.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-generate-transfers.sig
+++ b/mlton/codegen/amd64-codegen/amd64-generate-transfers.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-jump-info.fun
+++ b/mlton/codegen/amd64-codegen/amd64-jump-info.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-jump-info.sig
+++ b/mlton/codegen/amd64-codegen/amd64-jump-info.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-live-transfers.fun
+++ b/mlton/codegen/amd64-codegen/amd64-live-transfers.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-live-transfers.sig
+++ b/mlton/codegen/amd64-codegen/amd64-live-transfers.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-liveness.fun
+++ b/mlton/codegen/amd64-codegen/amd64-liveness.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-liveness.sig
+++ b/mlton/codegen/amd64-codegen/amd64-liveness.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-loop-info.fun
+++ b/mlton/codegen/amd64-codegen/amd64-loop-info.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-loop-info.sig
+++ b/mlton/codegen/amd64-codegen/amd64-loop-info.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-mlton-basic.fun
+++ b/mlton/codegen/amd64-codegen/amd64-mlton-basic.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-mlton-basic.sig
+++ b/mlton/codegen/amd64-codegen/amd64-mlton-basic.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-mlton.fun
+++ b/mlton/codegen/amd64-codegen/amd64-mlton.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-mlton.sig
+++ b/mlton/codegen/amd64-codegen/amd64-mlton.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-pseudo.sig
+++ b/mlton/codegen/amd64-codegen/amd64-pseudo.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-simplify.fun
+++ b/mlton/codegen/amd64-codegen/amd64-simplify.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-simplify.sig
+++ b/mlton/codegen/amd64-codegen/amd64-simplify.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-translate.fun
+++ b/mlton/codegen/amd64-codegen/amd64-translate.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64-translate.sig
+++ b/mlton/codegen/amd64-codegen/amd64-translate.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64.fun
+++ b/mlton/codegen/amd64-codegen/amd64.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/amd64.sig
+++ b/mlton/codegen/amd64-codegen/amd64.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/peephole.fun
+++ b/mlton/codegen/amd64-codegen/peephole.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/peephole.sig
+++ b/mlton/codegen/amd64-codegen/peephole.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/sources.cm
+++ b/mlton/codegen/amd64-codegen/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/amd64-codegen/sources.mlb
+++ b/mlton/codegen/amd64-codegen/sources.mlb
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/c-codegen/c-codegen.sig
+++ b/mlton/codegen/c-codegen/c-codegen.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/c-codegen/sources.cm
+++ b/mlton/codegen/c-codegen/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/c-codegen/sources.mlb
+++ b/mlton/codegen/c-codegen/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/llvm-codegen/llvm-codegen.fun
+++ b/mlton/codegen/llvm-codegen/llvm-codegen.fun
@@ -1,6 +1,6 @@
 (* Copyright (C) 2013-2014 Matthew Fluet, Brian Leibig.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/llvm-codegen/llvm-codegen.sig
+++ b/mlton/codegen/llvm-codegen/llvm-codegen.sig
@@ -1,6 +1,6 @@
 (* Copyright (C) 2013-2014 Matthew Fluet, Brian Leibig.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/llvm-codegen/sources.cm
+++ b/mlton/codegen/llvm-codegen/sources.cm
@@ -1,6 +1,6 @@
 (* Copyright (C) 2013-2014 Matthew Fluet, Brian Leibig
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/llvm-codegen/sources.mlb
+++ b/mlton/codegen/llvm-codegen/sources.mlb
@@ -1,6 +1,6 @@
 (* Copyright (C) 2013-2014 Matthew Fluet, Brian Leibig
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/sources.cm
+++ b/mlton/codegen/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/sources.mlb
+++ b/mlton/codegen/sources.mlb
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/peephole.fun
+++ b/mlton/codegen/x86-codegen/peephole.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/peephole.sig
+++ b/mlton/codegen/x86-codegen/peephole.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/sources.cm
+++ b/mlton/codegen/x86-codegen/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/sources.mlb
+++ b/mlton/codegen/x86-codegen/sources.mlb
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-allocate-registers.fun
+++ b/mlton/codegen/x86-codegen/x86-allocate-registers.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-allocate-registers.sig
+++ b/mlton/codegen/x86-codegen/x86-allocate-registers.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-codegen.fun
+++ b/mlton/codegen/x86-codegen/x86-codegen.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-codegen.sig
+++ b/mlton/codegen/x86-codegen/x86-codegen.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-entry-transfer.fun
+++ b/mlton/codegen/x86-codegen/x86-entry-transfer.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-entry-transfer.sig
+++ b/mlton/codegen/x86-codegen/x86-entry-transfer.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-generate-transfers.fun
+++ b/mlton/codegen/x86-codegen/x86-generate-transfers.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-generate-transfers.sig
+++ b/mlton/codegen/x86-codegen/x86-generate-transfers.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-jump-info.fun
+++ b/mlton/codegen/x86-codegen/x86-jump-info.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-jump-info.sig
+++ b/mlton/codegen/x86-codegen/x86-jump-info.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-live-transfers.fun
+++ b/mlton/codegen/x86-codegen/x86-live-transfers.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-live-transfers.sig
+++ b/mlton/codegen/x86-codegen/x86-live-transfers.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-liveness.fun
+++ b/mlton/codegen/x86-codegen/x86-liveness.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-liveness.sig
+++ b/mlton/codegen/x86-codegen/x86-liveness.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-loop-info.fun
+++ b/mlton/codegen/x86-codegen/x86-loop-info.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-loop-info.sig
+++ b/mlton/codegen/x86-codegen/x86-loop-info.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-mlton-basic.fun
+++ b/mlton/codegen/x86-codegen/x86-mlton-basic.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-mlton-basic.sig
+++ b/mlton/codegen/x86-codegen/x86-mlton-basic.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-mlton.fun
+++ b/mlton/codegen/x86-codegen/x86-mlton.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-mlton.sig
+++ b/mlton/codegen/x86-codegen/x86-mlton.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-pseudo.sig
+++ b/mlton/codegen/x86-codegen/x86-pseudo.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-simplify.fun
+++ b/mlton/codegen/x86-codegen/x86-simplify.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-simplify.sig
+++ b/mlton/codegen/x86-codegen/x86-simplify.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-translate.fun
+++ b/mlton/codegen/x86-codegen/x86-translate.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86-translate.sig
+++ b/mlton/codegen/x86-codegen/x86-translate.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86.fun
+++ b/mlton/codegen/x86-codegen/x86.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/codegen/x86-codegen/x86.sig
+++ b/mlton/codegen/x86-codegen/x86.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/bits.sml
+++ b/mlton/control/bits.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/control.sig
+++ b/mlton/control/control.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/control.sml
+++ b/mlton/control/control.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/pretty.sig
+++ b/mlton/control/pretty.sig
@@ -2,7 +2,7 @@
  * Copyright (C) 2003-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/pretty.sml
+++ b/mlton/control/pretty.sml
@@ -2,7 +2,7 @@
  * Copyright (C) 2003-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/region.sig
+++ b/mlton/control/region.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/region.sml
+++ b/mlton/control/region.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/source-pos.sig
+++ b/mlton/control/source-pos.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/source-pos.sml
+++ b/mlton/control/source-pos.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/source.sig
+++ b/mlton/control/source.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/source.sml
+++ b/mlton/control/source.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/sources.cm
+++ b/mlton/control/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/sources.mlb
+++ b/mlton/control/sources.mlb
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/system.sig
+++ b/mlton/control/system.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/system.sml
+++ b/mlton/control/system.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/version_sml.src
+++ b/mlton/control/version_sml.src
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009,2013,2016,2018 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/control/wrapped.sig
+++ b/mlton/control/wrapped.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/core-ml/core-ml.fun
+++ b/mlton/core-ml/core-ml.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/core-ml/core-ml.sig
+++ b/mlton/core-ml/core-ml.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/core-ml/dead-code.fun
+++ b/mlton/core-ml/dead-code.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/core-ml/dead-code.sig
+++ b/mlton/core-ml/dead-code.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/core-ml/sources.cm
+++ b/mlton/core-ml/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/core-ml/sources.mlb
+++ b/mlton/core-ml/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/defunctorize/defunctorize.fun
+++ b/mlton/defunctorize/defunctorize.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/defunctorize/defunctorize.sig
+++ b/mlton/defunctorize/defunctorize.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2003-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/defunctorize/sources.cm
+++ b/mlton/defunctorize/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/defunctorize/sources.mlb
+++ b/mlton/defunctorize/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/decs.fun
+++ b/mlton/elaborate/decs.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/decs.sig
+++ b/mlton/elaborate/decs.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-core.fun
+++ b/mlton/elaborate/elaborate-core.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-core.sig
+++ b/mlton/elaborate/elaborate-core.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-env.fun
+++ b/mlton/elaborate/elaborate-env.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-env.sig
+++ b/mlton/elaborate/elaborate-env.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-mlbs.fun
+++ b/mlton/elaborate/elaborate-mlbs.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-mlbs.sig
+++ b/mlton/elaborate/elaborate-mlbs.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-modules.fun
+++ b/mlton/elaborate/elaborate-modules.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-modules.sig
+++ b/mlton/elaborate/elaborate-modules.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-programs.fun
+++ b/mlton/elaborate/elaborate-programs.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-programs.sig
+++ b/mlton/elaborate/elaborate-programs.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-sigexp.fun
+++ b/mlton/elaborate/elaborate-sigexp.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate-sigexp.sig
+++ b/mlton/elaborate/elaborate-sigexp.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate.fun
+++ b/mlton/elaborate/elaborate.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/elaborate.sig
+++ b/mlton/elaborate/elaborate.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/interface.fun
+++ b/mlton/elaborate/interface.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/interface.sig
+++ b/mlton/elaborate/interface.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/precedence-parse.sig
+++ b/mlton/elaborate/precedence-parse.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/scope.fun
+++ b/mlton/elaborate/scope.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/scope.sig
+++ b/mlton/elaborate/scope.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/sources.cm
+++ b/mlton/elaborate/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/sources.mlb
+++ b/mlton/elaborate/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/type-env.fun
+++ b/mlton/elaborate/type-env.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/elaborate/type-env.sig
+++ b/mlton/elaborate/type-env.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/Makefile
+++ b/mlton/front-end/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mlton/front-end/front-end.fun
+++ b/mlton/front-end/front-end.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/front-end.sig
+++ b/mlton/front-end/front-end.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/ml-yacc-lib-proxy.cm
+++ b/mlton/front-end/ml-yacc-lib-proxy.cm
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/ml.grm
+++ b/mlton/front-end/ml.grm
@@ -1,8 +1,20 @@
-(* Heavily modified from SML/NJ sources by sweeks@sweeks.com *)
+(* Heavily modified from SML/NJ sources. *)
 
 (* ml.grm
  *
  * Copyright 1989,1992 by AT&T Bell Laboratories
+ *
+ * SML/NJ is released under a HPND-style license.
+ * See the file NJ-LICENSE for details.
+ *)
+
+(* Copyright (C) 2008,2009,2014-2017 Matthew Fluet.
+ * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+ *    Jagannathan, and Stephen Weeks.
+ * Copyright (C) 1997-2000 NEC Research Institute.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
  *)
 
 fun reg (left, right) = Region.make {left = left, right = right}

--- a/mlton/front-end/ml.lex
+++ b/mlton/front-end/ml.lex
@@ -4,7 +4,7 @@
  *
  * Copyright 1989 by AT&T Bell Laboratories
  *
- * SML/NJ is released under a BSD-style license.
+ * SML/NJ is released under a HPND-style license.
  * See the file NJ-LICENSE for details.
  *)
 
@@ -13,7 +13,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/mlb-front-end.fun
+++ b/mlton/front-end/mlb-front-end.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/mlb-front-end.sig
+++ b/mlton/front-end/mlb-front-end.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/mlb.grm
+++ b/mlton/front-end/mlb.grm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/mlb.lex
+++ b/mlton/front-end/mlb.lex
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/sources.cm
+++ b/mlton/front-end/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/front-end/sources.mlb
+++ b/mlton/front-end/sources.mlb
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/compile.fun
+++ b/mlton/main/compile.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/compile.sig
+++ b/mlton/main/compile.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/lookup-constant.fun
+++ b/mlton/main/lookup-constant.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/lookup-constant.sig
+++ b/mlton/main/lookup-constant.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/main.sig
+++ b/mlton/main/main.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/main.sml
+++ b/mlton/main/main.sml
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/sources.cm
+++ b/mlton/main/sources.cm
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/main/sources.mlb
+++ b/mlton/main/sources.mlb
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/match-compile/match-compile.fun
+++ b/mlton/match-compile/match-compile.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/match-compile/match-compile.sig
+++ b/mlton/match-compile/match-compile.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/match-compile/nested-pat.fun
+++ b/mlton/match-compile/nested-pat.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/match-compile/nested-pat.sig
+++ b/mlton/match-compile/nested-pat.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/match-compile/sources.cm
+++ b/mlton/match-compile/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/match-compile/sources.mlb
+++ b/mlton/match-compile/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/mlton-smlnj.cm
+++ b/mlton/mlton-smlnj.cm
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/mlton.mlb
+++ b/mlton/mlton.mlb
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/sources.cm
+++ b/mlton/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/sources.mlb
+++ b/mlton/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/analyze.fun
+++ b/mlton/ssa/analyze.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/analyze.sig
+++ b/mlton/ssa/analyze.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/analyze2.fun
+++ b/mlton/ssa/analyze2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/analyze2.sig
+++ b/mlton/ssa/analyze2.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/combine-conversions.fun
+++ b/mlton/ssa/combine-conversions.fun
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Wesley W. Tersptra.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/common-arg.fun
+++ b/mlton/ssa/common-arg.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/common-block.fun
+++ b/mlton/ssa/common-block.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/common-subexp.fun
+++ b/mlton/ssa/common-subexp.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/constant-propagation.fun
+++ b/mlton/ssa/constant-propagation.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/contify.fun
+++ b/mlton/ssa/contify.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/deep-flatten.fun
+++ b/mlton/ssa/deep-flatten.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/direct-exp.fun
+++ b/mlton/ssa/direct-exp.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/direct-exp.sig
+++ b/mlton/ssa/direct-exp.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/direct-exp2.fun
+++ b/mlton/ssa/direct-exp2.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/direct-exp2.sig
+++ b/mlton/ssa/direct-exp2.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/equatable.sig
+++ b/mlton/ssa/equatable.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/equatable.sml
+++ b/mlton/ssa/equatable.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/flat-lattice.fun
+++ b/mlton/ssa/flat-lattice.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/flat-lattice.sig
+++ b/mlton/ssa/flat-lattice.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/flatten.fun
+++ b/mlton/ssa/flatten.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/global.fun
+++ b/mlton/ssa/global.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/global.sig
+++ b/mlton/ssa/global.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/inline.fun
+++ b/mlton/ssa/inline.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/inline.sig
+++ b/mlton/ssa/inline.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/introduce-loops.fun
+++ b/mlton/ssa/introduce-loops.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/known-case.fun
+++ b/mlton/ssa/known-case.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/local-flatten.fun
+++ b/mlton/ssa/local-flatten.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/local-ref.fun
+++ b/mlton/ssa/local-ref.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/loop-invariant.fun
+++ b/mlton/ssa/loop-invariant.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/loop-unroll.fun
+++ b/mlton/ssa/loop-unroll.fun
@@ -1,6 +1,6 @@
 (* Copyright (C) 2016 Matthew Surawski.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/loop-unswitch.fun
+++ b/mlton/ssa/loop-unswitch.fun
@@ -1,6 +1,6 @@
 (* Copyright (C) 2016 Matthew Surawski.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/multi.fun
+++ b/mlton/ssa/multi.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/multi.sig
+++ b/mlton/ssa/multi.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/n-point-lattice.fun
+++ b/mlton/ssa/n-point-lattice.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/n-point-lattice.sig
+++ b/mlton/ssa/n-point-lattice.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/poly-equal.fun
+++ b/mlton/ssa/poly-equal.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/poly-hash.fun
+++ b/mlton/ssa/poly-hash.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/prepasses.fun
+++ b/mlton/ssa/prepasses.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/prepasses.sig
+++ b/mlton/ssa/prepasses.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/prepasses2.fun
+++ b/mlton/ssa/prepasses2.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/prepasses2.sig
+++ b/mlton/ssa/prepasses2.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/profile.fun
+++ b/mlton/ssa/profile.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/profile.sig
+++ b/mlton/ssa/profile.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/profile2.fun
+++ b/mlton/ssa/profile2.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/profile2.sig
+++ b/mlton/ssa/profile2.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/redundant-tests.fun
+++ b/mlton/ssa/redundant-tests.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/redundant.fun
+++ b/mlton/ssa/redundant.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ref-flatten.fun
+++ b/mlton/ssa/ref-flatten.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/remove-unused.fun
+++ b/mlton/ssa/remove-unused.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/remove-unused2.fun
+++ b/mlton/ssa/remove-unused2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/restore.fun
+++ b/mlton/ssa/restore.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/restore.sig
+++ b/mlton/ssa/restore.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/restore2.fun
+++ b/mlton/ssa/restore2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/restore2.sig
+++ b/mlton/ssa/restore2.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/share-zero-vec.fun
+++ b/mlton/ssa/share-zero-vec.fun
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Matthew Fluet.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/shrink.sig
+++ b/mlton/ssa/shrink.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/shrink2.sig
+++ b/mlton/ssa/shrink2.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/simplify.fun
+++ b/mlton/ssa/simplify.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/simplify.sig
+++ b/mlton/ssa/simplify.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/simplify2.fun
+++ b/mlton/ssa/simplify2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/simplify2.sig
+++ b/mlton/ssa/simplify2.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/sources.cm
+++ b/mlton/ssa/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/sources.mlb
+++ b/mlton/ssa/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa-to-ssa2.fun
+++ b/mlton/ssa/ssa-to-ssa2.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa-to-ssa2.sig
+++ b/mlton/ssa/ssa-to-ssa2.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa-transform.sig
+++ b/mlton/ssa/ssa-transform.sig
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Wesley W. Tersptra.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa-tree.sig
+++ b/mlton/ssa/ssa-tree.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa-tree2.sig
+++ b/mlton/ssa/ssa-tree2.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa.fun
+++ b/mlton/ssa/ssa.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa.sig
+++ b/mlton/ssa/ssa.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa2-transform.sig
+++ b/mlton/ssa/ssa2-transform.sig
@@ -1,6 +1,6 @@
 (* Copyright (C) 2009 Wesley W. Tersptra.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa2.fun
+++ b/mlton/ssa/ssa2.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/ssa2.sig
+++ b/mlton/ssa/ssa2.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/three-point-lattice.fun
+++ b/mlton/ssa/three-point-lattice.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/three-point-lattice.sig
+++ b/mlton/ssa/three-point-lattice.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/two-point-lattice.fun
+++ b/mlton/ssa/two-point-lattice.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/two-point-lattice.sig
+++ b/mlton/ssa/two-point-lattice.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/type-check.fun
+++ b/mlton/ssa/type-check.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/type-check.sig
+++ b/mlton/ssa/type-check.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/type-check2.fun
+++ b/mlton/ssa/type-check2.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/type-check2.sig
+++ b/mlton/ssa/type-check2.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/useless.fun
+++ b/mlton/ssa/useless.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/ssa/zone.fun
+++ b/mlton/ssa/zone.fun
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/call-count.fun
+++ b/mlton/xml/call-count.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/call-count.sig
+++ b/mlton/xml/call-count.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/cps-transform.fun
+++ b/mlton/xml/cps-transform.fun
@@ -1,7 +1,7 @@
 (* Copyright (C) 2007-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/implement-exceptions.fun
+++ b/mlton/xml/implement-exceptions.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/implement-suffix.fun
+++ b/mlton/xml/implement-suffix.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/monomorphise.fun
+++ b/mlton/xml/monomorphise.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/monomorphise.sig
+++ b/mlton/xml/monomorphise.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/parse-sxml.fun
+++ b/mlton/xml/parse-sxml.fun
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Jason Carr.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/parse-sxml.sig
+++ b/mlton/xml/parse-sxml.sig
@@ -1,6 +1,6 @@
 (* Copyright (C) 2017 Jason Carr.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/polyvariance.fun
+++ b/mlton/xml/polyvariance.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/scc-funs.fun
+++ b/mlton/xml/scc-funs.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/scc-funs.sig
+++ b/mlton/xml/scc-funs.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/shrink.fun
+++ b/mlton/xml/shrink.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/shrink.sig
+++ b/mlton/xml/shrink.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/simplify-types.fun
+++ b/mlton/xml/simplify-types.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/simplify-types.sig
+++ b/mlton/xml/simplify-types.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sources.cm
+++ b/mlton/xml/sources.cm
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sources.mlb
+++ b/mlton/xml/sources.mlb
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sxml-exns.sig
+++ b/mlton/xml/sxml-exns.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sxml-simplify.fun
+++ b/mlton/xml/sxml-simplify.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sxml-simplify.sig
+++ b/mlton/xml/sxml-simplify.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sxml-tree.sig
+++ b/mlton/xml/sxml-tree.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sxml.fun
+++ b/mlton/xml/sxml.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/sxml.sig
+++ b/mlton/xml/sxml.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/type-check.fun
+++ b/mlton/xml/type-check.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/type-check.sig
+++ b/mlton/xml/type-check.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/uncurry.fun
+++ b/mlton/xml/uncurry.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml-simplify.fun
+++ b/mlton/xml/xml-simplify.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml-simplify.sig
+++ b/mlton/xml/xml-simplify.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml-transform.sig
+++ b/mlton/xml/xml-transform.sig
@@ -1,7 +1,7 @@
 (* Copyright (C) 2007-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml-tree.fun
+++ b/mlton/xml/xml-tree.fun
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml-tree.sig
+++ b/mlton/xml/xml-tree.sig
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml-type.sig
+++ b/mlton/xml/xml-type.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml.fun
+++ b/mlton/xml/xml.fun
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlton/xml/xml.sig
+++ b/mlton/xml/xml.sig
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlyacc/Makefile
+++ b/mlyacc/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mlyacc/call-main.sml
+++ b/mlyacc/call-main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlyacc/doc/Makefile
+++ b/mlyacc/doc/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/mlyacc/main.sml
+++ b/mlyacc/main.sml
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/mlyacc/mlyacc.mlb
+++ b/mlyacc/mlyacc.mlb
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/package/debian/copyright
+++ b/package/debian/copyright
@@ -10,22 +10,22 @@ Upstream Authors:
    MLton@mlton.org.
 
 MLton's copyright is held in part by the NEC Research Institute.  It
-is released under a BSD-style license.
+is released under a HPND-style license.
 
    MLton COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
-   
-   Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
+
+   Copyright (C) 1999-2018 Henry Cejtin, Matthew Fluet, Suresh
       Jagannathan, and Stephen Weeks.
-   Copyright (c) 1997-2000 by the NEC Research Institute
-   
+   Copyright (C) 1997-2000 by the NEC Research Institute
+
    Permission to use, copy, modify, and distribute this software and its
    documentation for any purpose and without fee is hereby granted,
    provided that the above copyright notice appear in all copies and that
    both the copyright notice and this permission notice and warranty
    disclaimer appear in supporting documentation, and that the name of
-   NEC, or any NEC entity not be used in advertising or publicity
-   pertaining to distribution of the software without specific, written
-   prior permission.
+   the above copyright holders, or their entities, not be used in
+   advertising or publicity pertaining to distribution of the software
+   without specific, written prior permission.
 
    The above copyright holders disclaim all warranties with regard to
    this software, including all implied warranties of merchantability and
@@ -44,15 +44,17 @@ of New Jersey compiler:
 Parts of MLton's Basis Library are derived from the following portions
 of the Basis Library code of the SMLNJ compiler:
 
-  OS.IO, Posix.IO, Process, and Unix
+  OS.IO, Posix.IO, Process, Unix
 
 The following utilities and libraries are derived from the SMLNJ system:
 
   mllex, mlyacc and MLYacc Library, Concurrent ML Library, SML/NJ
-  Library, CKit Library, mlnlffigen and MLNLFFI Library
+  Library, CKit Library, mlnlffigen and MLNLFFI Library, MLRISC
+  Library, ML-LPT Library
+
 
 SMLNJ's copyright is held by Lucent Technologies.  It was released
-under a BSD-style license.
+under a HPND-style license.
 
    STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
 
@@ -78,9 +80,9 @@ under a BSD-style license.
 Parts of MLton's Basis Library are derived from the following portions
 of the Basis Library code of the ML Kit compiler:
 
-   Path, Time, and Date
+   Path, Time, Date
 
-The ML Kit Basis Bibrary is distributed under the MIT License.
+The ML Kit Basis Library is distributed under the MIT License.
 
    Copyright (c) 2004 IT University of Copenhagen
    
@@ -102,5 +104,3 @@ The ML Kit Basis Bibrary is distributed under the MIT License.
    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-   

--- a/package/mingw/License.rtf
+++ b/package/mingw/License.rtf
@@ -20,10 +20,10 @@
 you cannot hold anyone liable for damages}{\rtlch\fcs1 \af2\afs20 \ltrch\fcs0 \f2\fs20\lang4105\langfe1031\langnp4105\insrsid14632213  it causes. 
 \par 
 \par MLton links its output against these libraries:
-\par MLton\tab \tab - BSD-style
+\par MLton\tab \tab - HPND-style
 \par MinGW\tab \tab - public domain
 \par Win32API\tab - public domain
-\par gdtoa\tab \tab - BSD-style
+\par gdtoa\tab \tab - HPND-style
 \par GMP\tab \tab - LGPL
 \par 
 \par MLton uses these tools during compilation (their licenses do not apply to resulting applications):

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -2,7 +2,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/regression/library/Makefile
+++ b/regression/library/Makefile
@@ -1,7 +1,7 @@
 ## Copyright (C) 2008 Henry Cejtin, Matthew Fluet, Suresh
  #    Jagannathan, and Stephen Weeks.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -3,7 +3,7 @@
  #    Jagannathan, and Stephen Weeks.
  # Copyright (C) 1997-2000 NEC Research Institute.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 

--- a/runtime/cenv.h
+++ b/runtime/cenv.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/export.h
+++ b/runtime/export.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc.c
+++ b/runtime/gc.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc.h
+++ b/runtime/gc.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/align.c
+++ b/runtime/gc/align.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/align.h
+++ b/runtime/gc/align.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/array-allocate.c
+++ b/runtime/gc/array-allocate.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/array-allocate.h
+++ b/runtime/gc/array-allocate.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/array.c
+++ b/runtime/gc/array.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/array.h
+++ b/runtime/gc/array.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/atomic.c
+++ b/runtime/gc/atomic.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/atomic.h
+++ b/runtime/gc/atomic.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/call-stack.c
+++ b/runtime/gc/call-stack.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/call-stack.h
+++ b/runtime/gc/call-stack.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/cheney-copy.c
+++ b/runtime/gc/cheney-copy.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/cheney-copy.h
+++ b/runtime/gc/cheney-copy.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/controls.c
+++ b/runtime/gc/controls.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/controls.h
+++ b/runtime/gc/controls.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/copy-thread.c
+++ b/runtime/gc/copy-thread.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/copy-thread.h
+++ b/runtime/gc/copy-thread.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/current.c
+++ b/runtime/gc/current.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/current.h
+++ b/runtime/gc/current.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/debug.h
+++ b/runtime/gc/debug.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/dfs-mark.c
+++ b/runtime/gc/dfs-mark.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/dfs-mark.h
+++ b/runtime/gc/dfs-mark.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/done.c
+++ b/runtime/gc/done.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/done.h
+++ b/runtime/gc/done.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/enter_leave.c
+++ b/runtime/gc/enter_leave.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/enter_leave.h
+++ b/runtime/gc/enter_leave.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/foreach.c
+++ b/runtime/gc/foreach.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/foreach.h
+++ b/runtime/gc/foreach.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/forward.c
+++ b/runtime/gc/forward.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/forward.h
+++ b/runtime/gc/forward.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/frame.c
+++ b/runtime/gc/frame.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/frame.h
+++ b/runtime/gc/frame.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/garbage-collection.c
+++ b/runtime/gc/garbage-collection.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/garbage-collection.h
+++ b/runtime/gc/garbage-collection.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/generational.c
+++ b/runtime/gc/generational.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/generational.h
+++ b/runtime/gc/generational.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/handler.c
+++ b/runtime/gc/handler.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/handler.h
+++ b/runtime/gc/handler.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/hash-cons.c
+++ b/runtime/gc/hash-cons.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/hash-cons.h
+++ b/runtime/gc/hash-cons.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/heap.c
+++ b/runtime/gc/heap.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2005-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/heap.h
+++ b/runtime/gc/heap.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/heap_predicates.c
+++ b/runtime/gc/heap_predicates.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/init-world.h
+++ b/runtime/gc/init-world.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/init.h
+++ b/runtime/gc/init.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/int-inf.c
+++ b/runtime/gc/int-inf.c
@@ -3,7 +3,7 @@
  *    Suresh Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/int-inf.h
+++ b/runtime/gc/int-inf.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/invariant.c
+++ b/runtime/gc/invariant.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/invariant.h
+++ b/runtime/gc/invariant.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/major.h
+++ b/runtime/gc/major.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/mark-compact.c
+++ b/runtime/gc/mark-compact.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/mark-compact.h
+++ b/runtime/gc/mark-compact.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/model.c
+++ b/runtime/gc/model.c
@@ -1,6 +1,6 @@
 /* Copyright (C) 2005-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */

--- a/runtime/gc/model.h
+++ b/runtime/gc/model.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/new-object.c
+++ b/runtime/gc/new-object.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/new-object.h
+++ b/runtime/gc/new-object.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/object-size.c
+++ b/runtime/gc/object-size.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/object-size.h
+++ b/runtime/gc/object-size.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/object.c
+++ b/runtime/gc/object.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/object.h
+++ b/runtime/gc/object.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/objptr.c
+++ b/runtime/gc/objptr.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/objptr.h
+++ b/runtime/gc/objptr.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2005-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/pack.c
+++ b/runtime/gc/pack.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/pack.h
+++ b/runtime/gc/pack.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/pointer.c
+++ b/runtime/gc/pointer.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/pointer.h
+++ b/runtime/gc/pointer.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/profiling.c
+++ b/runtime/gc/profiling.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/profiling.h
+++ b/runtime/gc/profiling.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/read_write.c
+++ b/runtime/gc/read_write.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/rusage.c
+++ b/runtime/gc/rusage.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/rusage.h
+++ b/runtime/gc/rusage.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/share.c
+++ b/runtime/gc/share.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/share.h
+++ b/runtime/gc/share.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/signals.c
+++ b/runtime/gc/signals.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/signals.h
+++ b/runtime/gc/signals.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/size.c
+++ b/runtime/gc/size.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/size.h
+++ b/runtime/gc/size.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/sources.c
+++ b/runtime/gc/sources.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/sources.h
+++ b/runtime/gc/sources.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/stack.c
+++ b/runtime/gc/stack.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/stack.h
+++ b/runtime/gc/stack.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/statistics.c
+++ b/runtime/gc/statistics.c
@@ -2,6 +2,6 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */

--- a/runtime/gc/statistics.h
+++ b/runtime/gc/statistics.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/string.c
+++ b/runtime/gc/string.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/string.h
+++ b/runtime/gc/string.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/switch-thread.c
+++ b/runtime/gc/switch-thread.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/switch-thread.h
+++ b/runtime/gc/switch-thread.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/sysvals.h
+++ b/runtime/gc/sysvals.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/thread.c
+++ b/runtime/gc/thread.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/thread.h
+++ b/runtime/gc/thread.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/translate.c
+++ b/runtime/gc/translate.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/translate.h
+++ b/runtime/gc/translate.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/virtual-memory.c
+++ b/runtime/gc/virtual-memory.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/weak.c
+++ b/runtime/gc/weak.c
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/weak.h
+++ b/runtime/gc/weak.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/world.c
+++ b/runtime/gc/world.c
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gc/world.h
+++ b/runtime/gc/world.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gen/gen-basis-ffi.sml
+++ b/runtime/gen/gen-basis-ffi.sml
@@ -1,7 +1,7 @@
 (* Copyright (C) 2004-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
 

--- a/runtime/gen/gen-sizes.c
+++ b/runtime/gen/gen-sizes.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/gen/gen-types.c
+++ b/runtime/gen/gen-types.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 
@@ -13,7 +13,7 @@ static const char* mlTypesHPrefix[] = {
   "/* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh",
   " *    Jagannathan, and Stephen Weeks.",
   " *",
-  " * MLton is released under a BSD-style license.",
+  " * MLton is released under a HPND-style license.",
   " * See the file MLton-LICENSE for details.",
   " */",
   "",
@@ -38,7 +38,7 @@ static const char* cTypesHPrefix[] = {
   "/* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh",
   " *    Jagannathan, and Stephen Weeks.",
   " *",
-  " * MLton is released under a BSD-style license.",
+  " * MLton is released under a HPND-style license.",
   " * See the file MLton-LICENSE for details.",
   " */",
   "",
@@ -52,7 +52,7 @@ static const char* cTypesSMLPrefix[] = {
   "(* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh",
   " *    Jagannathan, and Stephen Weeks.",
   " *",
-  " * MLton is released under a BSD-style license.",
+  " * MLton is released under a HPND-style license.",
   " * See the file MLton-LICENSE for details.",
   " *)",
   "",

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2004-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/platform.h
+++ b/runtime/platform.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util.c
+++ b/runtime/util.c
@@ -2,7 +2,7 @@
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/align.h
+++ b/runtime/util/align.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/die.c
+++ b/runtime/util/die.c
@@ -1,7 +1,7 @@
 /* Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/die.h
+++ b/runtime/util/die.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/endian.h
+++ b/runtime/util/endian.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/pointer.h
+++ b/runtime/util/pointer.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/read_write.h
+++ b/runtime/util/read_write.h
@@ -3,7 +3,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/safe.h
+++ b/runtime/util/safe.h
@@ -2,7 +2,7 @@
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/to-string.c
+++ b/runtime/util/to-string.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/runtime/util/to-string.h
+++ b/runtime/util/to-string.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2004-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
- * MLton is released under a BSD-style license.
+ * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  */
 

--- a/util/cm2mlb/Makefile
+++ b/util/cm2mlb/Makefile
@@ -1,6 +1,6 @@
 ## Copyright (C) 2010 Matthew Fluet.
  #
- # MLton is released under a BSD-style license.
+ # MLton is released under a HPND-style license.
  # See the file MLton-LICENSE for details.
  ##
 


### PR DESCRIPTION
Characterize MLton-LICENSE (and NJ-LICENSE and gdtoa-LICENSE) as an instance of the Historical Permission Notice and Disclaimer (HPND) license, rather than BSD-style.  In MLTON-LICENSE and `doc/license/README`, note that the the Historical Permission Notice and Disclaimer license is an open source (https://opensource.org/licenses/HPND) and free software (https://www.gnu.org/licenses/license-list.en.html#HPND) license.

Closes MLton/mlton#257.