### PR TITLE
Implementation for Vector.toListKeepAllMap

### DIFF
--- a/lib/mlton/basic/vector.fun
+++ b/lib/mlton/basic/vector.fun
@@ -280,11 +280,13 @@ fun toList a = foldr (a, [], op ::)
 
 fun toListMap (a, f) = foldr (a, [], fn (a, ac) => f a :: ac)
 
-fun toListKeepAllMap (v, f) =
-   foldr (v, [], fn (a, bs) =>
-          case f a of
-             NONE => bs
-           | SOME b => b :: bs)
+fun toListKeepAllMapi (v, f) =
+   foldri (v, [], fn (i, a, bs) =>
+           case f (i, a) of
+              NONE => bs
+            | SOME b => b :: bs)
+
+fun toListKeepAllMap (v, f) = toListKeepAllMapi (v, f o #2)
 
 fun layout l v = Layout.tuple (toListMap (v, l))
 

--- a/lib/mlton/basic/vector.fun
+++ b/lib/mlton/basic/vector.fun
@@ -281,14 +281,10 @@ fun toList a = foldr (a, [], op ::)
 fun toListMap (a, f) = foldr (a, [], fn (a, ac) => f a :: ac)
 
 fun toListKeepAllMap (v, f) =
-   let
-      val a = map(v, f)
-   in
-      foldr (a, [], fn (a, ac) =>
-             case a of
-                NONE => ac
-              | SOME b => b :: ac)
-   end
+   foldr (v, [], fn (a, bs) =>
+          case f a of
+             NONE => bs
+           | SOME b => b :: bs)
 
 fun layout l v = Layout.tuple (toListMap (v, l))
 

--- a/lib/mlton/basic/vector.fun
+++ b/lib/mlton/basic/vector.fun
@@ -623,4 +623,14 @@ fun removeDuplicates (v, equals) =
 
 fun randomElement v = sub (v, Random.natLessThan (length v))
 
+fun toListKeepAllMap (v, f) = 
+   let 
+      val a = map(v, f)
+   in
+      foldr (a, [], fn (a, ac) => 
+         case a of
+            NONE => ac
+          | SOME b => b :: ac)
+   end
+
 end

--- a/lib/mlton/basic/vector.fun
+++ b/lib/mlton/basic/vector.fun
@@ -280,6 +280,16 @@ fun toList a = foldr (a, [], op ::)
 
 fun toListMap (a, f) = foldr (a, [], fn (a, ac) => f a :: ac)
 
+fun toListKeepAllMap (v, f) =
+   let
+      val a = map(v, f)
+   in
+      foldr (a, [], fn (a, ac) =>
+             case a of
+                NONE => ac
+              | SOME b => b :: ac)
+   end
+
 fun layout l v = Layout.tuple (toListMap (v, l))
 
 fun toString xToString l =
@@ -622,15 +632,5 @@ fun removeDuplicates (v, equals) =
                 else SOME x)
 
 fun randomElement v = sub (v, Random.natLessThan (length v))
-
-fun toListKeepAllMap (v, f) = 
-   let 
-      val a = map(v, f)
-   in
-      foldr (a, [], fn (a, ac) => 
-         case a of
-            NONE => ac
-          | SOME b => b :: ac)
-   end
 
 end

--- a/lib/mlton/basic/vector.sig
+++ b/lib/mlton/basic/vector.sig
@@ -120,6 +120,7 @@ signature VECTOR =
       val toArray: 'a t -> 'a array
       val toList: 'a t -> 'a list
       val toListMap: 'a t * ('a -> 'b) -> 'b list
+      val toListKeepAllMap: 'a t * ('a -> 'b option) -> 'b list
       val toListRev: 'a t -> 'a list
       val toString: ('a -> string) -> 'a t -> string
       val unzip: ('a * 'b) t -> 'a t * 'b t

--- a/lib/mlton/basic/vector.sig
+++ b/lib/mlton/basic/vector.sig
@@ -120,6 +120,7 @@ signature VECTOR =
       val toArray: 'a t -> 'a array
       val toList: 'a t -> 'a list
       val toListKeepAllMap: 'a t * ('a -> 'b option) -> 'b list
+      val toListKeepAllMapi: 'a t * (int * 'a -> 'b option) -> 'b list
       val toListMap: 'a t * ('a -> 'b) -> 'b list
       val toListRev: 'a t -> 'a list
       val toString: ('a -> string) -> 'a t -> string

--- a/lib/mlton/basic/vector.sig
+++ b/lib/mlton/basic/vector.sig
@@ -119,8 +119,8 @@ signature VECTOR =
       val tabulator: int * (('a -> unit) -> unit) -> 'a t
       val toArray: 'a t -> 'a array
       val toList: 'a t -> 'a list
-      val toListMap: 'a t * ('a -> 'b) -> 'b list
       val toListKeepAllMap: 'a t * ('a -> 'b option) -> 'b list
+      val toListMap: 'a t * ('a -> 'b) -> 'b list
       val toListRev: 'a t -> 'a list
       val toString: ('a -> string) -> 'a t -> string
       val unzip: ('a * 'b) t -> 'a t * 'b t

--- a/mlton/atoms/int-size.fun
+++ b/mlton/atoms/int-size.fun
@@ -23,12 +23,11 @@ fun isValidSize (i: int) =
    (1 <= i andalso i <= 32) orelse i = 64
 
 val sizes: Bits.t list =
-   Vector.toList
-   (Vector.keepAllMap
-    (Vector.tabulate (65, fn i => if isValidSize i
+   Vector.toListKeepAllMap (Vector.tabulate (65, fn i => 
+                                  if isValidSize i
                                      then SOME (Bits.fromInt i)
                                   else NONE),
-     fn i => i))
+     fn i => i)
 
 fun make i = T {bits = i}
 

--- a/mlton/atoms/int-size.fun
+++ b/mlton/atoms/int-size.fun
@@ -23,11 +23,12 @@ fun isValidSize (i: int) =
    (1 <= i andalso i <= 32) orelse i = 64
 
 val sizes: Bits.t list =
-   Vector.toListKeepAllMap (Vector.tabulate (65, fn i => 
-                                  if isValidSize i
-                                     then SOME (Bits.fromInt i)
-                                  else NONE),
-     fn i => i)
+   Vector.toListKeepAllMap
+   (Vector.tabulate (65, fn i =>
+                     if isValidSize i
+                        then SOME (Bits.fromInt i)
+                        else NONE),
+    fn i => i)
 
 fun make i = T {bits = i}
 

--- a/mlton/atoms/word-size.fun
+++ b/mlton/atoms/word-size.fun
@@ -52,7 +52,7 @@ val allVector = Vector.tabulate (65, fn i =>
                                      then SOME (fromBits (Bits.fromInt i))
                                   else NONE)
 
-val all: t list = Vector.toList (Vector.keepAllMap (allVector, fn so => so))
+val all: t list = Vector.toListKeepAllMap (allVector, fn so => so)
 
 val prims = List.map ([8, 16, 32, 64], fromBits o Bits.fromInt)
 

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -1078,7 +1078,7 @@ structure Program =
                                | Const c => SOME (ApplyArg.Const c)
                                | Var x => SOME (ApplyArg.Var x)
                                | _ => NONE
-                           val applyArgs = Vector.toListKeepAllMap (args, getArg) 
+                           val applyArgs = Vector.toListKeepAllMap (args, getArg)
                            datatype z = datatype ApplyResult.t
                         in
                            if Vector.length args <> List.length applyArgs

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -1078,15 +1078,15 @@ structure Program =
                                | Const c => SOME (ApplyArg.Const c)
                                | Var x => SOME (ApplyArg.Var x)
                                | _ => NONE
-                           val applyArgs = Vector.keepAllMap (args, getArg)
+                           val applyArgs = Vector.toListKeepAllMap (args, getArg) 
                            datatype z = datatype ApplyResult.t
                         in
-                           if Vector.length args <> Vector.length applyArgs
+                           if Vector.length args <> List.length applyArgs
                               then keep ()
                            else
                               case (tracePrimApply
                                     Prim.apply
-                                    (prim, Vector.toList applyArgs,
+                                    (prim, applyArgs,
                                      fn ({var = x, ...}, {var = y, ...}) =>
                                      Var.equals (x, y))) of
                                  Apply (prim, args) =>

--- a/mlton/backend/ssa-to-rssa.fun
+++ b/mlton/backend/ssa-to-rssa.fun
@@ -1311,7 +1311,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                              NONE => Error.bug "SsaToRssa.translateStatementsTransfer: PrimApp,Array_uninit"
                                            | SOME eltTys => eltTys
                                        val sss =
-                                          (Vector.toList o Vector.keepAllMapi)
+                                          Vector.toListKeepAllMapi
                                           (S.Prod.dest eltTys, fn (offset, {elt, ...}) =>
                                            case toRtype elt of
                                               NONE => NONE

--- a/mlton/elaborate/elaborate-env.fun
+++ b/mlton/elaborate/elaborate-env.fun
@@ -456,24 +456,25 @@ structure TypeStr =
                   let
                      val extra = ref false
                      val cons =
-                        Vector.toListKeepAllMap (Cons.dest cons, fn {name, scheme, ...} =>
-                           let
-                              val (tyvars, ty) = Scheme.dest scheme
-                           in
-                              case Type.deArrowOpt ty of
-                                 NONE => (extra := true; NONE)
-                               | SOME (arg, _) =>
-                                    let
-                                       val argScheme =
-                                          Scheme.make {canGeneralize = true,
-                                                       ty = arg,
-                                                       tyvars = tyvars}
-                                    in
-                                       case Scheme.checkEquality (argScheme, {layoutPrettyTycon = layoutPrettyTycon}) of
-                                          NONE => (extra := true; NONE)
-                                        | SOME l => SOME (seq [Ast.Con.layout name, str " of ", l])
-                                    end
-                           end)
+                        Vector.toListKeepAllMap
+                        (Cons.dest cons, fn {name, scheme, ...} =>
+                         let
+                            val (tyvars, ty) = Scheme.dest scheme
+                         in
+                            case Type.deArrowOpt ty of
+                               NONE => (extra := true; NONE)
+                             | SOME (arg, _) =>
+                                  let
+                                     val argScheme =
+                                        Scheme.make {canGeneralize = true,
+                                                     ty = arg,
+                                                     tyvars = tyvars}
+                                  in
+                                     case Scheme.checkEquality (argScheme, {layoutPrettyTycon = layoutPrettyTycon}) of
+                                        NONE => (extra := true; NONE)
+                                      | SOME l => SOME (seq [Ast.Con.layout name, str " of ", l])
+                                  end
+                         end)
 
                      val cons =
                         if !extra

--- a/mlton/elaborate/elaborate-env.fun
+++ b/mlton/elaborate/elaborate-env.fun
@@ -456,26 +456,25 @@ structure TypeStr =
                   let
                      val extra = ref false
                      val cons =
-                        Vector.toList
-                        (Vector.keepAllMap
-                         (Cons.dest cons, fn {name, scheme, ...} =>
-                          let
-                             val (tyvars, ty) = Scheme.dest scheme
-                          in
-                             case Type.deArrowOpt ty of
-                                NONE => (extra := true; NONE)
-                              | SOME (arg, _) =>
-                                   let
-                                      val argScheme =
-                                         Scheme.make {canGeneralize = true,
-                                                      ty = arg,
-                                                      tyvars = tyvars}
-                                   in
-                                      case Scheme.checkEquality (argScheme, {layoutPrettyTycon = layoutPrettyTycon}) of
-                                         NONE => (extra := true; NONE)
-                                       | SOME l => SOME (seq [Ast.Con.layout name, str " of ", l])
-                                   end
-                          end))
+                        Vector.toListKeepAllMap (Cons.dest cons, fn {name, scheme, ...} =>
+                           let
+                              val (tyvars, ty) = Scheme.dest scheme
+                           in
+                              case Type.deArrowOpt ty of
+                                 NONE => (extra := true; NONE)
+                               | SOME (arg, _) =>
+                                    let
+                                       val argScheme =
+                                          Scheme.make {canGeneralize = true,
+                                                       ty = arg,
+                                                       tyvars = tyvars}
+                                    in
+                                       case Scheme.checkEquality (argScheme, {layoutPrettyTycon = layoutPrettyTycon}) of
+                                          NONE => (extra := true; NONE)
+                                        | SOME l => SOME (seq [Ast.Con.layout name, str " of ", l])
+                                    end
+                           end)
+
                      val cons =
                         if !extra
                            then List.snoc (cons, str "...")


### PR DESCRIPTION
Introduced Vector.toListKeepAllMap for an efficiency improvement over Vector.toList(Vector.keepAllMap(...)). Replaced usages with the new function.