### PR TITLE
Fix `find` expression in `./lib/mlrisc-lib/Makefile`

### DIFF
--- a/lib/mlrisc-lib/Makefile
+++ b/lib/mlrisc-lib/Makefile
@@ -20,7 +20,7 @@ all: MLRISC/README.mlton
 MLRISC/README.mlton: MLRISC.tgz MLRISC.patch
 	rm -rf MLRISC
 	$(GZIP) -dc MLRISC.tgz | $(TAR) xf -
-	$(FIND) MLRISC -name '._*' -depth -exec rm -f '{}' ';'
+	$(FIND) MLRISC -name '._*' -prune -exec rm -f '{}' ';'
 	chmod -R a+r MLRISC
 	chmod -R g-s MLRISC
 	$(PATCH) -s -d MLRISC -p1 < MLRISC.patch


### PR DESCRIPTION
Commit 4caacdb (Add `-prune` to `find` commands that may delete directories) mistakenly used `-depth` rather than `-prune` for `./lib/mlrisc-lib/Makefile`.