### PR TITLE
Add HashTable and Hash structures and use in code

### DIFF
--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -14,7 +14,8 @@ signature HASH_TABLE =
       val layout: ('a * 'b -> Layout.t) -> ('a, 'b) t -> Layout.t
       val lookupOrInsert: ('a, 'b) t * 'a * (unit -> 'b) -> 'b
       val new: {equals: 'a * 'a -> bool,
-                hash: 'a -> word} -> ('a, 'b) t
+                hash: 'a -> word,
+                cache: bool} -> ('a, 'b) t
       val peek: ('a, 'b) t * 'a -> 'b option
 
       val remove: ('a, 'b) t * 'a -> unit

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -19,6 +19,7 @@ signature HASH_TABLE =
       val peek: ('a, 'b) t * 'a -> 'b option
 
       val remove: ('a, 'b) t * 'a -> unit
+      val removeWhen: ('a, 'b) t * 'a * ('b -> bool) -> unit
       val removeAll : ('a, 'b) t * ('a * 'b -> bool) -> unit
 
       val size: ('a, 'b) t -> int

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -21,7 +21,7 @@ signature HASH_TABLE =
       val removeAll : ('a, 'b) t * ('a * 'b -> bool) -> unit
 
       val size: ('a, 'b) t -> int
-      val stats: unit -> Layout.t
+      val stats': ('a, 'b) t -> Layout.t
 
       val toList: ('a, 'b) t -> ('a * 'b) list
    end

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Jason Carr
+(* Copyright (C) 2018 Jason Carr
  * Copyright (C) 2009 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -26,11 +26,3 @@ signature HASH_TABLE =
 
       val toList: ('a, 'b) t -> ('a * 'b) list
    end
-
-functor TestHashTable (S: HASH_TABLE): sig end =
-struct
-
-open S
-
-val _ = Assert.assert("TestHashTable", fn () => true)
-end

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -14,8 +14,7 @@ signature HASH_TABLE =
       val layout: ('a * 'b -> Layout.t) -> ('a, 'b) t -> Layout.t
       val lookupOrInsert: ('a, 'b) t * 'a * (unit -> 'b) -> 'b
       val new: {equals: 'a * 'a -> bool,
-                hash: 'a -> word,
-                cache: bool} -> ('a, 'b) t
+                hash: 'a -> word} -> ('a, 'b) t
       val peek: ('a, 'b) t * 'a -> 'b option
 
       val remove: ('a, 'b) t * 'a -> unit

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -16,13 +16,10 @@ signature HASH_TABLE =
       val new: {equals: 'a * 'a -> bool,
                 hash: 'a -> word} -> ('a, 'b) t
       val peek: ('a, 'b) t * 'a -> 'b option
-
       val remove: ('a, 'b) t * 'a -> unit
       val removeAll : ('a, 'b) t * ('a * 'b -> bool) -> unit
       val removeWhen: ('a, 'b) t * 'a * ('b -> bool) -> unit
-
       val size: ('a, 'b) t -> int
       val stats': ('a, 'b) t -> Layout.t
-
       val toList: ('a, 'b) t -> ('a * 'b) list
    end

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -1,38 +1,23 @@
-(* Copyright (C) 2009 Matthew Fluet.
+(* Copyright (C) 2017 Jason Carr
+ * Copyright (C) 2009 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
-
-(* This code is not working -- it is not even in sources.cm *)
 signature HASH_TABLE =
    sig
       type ('a, 'b) t
 
-      val fold: ('a, 'b) t * 'c * ('b * 'c -> 'c) -> 'c
-      val foldi: ('a, 'b) t * 'c * ('a * 'b * 'c -> 'c) -> 'c
-      val forall: ('a, 'b) t * ('b -> bool) -> bool
-      val foralli: ('a, 'b) t * ('a * 'b -> bool) -> bool
-      val foreach: ('a, 'b) t * ('b -> unit) -> unit
-      val foreachi: ('a, 'b) t * ('a * 'b -> unit) -> unit
-      (* If it's already in the table, call the thunk, else insert it and
-       * return it.
-       *)
-      val insertIfNew: ('a, 'b) t * 'a * 'b * (unit -> 'b) -> 'b
-      val listItems: ('a, 'b) t -> 'b list
-      val listItemsi: ('a, 'b) t -> ('a * 'b) list
+      val insertIfNew: ('a, 'b) t * 'a * (unit -> 'b) * ('b -> unit) -> 'b
       val layout: ('a * 'b -> Layout.t) -> ('a, 'b) t -> Layout.t
       val lookupOrInsert: ('a, 'b) t * 'a * (unit -> 'b) -> 'b
-      val map: ('a, 'b) t * ('b -> 'c) -> ('a, 'c) t
-      val mapi: ('a, 'b) t * ('a * 'b -> 'c) -> ('a, 'c) t
       val new: {equals: 'a * 'a -> bool,
                 hash: 'a -> word} -> ('a, 'b) t
       val peek: ('a, 'b) t * 'a -> 'b option
       val size: ('a, 'b) t -> int
       val stats: unit -> Layout.t
-      val update: ('a, 'b) t * 'a * 'b -> unit
    end
 
 functor TestHashTable (S: HASH_TABLE): sig end =
@@ -40,31 +25,5 @@ struct
 
 open S
 
-val _ =
-   Assert.assert
-   ("TestHashTable", fn () => 
-    let val t = new Int.equals
-       val n = 10
-       val hash = Word.fromInt
-       val _ =
-          Int.for(0, n, fn i =>
-                  (lookupOrInsert(t, hash i, i, fn () => i * 2)
-                   ; ()))
-       val sum = Int.fold(0, n, 0, op +)
-    in
-       let val r = ref 0
-       in foreach (t, fn j => r := !r + j)
-          ; 2 * sum = !r
-       end
-    andalso Int.forall(0, n, fn i => Option.isSome(peek(t, hash i, i)))
-    andalso foralli(t, fn (i, j) => j = 2 * i)
-    andalso n = List.length(listItems t)
-    andalso n = List.length(listItemsi t)
-    andalso let val t' = map(t, fn j => j div 2)
-            in n = size t'
-               andalso foralli(t', fn (i, j) => i = j)
-            end
-         andalso n = size t
-    end)
-
+val _ = Assert.assert("TestHashTable", fn () => true)
 end

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -16,8 +16,14 @@ signature HASH_TABLE =
       val new: {equals: 'a * 'a -> bool,
                 hash: 'a -> word} -> ('a, 'b) t
       val peek: ('a, 'b) t * 'a -> 'b option
+
+      val remove: ('a, 'b) t * 'a -> unit
+      val removeAll : ('a, 'b) t * ('a * 'b -> bool) -> unit
+
       val size: ('a, 'b) t -> int
       val stats: unit -> Layout.t
+
+      val toList: ('a, 'b) t -> ('a * 'b) list
    end
 
 functor TestHashTable (S: HASH_TABLE): sig end =

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -18,8 +18,8 @@ signature HASH_TABLE =
       val peek: ('a, 'b) t * 'a -> 'b option
 
       val remove: ('a, 'b) t * 'a -> unit
-      val removeWhen: ('a, 'b) t * 'a * ('b -> bool) -> unit
       val removeAll : ('a, 'b) t * ('a * 'b -> bool) -> unit
+      val removeWhen: ('a, 'b) t * 'a * ('b -> bool) -> unit
 
       val size: ('a, 'b) t -> int
       val stats': ('a, 'b) t -> Layout.t

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -28,6 +28,8 @@ in
    val stats = stats o projectSet
    val toList = toList o projectSet
    val layout = layout o projectSet
+   val removeAll = removeAll o projectSet
+   val toList = toList o projectSet
 end
 
 fun keyEquals (equals, a) (a', _) = equals
@@ -43,5 +45,7 @@ fun insertIfNew (T {set, hash, equals}, a, genB, whenFound) =
       (set, hash a, keyEquals (equals, a),
        fn () => (a, genB ()),
        fn (_, b) => whenFound b)
+
+fun remove (T {set, hash, equals}, a) = Set.remove (set, hash a, keyEquals (equals, a))
 
 end

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -11,11 +11,13 @@ struct
 structure Set = HashSet
 
 datatype ('a, 'b) t = T of {set: {hash: word, key: 'a, value: 'b} Set.t,
-                        hash: 'a -> word,
-                        equals: 'a -> 'a -> bool}
+                            hash: 'a -> word,
+                            equals: 'a -> 'a -> bool}
 
 fun ('a, 'b) new {equals, hash}: ('a, 'b) t =
-   T {set=Set.new {hash = #hash}, hash=hash, equals=fn x => fn y => equals (x, y)}
+   T {set = Set.new {hash = #hash},
+      hash = hash,
+      equals = fn x => fn y => equals (x, y)}
 
 fun toPair {key, value, hash} = (key, value)
 (* we'd like to factor these apart but it makes generalization difficult *)
@@ -24,31 +26,31 @@ fun toList (T {set, ...}) = List.map (Set.toList set, toPair)
 fun layout f (T {set, ...}) = Set.layout (f o toPair) set
 fun stats' (T {set, ...}) = Set.stats' set
 
-
 fun peek (T {set, hash, equals, ...}, a) =
-   Option.map (Set.peek (set, hash a, (equals a) o (#key)), #value)
+   Option.map (Set.peek (set, hash a, equals a o #key), #value)
 
 fun lookupOrInsert (T {set, hash, equals}, a, genB) =
    let
       val hash = hash a
    in
-   (#value) (Set.lookupOrInsert (set, hash, (equals a) o (#key),
-         fn () => {hash=hash, key=a, value=genB ()}))
+      (#value o Set.lookupOrInsert)
+      (set, hash, equals a o #key,
+       fn () => {hash = hash, key = a, value = genB ()})
    end
 
 fun insertIfNew (T {set, hash, equals}, a, genB, whenFound) =
    let
       val hash = hash a
    in
-   (#value) (Set.insertIfNew
-      (set, hash, (equals a) o (#key),
-       fn () => {hash=hash, key=a, value=genB ()},
-       fn {value=b, ...} => whenFound b))
+      (#value o Set.insertIfNew)
+      (set, hash, equals a o #key,
+       fn () => {hash = hash, key = a, value = genB ()},
+       fn {value = b, ...} => whenFound b)
    end
 
 fun removeWhen (T {set, hash, equals, ...}, a, cond) =
    Set.remove (set, hash a,
-      fn {key,value,...} => cond value andalso equals key a)
+               fn {key, value, ...} => cond value andalso equals key a)
 fun remove (t, a) = removeWhen (t, a, fn _ => true)
 fun removeAll (T {set, ...}, f) = Set.removeAll (set, f o toPair)
 

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -12,15 +12,10 @@ structure Set = HashSet
 
 datatype ('a, 'b) t = T of {set: {hash: word, key: 'a, value: 'b} Set.t,
                         hash: 'a -> word,
-                        equals: 'a * 'a -> bool,
-                        cache: bool}
+                        equals: 'a * 'a -> bool}
 
-fun ('a, 'b) new {equals, hash, cache}: ('a, 'b) t =
-   let
-      val hash' = if cache then #hash else hash o #key
-   in
-      T {set=Set.new {hash = hash'}, hash=hash, equals=equals, cache=cache}
-   end
+fun ('a, 'b) new {equals, hash}: ('a, 'b) t =
+   T {set=Set.new {hash = #hash}, hash=hash, equals=equals}
 
 fun toPair {key, value, hash} = (key, value)
 (* we'd like to factor these apart but it makes generalization difficult *)
@@ -34,21 +29,21 @@ fun keyEquals (equals, a) {key=a', hash, value} = equals (a, a')
 fun peek (T {set, hash, equals, ...}, a) =
    Option.map (Set.peek (set, hash a, keyEquals (equals, a)), #value)
 
-fun lookupOrInsert (T {set, hash, equals, cache}, a, genB) =
+fun lookupOrInsert (T {set, hash, equals}, a, genB) =
    let
       val hash = hash a
    in
    (#value) (Set.lookupOrInsert (set, hash, keyEquals (equals, a),
-         fn () => {hash=if cache then hash else 0w0, key=a, value=genB ()}))
+         fn () => {hash=hash, key=a, value=genB ()}))
    end
 
-fun insertIfNew (T {set, hash, equals, cache}, a, genB, whenFound) =
+fun insertIfNew (T {set, hash, equals}, a, genB, whenFound) =
    let
       val hash = hash a
    in
    (#value) (Set.insertIfNew
       (set, hash, keyEquals (equals, a),
-       fn () => {hash=if cache then hash else 0w0, key=a, value=genB ()},
+       fn () => {hash=hash, key=a, value=genB ()},
        fn {value=b, ...} => whenFound b))
    end
 

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -29,7 +29,7 @@ fun toList (T {set, ...}) = List.map (Set.toList set, toPair)
 fun layout f (T {set, ...}) = Set.layout (f o toPair) set
 fun stats' (T {set, ...}) = Set.stats' set
 
-fun keyEquals (equals, a) {key=a', ...} = equals (a, a')
+fun keyEquals (equals, a) {key=a', hash, value} = equals (a, a')
 
 fun peek (T {set, hash, equals, ...}, a) =
    Option.map (Set.peek (set, hash a, keyEquals (equals, a)), #value)

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Jason Carr
+(* Copyright (C) 2018 Jason Carr
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -52,7 +52,10 @@ fun insertIfNew (T {set, hash, equals, cache}, a, genB, whenFound) =
        fn {value=b, ...} => whenFound b))
    end
 
-fun remove (T {set, hash, equals, ...}, a) = Set.remove (set, hash a, keyEquals (equals, a))
+fun removeWhen (T {set, hash, equals, ...}, a, cond) =
+   Set.remove (set, hash a,
+      fn {key,value,...} => cond value andalso equals (key, a))
+fun remove (t, a) = removeWhen (t, a, fn _ => true)
 fun removeAll (T {set, ...}, f) = Set.removeAll (set, f o toPair)
 
 end

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -12,10 +12,10 @@ structure Set = HashSet
 
 datatype ('a, 'b) t = T of {set: {hash: word, key: 'a, value: 'b} Set.t,
                         hash: 'a -> word,
-                        equals: 'a * 'a -> bool}
+                        equals: 'a -> 'a -> bool}
 
 fun ('a, 'b) new {equals, hash}: ('a, 'b) t =
-   T {set=Set.new {hash = #hash}, hash=hash, equals=equals}
+   T {set=Set.new {hash = #hash}, hash=hash, equals=fn x => fn y => equals (x, y)}
 
 fun toPair {key, value, hash} = (key, value)
 (* we'd like to factor these apart but it makes generalization difficult *)
@@ -24,16 +24,15 @@ fun toList (T {set, ...}) = List.map (Set.toList set, toPair)
 fun layout f (T {set, ...}) = Set.layout (f o toPair) set
 fun stats' (T {set, ...}) = Set.stats' set
 
-fun keyEquals (equals, a) {key=a', hash, value} = equals (a, a')
 
 fun peek (T {set, hash, equals, ...}, a) =
-   Option.map (Set.peek (set, hash a, keyEquals (equals, a)), #value)
+   Option.map (Set.peek (set, hash a, (equals a) o (#key)), #value)
 
 fun lookupOrInsert (T {set, hash, equals}, a, genB) =
    let
       val hash = hash a
    in
-   (#value) (Set.lookupOrInsert (set, hash, keyEquals (equals, a),
+   (#value) (Set.lookupOrInsert (set, hash, (equals a) o (#key),
          fn () => {hash=hash, key=a, value=genB ()}))
    end
 
@@ -42,14 +41,14 @@ fun insertIfNew (T {set, hash, equals}, a, genB, whenFound) =
       val hash = hash a
    in
    (#value) (Set.insertIfNew
-      (set, hash, keyEquals (equals, a),
+      (set, hash, (equals a) o (#key),
        fn () => {hash=hash, key=a, value=genB ()},
        fn {value=b, ...} => whenFound b))
    end
 
 fun removeWhen (T {set, hash, equals, ...}, a, cond) =
    Set.remove (set, hash a,
-      fn {key,value,...} => cond value andalso equals (key, a))
+      fn {key,value,...} => cond value andalso equals key a)
 fun remove (t, a) = removeWhen (t, a, fn _ => true)
 fun removeAll (T {set, ...}, f) = Set.removeAll (set, f o toPair)
 

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2017 Jason Carr
+ * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a HPND-style license.
@@ -11,94 +12,36 @@ struct
 
 structure Set = HashSet
 
-type ('a, 'b) t = ('a * 'b) Set.t
+datatype ('a, 'b) t = T of {set: ('a * 'b) Set.t,
+                        hash: 'a -> word,
+                        equals: 'a * 'a -> bool}
 
 fun ('a, 'b) new {equals, hash}: ('a, 'b) t =
-   Set.new {equals = fn ((a, _), (a', _)) => equals (a, a')
-            hash = hash o #1}
+   {set=Set.new { hash = hash o #1}, hash=hash, equals=equals}
+            (* equals = fn ((a, _), (a', _)) => equals (a, a') *)
 
 local
    open Set
+   fun projectSet (T {set, ...}) = set
 in
-   val size = size
-   val stats = stats
+   val size = size o projectSet
+   val stats = stats o projectSet
+   val toList = toList o projectSet
+   val layout = layout o projectSet
 end
 
-fun update (t, a, b) = Set.update (t, (a, b))
+fun keyEquals (equals, a) (a', _) = equals
 
-fun peek (t, a) =
-   Option.map (Set.peek (t, Set.hash (t, 
+fun peek (T {set, hash, equals}, a) =
+   Option.map (Set.peek (set, hash a, keyEquals (equals, a)), #2)
 
-fun update (T {buckets = ref buckets, equals, mask, ...}, w, a, b) =
-   let
-      val j = index (w, !mask)
-      val _ =
-         Array.update
-         (buckets, j,
-          (w, a, b)
-          :: List.fold (Array.sub (buckets, j), [], fn (z as (w', a', _), ac) =>
-                        if Word.equals (w, w') andalso equals (a, a')
-                           then ac
-                        else z :: ac))
-   in ()
-   end
+fun lookupOrInsert (T {set, hash, equals}, a, genB) =
+   #2 o Set.lookupOrInsert (set, hash a, keyEquals (equals, a), fn () => (a, genB ()))
 
-fun peek(t, w, i) = peekGen(t, w, i, fn _ => NONE, SOME)
-
-fun lookupGen (table as T {buckets, numItems, ...}, w, i, x, yes) =
-   let
-      fun no (j, b) =
-         let val x = x ()
-            val _ = Int.inc numItems
-            val _ = Array.update (!buckets, j, (w, i, x) :: b)
-            val _ = maybeGrow table
-         in x
-         end
-   in peekGen (table, w, i, no, yes)
-   end
-
-fun lookupOrInsert (table, w, i, x) =
-   lookupGen (table, w, i, x, fn x => x)
-
-fun insertIfNew (table, w, i, x, yes) =
-   lookupGen (table, w, i, fn () => x, fn _ => yes ())
-
-fun foldi(T{buckets, ...}, b, f) =
-   Array.fold(!buckets, b, fn (r, b) =>
-              List.fold(r, b, fn ((_, i, x), b) => f(i, x, b)))
-
-fun listItemsi t = foldi(t, [], fn (i, x, l) => (i, x) :: l)
-
-fun layout lay t = List.layout lay (listItemsi t)
-
-fun fold(t, b, f) = foldi(t, b, fn (_, x, b) => f(x, b))
-
-fun foreachi(t, f) = foldi(t, (), fn (i, x, ()) => f(i, x))
-
-fun foreach(t, f) = foreachi(t, f o #2)
-
-fun foralli(t, f) =
-   DynamicWind.withEscape
-   (fn escape =>
-    (foreachi(t, fn z => if f z then () else escape false)
-     ; true))
-
-fun forall(t, f) = foralli(t, f o #2)
-
-fun listItems t = fold(t, [], op ::)
-
-fun appi(t, f) = foldi(t, (), fn (i, x, ()) => f(i, x))
-
-fun app(t, f) = appi(t, f o #2)
-
-fun mapi (T{numItems, mask, equals, buckets}, f) =
-   T {numItems = ref (!numItems),
-      mask = ref (!mask),
-      equals = equals,
-      buckets = ref (Array.map (!buckets, fn r =>
-                                List.revMap (r, fn (w, i, x) =>
-                                             (w, i, f (i, x)))))}
-
-fun map (t, f) = mapi (t, f o #2)
+fun insertIfNew (T {set, hash, equals}, a, genB, whenFound) =
+   #2 o Set.insertIfNew
+      (set, hash a, keyEquals (equals, a),
+       fn () => (a, genB ()),
+       fn (_, b) => whenFound b)
 
 end

--- a/lib/mlton/basic/hash.sig
+++ b/lib/mlton/basic/hash.sig
@@ -7,14 +7,16 @@
 (* HASH defines a set of transformations on hash values *)
 signature HASH =
    sig
-      (* combine a list of hash values so that each is independent from the last.
-       * No guarantee is made as to whether or not combine [w] = w *)
-      val combine: word List.t -> word
+      (* combine a number of values into one value independent from either *)
+      val combine: word * word -> word
+      val combine3: word * word * word -> word
 
-      (* combine a list of hash values so that each is independent from the last.
-       * No guarantee is made as to whether or not combine [w] = w *)
+      (* combine a vector of hash values *)
       val vector: word Vector.t -> word
       val vectorMap: ('a Vector.t * ('a -> word)) -> word
+
+      val list: word List.t -> word
+      val listMap: ('a List.t * ('a -> word)) -> word
 
       (* 0x9e3779b97f4a7c15 *)
       val permute: word -> word

--- a/lib/mlton/basic/hash.sig
+++ b/lib/mlton/basic/hash.sig
@@ -11,13 +11,11 @@ signature HASH =
       val combine: word * word -> word
       val combine3: word * word * word -> word
 
-      (* combine a vector of hash values *)
-      val vector: word Vector.t -> word
-      val vectorMap: ('a Vector.t * ('a -> word)) -> word
-
       val list: word List.t -> word
       val listMap: ('a List.t * ('a -> word)) -> word
 
-      (* 0x9e3779b97f4a7c15 *)
       val permute: word -> word
+
+      val vector: word Vector.t -> word
+      val vectorMap: ('a Vector.t * ('a -> word)) -> word
    end

--- a/lib/mlton/basic/hash.sig
+++ b/lib/mlton/basic/hash.sig
@@ -1,0 +1,16 @@
+(* Copyright (C) 2017 Jason Carr
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+(* HASH defines a set of transformations on hash values *)
+signature HASH =
+   sig
+      (* combine a list of hash values so that each is independent from the last.
+       * No guarantee is made as to whether or not combine [w] = w *)
+      val combine: word List.t -> word
+
+      (* 0x9e3779b97f4a7c15 *)
+      val permute: word -> word
+   end

--- a/lib/mlton/basic/hash.sig
+++ b/lib/mlton/basic/hash.sig
@@ -10,10 +10,11 @@ signature HASH =
       (* combine a list of hash values so that each is independent from the last.
        * No guarantee is made as to whether or not combine [w] = w *)
       val combine: word List.t -> word
-      
+
       (* combine a list of hash values so that each is independent from the last.
        * No guarantee is made as to whether or not combine [w] = w *)
-      val combineVec: word Vector.t -> word
+      val vector: word Vector.t -> word
+      val vectorMap: ('a Vector.t * ('a -> word)) -> word
 
       (* 0x9e3779b97f4a7c15 *)
       val permute: word -> word

--- a/lib/mlton/basic/hash.sig
+++ b/lib/mlton/basic/hash.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Jason Carr
+(* Copyright (C) 2018 Jason Carr
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.

--- a/lib/mlton/basic/hash.sig
+++ b/lib/mlton/basic/hash.sig
@@ -10,6 +10,10 @@ signature HASH =
       (* combine a list of hash values so that each is independent from the last.
        * No guarantee is made as to whether or not combine [w] = w *)
       val combine: word List.t -> word
+      
+      (* combine a list of hash values so that each is independent from the last.
+       * No guarantee is made as to whether or not combine [w] = w *)
+      val combineVec: word Vector.t -> word
 
       (* 0x9e3779b97f4a7c15 *)
       val permute: word -> word

--- a/lib/mlton/basic/hash.sml
+++ b/lib/mlton/basic/hash.sml
@@ -10,11 +10,9 @@ struct
    (* Fowler–Noll–Vo hash *)
    val prime = 0w16777619
    val offset_basis = 0w2166136261
-   fun multPrime n = Word.<< (n, 0w24) + Word.<< (n, 0w8) + 0wx93 * n
-   fun combineHelp hs k =
-      case hs of
-           [] => offset_basis
-         | (h :: hs') => combineHelp hs' (multPrime (Word.xorb (h, k)))
-   fun combine hs = combineHelp hs offset_basis
+   fun multPrime n = prime * n
+   fun combine2 (h, k) = multPrime (Word.xorb (h, k))
+   fun combine hs = List.fold (hs, offset_basis, combine2)
+   fun combineVec vec = Vector.fold (vec, offset_basis, combine2)
    fun permute h = offset_basis + multPrime h
 end

--- a/lib/mlton/basic/hash.sml
+++ b/lib/mlton/basic/hash.sml
@@ -14,9 +14,15 @@ struct
    val prime = 0w16777619
    val offset_basis = 0wx55555 (* pretty much arbitrary, just shouldn't be zero *)
    fun multPrime n = prime * n
-   fun combine2 (h, k) = multPrime (Word.xorb (h, k))
-   fun combine hs = List.fold (hs, offset_basis, combine2)
-   fun vector vec = Vector.fold (vec, offset_basis, combine2)
-   fun vectorMap (vec, f) = Vector.fold (vec, offset_basis, fn (v, k) => combine2 (f v, k))
+   fun combine (h1, h2) = multPrime (Word.xorb (h1, h2 + offset_basis))
+   fun combine3 (h1, h2, h3) = combine (h1, combine (h2, h3))
+   fun combine4 (h1, h2, h3, h4) = combine (h1, combine3 (h2, h3, h4))
+
+   fun combineNoOffset (h1, h2) = multPrime (Word.xorb (h1, h2))
+   fun vector vec = Vector.fold (vec, offset_basis, combineNoOffset)
+   fun vectorMap (vec, f) = Vector.fold (vec, offset_basis, fn (v, k) => combineNoOffset (f v, k))
+   fun list hs = List.fold (hs, offset_basis, combineNoOffset)
+   fun listMap (hs, f) = List.fold (hs, offset_basis, fn (v, k) => combineNoOffset (f v, k))
+
    fun permute h = offset_basis + multPrime h
 end

--- a/lib/mlton/basic/hash.sml
+++ b/lib/mlton/basic/hash.sml
@@ -16,6 +16,7 @@ struct
    fun multPrime n = prime * n
    fun combine2 (h, k) = multPrime (Word.xorb (h, k))
    fun combine hs = List.fold (hs, offset_basis, combine2)
-   fun combineVec vec = Vector.fold (vec, offset_basis, combine2)
+   fun vector vec = Vector.fold (vec, offset_basis, combine2)
+   fun vectorMap (vec, f) = Vector.fold (vec, offset_basis, fn (v, k) => combine2 (f v, k))
    fun permute h = offset_basis + multPrime h
 end

--- a/lib/mlton/basic/hash.sml
+++ b/lib/mlton/basic/hash.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Jason Carr
+(* Copyright (C) 2018 Jason Carr
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.

--- a/lib/mlton/basic/hash.sml
+++ b/lib/mlton/basic/hash.sml
@@ -1,0 +1,20 @@
+(* Copyright (C) 2017 Jason Carr
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+(* simple (non-cryptographic) hashing methods *)
+structure Hash: HASH =
+struct
+   (* Fowler–Noll–Vo hash *)
+   val prime = 0w16777619
+   val offset_basis = 0w2166136261
+   fun multPrime n = Word.<< (n, 0w24) + Word.<< (n, 0w8) + 0wx93 * n
+   fun combineHelp hs k =
+      case hs of
+           [] => offset_basis
+         | (h :: hs') => combineHelp hs' (multPrime (Word.xorb (h, k)))
+   fun combine hs = combineHelp hs offset_basis
+   fun permute h = offset_basis + multPrime h
+end

--- a/lib/mlton/basic/hash.sml
+++ b/lib/mlton/basic/hash.sml
@@ -7,9 +7,12 @@
 (* simple (non-cryptographic) hashing methods *)
 structure Hash: HASH =
 struct
-   (* Fowler–Noll–Vo hash *)
+   (* Fowler–Noll–Vo hash,
+    * but we use a different offset_basis that will fit
+    * into a 31-bit word. It seems to have relatively
+    * little impact. *)
    val prime = 0w16777619
-   val offset_basis = 0w2166136261
+   val offset_basis = 0wx55555 (* pretty much arbitrary, just shouldn't be zero *)
    fun multPrime n = prime * n
    fun combine2 (h, k) = multPrime (Word.xorb (h, k))
    fun combine hs = List.fold (hs, offset_basis, combine2)

--- a/lib/mlton/basic/sources.cm
+++ b/lib/mlton/basic/sources.cm
@@ -67,6 +67,7 @@ structure FileDesc
 structure FixedPoint
 structure Function
 structure HashSet
+structure HashTable
 structure Html
 structure In
 structure InitScript
@@ -265,6 +266,8 @@ binary-search.sig
 binary-search.sml
 hash-set.sig
 hash-set.sml
+hash-table.sig
+hash-table.sml
 string.sml
 instream.sml
 file.sig

--- a/lib/mlton/basic/sources.cm
+++ b/lib/mlton/basic/sources.cm
@@ -66,6 +66,7 @@ structure File
 structure FileDesc
 structure FixedPoint
 structure Function
+structure Hash
 structure HashSet
 structure HashTable
 structure Html
@@ -264,6 +265,8 @@ array.fun
 array.sml
 binary-search.sig
 binary-search.sml
+hash.sig
+hash.sml
 hash-set.sig
 hash-set.sml
 hash-table.sig

--- a/lib/mlton/basic/sources.mlb
+++ b/lib/mlton/basic/sources.mlb
@@ -106,6 +106,8 @@ in
       array.sml
       binary-search.sig
       binary-search.sml
+      hash.sig
+      hash.sml
       hash-set.sig
       hash-set.sml
       hash-table.sig
@@ -236,6 +238,7 @@ in
       structure FileDesc
       structure FixedPoint
       structure Function
+      structure Hash
       structure HashSet
       structure HashTable
       (* structure Http *)

--- a/lib/mlton/basic/sources.mlb
+++ b/lib/mlton/basic/sources.mlb
@@ -108,6 +108,8 @@ in
       binary-search.sml
       hash-set.sig
       hash-set.sml
+      hash-table.sig
+      hash-table.sml
       string.sml
       instream.sml
       file.sig
@@ -235,6 +237,7 @@ in
       structure FixedPoint
       structure Function
       structure HashSet
+      structure HashTable
       (* structure Http *)
       structure In
       structure Int

--- a/lib/mlton/sources.cm
+++ b/lib/mlton/sources.cm
@@ -70,7 +70,9 @@ structure File
 structure FileDesc
 structure FixedPoint
 structure Function
+structure Hash
 structure HashSet
+structure HashTable
 structure Html
 structure In
 structure InitScript

--- a/lib/mlton/sources.mlb
+++ b/lib/mlton/sources.mlb
@@ -66,6 +66,7 @@ ann "forceUsed" in
       structure FileDesc
       structure FixedPoint
       structure Function
+      structure Hash
       structure HashSet
       structure HashTable
       (* structure Http *)

--- a/lib/mlton/sources.mlb
+++ b/lib/mlton/sources.mlb
@@ -67,6 +67,7 @@ ann "forceUsed" in
       structure FixedPoint
       structure Function
       structure HashSet
+      structure HashTable
       (* structure Http *)
       structure In
       structure Int

--- a/mlnlffigen/sources.mlb
+++ b/mlnlffigen/sources.mlb
@@ -52,8 +52,10 @@ local
    local open basis_lib ckit_lib in
       ast-to-spec.sml
       hash.sml
+      structure NLFFIHash = Hash
    end
    local open mlton_lib ckit_lib in
+      structure Hash = NLFFIHash
       gen.sml
    end
 

--- a/mlnlffigen/sources.mlb
+++ b/mlnlffigen/sources.mlb
@@ -7,7 +7,24 @@
 
 local
    basis basis_lib = bas $(SML_LIB)/basis/basis.mlb end
-   basis mlton_lib = bas ../lib/mlton/sources.mlb end
+   basis mlton_lib = bas local
+      ../lib/mlton/sources.mlb
+   in
+      structure File
+      structure List
+      structure HashSet
+      structure MLton
+      structure Out
+      structure Option
+      structure Process
+      structure Popt
+      structure Promise
+      structure Result
+      structure String
+      structure Vector
+
+      functor Control
+   end end
    basis smlnj_lib = bas $(SML_LIB)/smlnj-lib/Util/smlnj-lib.mlb end
    basis pp_lib = bas $(SML_LIB)/smlnj-lib/PP/pp-lib.mlb end
    basis regexp_lib = bas $(SML_LIB)/smlnj-lib/RegExp/regexp-lib.mlb end
@@ -32,7 +49,7 @@ local
       cpif-dev.sml
       pp.sml
    end
-   local open mlton_lib ckit_lib in
+   local open basis_lib mlton_lib ckit_lib in
       control.sig
       control.sml
    end
@@ -52,14 +69,12 @@ local
    local open basis_lib ckit_lib in
       ast-to-spec.sml
       hash.sml
-      structure NLFFIHash = Hash
    end
-   local open mlton_lib ckit_lib in
-      structure Hash = NLFFIHash
+   local open basis_lib mlton_lib ckit_lib in
       gen.sml
    end
 
-   local open mlton_lib regexp_lib in
+   local open basis_lib mlton_lib regexp_lib in
       main.sml
    end
 in

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -126,9 +126,7 @@ structure Type =
          val generator: Word.t = 0wx5555
       in
          fun con (c, ts) =
-            lookup (Vector.fold (ts, Tycon.hash c, fn (t, w) =>
-                                 Word.xorb (w * generator, hash t)),
-                    Con (c, ts))
+            lookup (Hash.combine [Tycon.hash c, Hash.combineVec (Vector.map (ts, hash))], Con (c, ts))
          val con = Trace.trace2 ("HashType.Type.con",
                                  Tycon.layout,
                                  Vector.layout layout,

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -123,7 +123,7 @@ structure Type =
       fun var a = lookup (Tyvar.hash a, Var a)
 
       fun con (c, ts) =
-         lookup (Hash.combine [Tycon.hash c, Hash.combineVec (Vector.map (ts, hash))], Con (c, ts))
+         lookup (Hash.combine [Tycon.hash c, Hash.vectorMap (ts, hash)], Con (c, ts))
       val con = Trace.trace2 ("HashType.Type.con",
                               Tycon.layout,
                               Vector.layout layout,

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -122,16 +122,12 @@ structure Type =
 
       fun var a = lookup (Tyvar.hash a, Var a)
 
-      local
-         val generator: Word.t = 0wx5555
-      in
-         fun con (c, ts) =
-            lookup (Hash.combine [Tycon.hash c, Hash.combineVec (Vector.map (ts, hash))], Con (c, ts))
-         val con = Trace.trace2 ("HashType.Type.con",
-                                 Tycon.layout,
-                                 Vector.layout layout,
-                                 layout) con
-      end
+      fun con (c, ts) =
+         lookup (Hash.combine [Tycon.hash c, Hash.combineVec (Vector.map (ts, hash))], Con (c, ts))
+      val con = Trace.trace2 ("HashType.Type.con",
+                              Tycon.layout,
+                              Vector.layout layout,
+                              layout) con
    end
 structure Ops = TypeOps (structure Tycon = Tycon
                          open Type)

--- a/mlton/atoms/hash-type.fun
+++ b/mlton/atoms/hash-type.fun
@@ -123,7 +123,7 @@ structure Type =
       fun var a = lookup (Tyvar.hash a, Var a)
 
       fun con (c, ts) =
-         lookup (Hash.combine [Tycon.hash c, Hash.vectorMap (ts, hash)], Con (c, ts))
+         lookup (Hash.combine (Tycon.hash c, Hash.vectorMap (ts, hash)), Con (c, ts))
       val con = Trace.trace2 ("HashType.Type.con",
                               Tycon.layout,
                               Vector.layout layout,

--- a/mlton/atoms/profile-exp.fun
+++ b/mlton/atoms/profile-exp.fun
@@ -31,8 +31,8 @@ local
    val leave = newHash ()
 in
    val hash =
-      fn Enter si => Word.xorb (enter, SourceInfo.hash si)
-       | Leave si => Word.xorb (leave, SourceInfo.hash si)
+      fn Enter si => Hash.combine [enter, SourceInfo.hash si]
+       | Leave si => Hash.combine [leave, SourceInfo.hash si]
 end
 
 end

--- a/mlton/atoms/profile-exp.fun
+++ b/mlton/atoms/profile-exp.fun
@@ -31,8 +31,8 @@ local
    val leave = newHash ()
 in
    val hash =
-      fn Enter si => Hash.combine [enter, SourceInfo.hash si]
-       | Leave si => Hash.combine [leave, SourceInfo.hash si]
+      fn Enter si => Hash.combine (enter, SourceInfo.hash si)
+       | Leave si => Hash.combine (leave, SourceInfo.hash si)
 end
 
 end

--- a/mlton/ssa/common-subexp.fun
+++ b/mlton/ssa/common-subexp.fun
@@ -105,7 +105,7 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
 
       (* Keep a hash table of canonicalized Exps that are in scope. *)
       val table: (Exp.t, Var.t) HashTable.t =
-         HashTable.new {hash=Exp.hash, equals=Exp.equals, cache=true}
+         HashTable.new {hash=Exp.hash, equals=Exp.equals}
       fun lookup (var, exp) =
          HashTable.lookupOrInsert
          (table, exp, fn () => var)

--- a/mlton/ssa/common-subexp.fun
+++ b/mlton/ssa/common-subexp.fun
@@ -104,15 +104,11 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
           | _ => e
 
       (* Keep a hash table of canonicalized Exps that are in scope. *)
-      val table: {hash: word, exp: Exp.t, var: Var.t} HashSet.t =
-         HashSet.new {hash = #hash}
-      fun lookup (var, exp, hash) =
-         HashSet.lookupOrInsert
-         (table, hash,
-          fn {exp = exp', ...} => Exp.equals (exp, exp'),
-          fn () => {exp = exp,
-                    hash = hash,
-                    var = var})
+      val table: (Exp.t, Var.t) HashTable.t =
+         HashTable.new {hash=Exp.hash, equals=Exp.equals, cache=true}
+      fun lookup (var, exp) =
+         HashTable.lookupOrInsert
+         (table, exp, fn () => var)
 
       (* All of the globals are in scope, and never go out of scope. *)
       (* The hash-cons'ing of globals in ConstantPropagation ensures
@@ -125,7 +121,7 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
              val var = valOf var
              val () = setVarIndex var
              val exp = canon exp
-             val _ = lookup (var, exp, Exp.hash exp)
+             val _ = lookup (var, exp)
           in
              ()
           end)
@@ -160,10 +156,9 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
                   val _ = List.foreach
                           (!add, fn (var, exp) =>
                            let
-                             val hash = Exp.hash exp
-                             val elem as {var = var', ...} = lookup (var, exp, hash)
+                             val var' = lookup (var, exp)
                              val _ = if Var.equals(var, var')
-                                       then List.push (remove, elem)
+                                       then List.push (remove, (exp, var'))
                                        else ()
                            in
                              ()
@@ -192,12 +187,10 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
                                      (setReplace (var, SOME var'); NONE)
                                   fun doit () =
                                      let
-                                        val hash = Exp.hash exp
-                                        val elem as {var = var', ...} =
-                                           lookup (var, exp, hash)
+                                        val var' = lookup (var, exp)
                                      in
                                         if Var.equals(var, var')
-                                          then (List.push (remove, elem)
+                                          then (List.push (remove, (exp, var'))
                                                 ; keep ())
                                           else replace var'
                                      end
@@ -251,12 +244,9 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
                               val exp = canon (PrimApp {prim = prim,
                                                         targs = Vector.new0 (),
                                                         args = args})
-                              val hash = Exp.hash exp
                            in
-                              case HashSet.peek
-                                   (table, hash,
-                                    fn {exp = exp', ...} => Exp.equals (exp, exp')) of
-                                 SOME {var, ...} =>
+                              case HashTable.peek (table, exp) of
+                                 SOME var =>
                                     if overflowVar var
                                        then Goto {dst = overflow,
                                                   args = Vector.new0 ()}
@@ -315,15 +305,15 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
                            let open Layout
                            in
                               display (seq [str "remove: ",
-                                            List.layout (fn {var,exp,...} =>
-                                                         seq [Var.layout var,
-                                                              str ": ",
-                                                              Exp.layout exp]) (!remove)])
+                                            List.layout (fn (exp, var) => seq
+                                             [Var.layout var,
+                                              Layout.str ":",
+                                              Exp.layout exp]) (!remove)])
                            end)
                   val _ = List.foreach
-                          (!remove, fn {var, hash, ...} =>
-                           HashSet.remove
-                           (table, hash, fn {var = var', ...} =>
+                          (!remove, fn (exp, var) =>
+                          HashTable.removeWhen
+                           (table, exp, fn var' =>
                             Var.equals (var, var')))
                   val _ = diag "removed"
                in

--- a/mlton/ssa/common-subexp.fun
+++ b/mlton/ssa/common-subexp.fun
@@ -105,7 +105,7 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
 
       (* Keep a hash table of canonicalized Exps that are in scope. *)
       val table: (Exp.t, Var.t) HashTable.t =
-         HashTable.new {hash=Exp.hash, equals=Exp.equals}
+         HashTable.new {hash = Exp.hash, equals = Exp.equals}
       fun lookup (var, exp) =
          HashTable.lookupOrInsert
          (table, exp, fn () => var)
@@ -305,14 +305,14 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
                            let open Layout
                            in
                               display (seq [str "remove: ",
-                                            List.layout (fn (exp, var) => seq
-                                             [Var.layout var,
-                                              Layout.str ":",
-                                              Exp.layout exp]) (!remove)])
+                                            List.layout (fn (exp, var) =>
+                                                         seq [Var.layout var,
+                                                              str ": ",
+                                                              Exp.layout exp]) (!remove)])
                            end)
                   val _ = List.foreach
                           (!remove, fn (exp, var) =>
-                          HashTable.removeWhen
+                           HashTable.removeWhen
                            (table, exp, fn var' =>
                             Var.equals (var, var')))
                   val _ = diag "removed"

--- a/mlton/ssa/known-case.fun
+++ b/mlton/ssa/known-case.fun
@@ -431,7 +431,7 @@ fun transform (Program.T {globals, datatypes, functions, main})
                   addBlock block)
              local
                val table: (Transfer.t, Label.t) HashTable.t =
-                  HashTable.new {hash=Transfer.hash, equals=Transfer.equals}
+                  HashTable.new {hash = Transfer.hash, equals = Transfer.equals}
              in
                 fun newBlock transfer =
                    let
@@ -454,7 +454,7 @@ fun transform (Program.T {globals, datatypes, functions, main})
                  *)
                 fun newBlock' transfer =
                    HashTable.lookupOrInsert
-                         (table, transfer, fn () => newBlock transfer)
+                   (table, transfer, fn () => newBlock transfer)
                 val _ = newBlock' (* quell unused variable warning *)
                fun bugBlock () = newBlock Bug
              end

--- a/mlton/ssa/known-case.fun
+++ b/mlton/ssa/known-case.fun
@@ -431,7 +431,7 @@ fun transform (Program.T {globals, datatypes, functions, main})
                   addBlock block)
              local
                val table: (Transfer.t, Label.t) HashTable.t =
-                  HashTable.new {hash=Transfer.hash, equals=Transfer.equals, cache=true}
+                  HashTable.new {hash=Transfer.hash, equals=Transfer.equals}
              in
                 fun newBlock transfer =
                    let

--- a/mlton/ssa/parse-ssa.fun
+++ b/mlton/ssa/parse-ssa.fun
@@ -46,7 +46,7 @@ struct
 
    fun 'a makeNameResolver(f: string -> 'a): string -> 'a =
       let
-         val table = HashTable.new {hash=String.hash, equals=String.equals, cache=true}
+         val table = HashTable.new {hash=String.hash, equals=String.equals}
       in
          fn x => HashTable.lookupOrInsert (table, x, fn () => f x)
       end

--- a/mlton/ssa/parse-ssa.fun
+++ b/mlton/ssa/parse-ssa.fun
@@ -46,7 +46,7 @@ struct
 
    fun 'a makeNameResolver(f: string -> 'a): string -> 'a =
       let
-         val table = HashTable.new {hash=String.hash, equals=String.equals}
+         val table = HashTable.new {hash = String.hash, equals = String.equals}
       in
          fn x => HashTable.lookupOrInsert (table, x, fn () => f x)
       end

--- a/mlton/ssa/parse-ssa.fun
+++ b/mlton/ssa/parse-ssa.fun
@@ -46,11 +46,9 @@ struct
 
    fun 'a makeNameResolver(f: string -> 'a): string -> 'a =
       let
-         val hash = String.hash
-         val map = HashSet.new{hash= hash o #1}
-         fun eq x (a: string * 'a) = String.equals(x, #1 a)
+         val table = HashTable.new {hash=String.hash, equals=String.equals, cache=true}
       in
-         fn x => (#2 o HashSet.lookupOrInsert)(map, hash x, eq x, fn () => (x, f x))
+         fn x => HashTable.lookupOrInsert (table, x, fn () => f x)
       end
 
 

--- a/mlton/ssa/parse-ssa2.fun
+++ b/mlton/ssa/parse-ssa2.fun
@@ -45,13 +45,11 @@
     (P.nextSat (fn b => isInfixChar b orelse b = #"_"))) <* P.spaces
 
  fun 'a makeNameResolver(f: string -> 'a): string -> 'a =
-      let
-          val hash = String.hash
-          val map = HashSet.new{hash= hash o #1}
-          fun eq x (a: string * 'a) = String.equals(x, #1 a)
-        in
-           fn x => (#2 o HashSet.lookupOrInsert)(map, hash x, eq x, fn () => (x, f x))
-        end
+    let
+       val table = HashTable.new {hash=String.hash, equals=String.equals, cache=true}
+    in
+       fn x => HashTable.lookupOrInsert (table, x, fn () => f x)
+    end
 
  val ident = (String.implode <$> (P.any[(op ::) <$$>
               (P.nextSat isIdentFirst,

--- a/mlton/ssa/parse-ssa2.fun
+++ b/mlton/ssa/parse-ssa2.fun
@@ -46,7 +46,7 @@
 
  fun 'a makeNameResolver(f: string -> 'a): string -> 'a =
     let
-       val table = HashTable.new {hash=String.hash, equals=String.equals, cache=true}
+       val table = HashTable.new {hash=String.hash, equals=String.equals}
     in
        fn x => HashTable.lookupOrInsert (table, x, fn () => f x)
     end

--- a/mlton/ssa/parse-ssa2.fun
+++ b/mlton/ssa/parse-ssa2.fun
@@ -46,7 +46,7 @@
 
  fun 'a makeNameResolver(f: string -> 'a): string -> 'a =
     let
-       val table = HashTable.new {hash=String.hash, equals=String.equals}
+       val table = HashTable.new {hash = String.hash, equals = String.equals}
     in
        fn x => HashTable.lookupOrInsert (table, x, fn () => f x)
     end

--- a/mlton/ssa/restore.fun
+++ b/mlton/ssa/restore.fun
@@ -540,9 +540,7 @@ fun restoreFunction {globals: Statement.t vector}
                   else let
                          val phiArgs = Vector.map
                                         (phiArgs, valOf o VarInfo.peekVar o varInfo)
-                         val hash = Vector.fold
-                                    (phiArgs, Label.hash dst, fn (x, h) =>
-                                     Word.xorb(Var.hash x, h))
+                         val hash = Hash.combine [Label.hash dst, Hash.vectorMap (phiArgs, Var.hash)]
                          val {route, ...} 
                            = HashSet.lookupOrInsert
                              (routeTable, hash, 

--- a/mlton/ssa/restore.fun
+++ b/mlton/ssa/restore.fun
@@ -540,7 +540,7 @@ fun restoreFunction {globals: Statement.t vector}
                   else let
                          val phiArgs = Vector.map
                                         (phiArgs, valOf o VarInfo.peekVar o varInfo)
-                         val hash = Hash.combine [Label.hash dst, Hash.vectorMap (phiArgs, Var.hash)]
+                         val hash = Hash.combine (Label.hash dst, Hash.vectorMap (phiArgs, Var.hash))
                          val {route, ...} 
                            = HashSet.lookupOrInsert
                              (routeTable, hash, 

--- a/mlton/ssa/restore2.fun
+++ b/mlton/ssa/restore2.fun
@@ -539,9 +539,7 @@ fun restoreFunction {globals: Statement.t vector}
                   else let
                          val phiArgs = Vector.map
                                         (phiArgs, valOf o VarInfo.peekVar o varInfo)
-                         val hash = Vector.fold
-                                    (phiArgs, Label.hash dst, fn (x, h) =>
-                                     Word.xorb(Var.hash x, h))
+                         val hash = Hash.combine [Label.hash dst, Hash.vectorMap (phiArgs, Var.hash)]
                          val {route, ...} 
                            = HashSet.lookupOrInsert
                              (routeTable, hash, 

--- a/mlton/ssa/restore2.fun
+++ b/mlton/ssa/restore2.fun
@@ -539,7 +539,7 @@ fun restoreFunction {globals: Statement.t vector}
                   else let
                          val phiArgs = Vector.map
                                         (phiArgs, valOf o VarInfo.peekVar o varInfo)
-                         val hash = Hash.combine [Label.hash dst, Hash.vectorMap (phiArgs, Var.hash)]
+                         val hash = Hash.combine (Label.hash dst, Hash.vectorMap (phiArgs, Var.hash))
                          val {route, ...} 
                            = HashSet.lookupOrInsert
                              (routeTable, hash, 

--- a/mlton/ssa/share-zero-vec.fun
+++ b/mlton/ssa/share-zero-vec.fun
@@ -37,29 +37,30 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
 
       val shrink = shrinkFunction {globals = globals}
 
+      (* initialize a HashTable for new zero-length array globals *)
       val newGlobals = ref []
       local
          val hs: (Type.t, Var.t) HashTable.t =
-            HashTable.new {hash=Type.hash, equals=Type.equals}
+            HashTable.new {hash = Type.hash, equals = Type.equals}
       in
          fun getZeroArrVar (ty: Type.t): Var.t =
             HashTable.lookupOrInsert
             (hs, ty,
              fn () =>
-                let
-                   val zeroArrVar = Var.newString "zeroArr"
-                   val statement =
-                      Statement.T
-                      {var = SOME zeroArrVar,
-                       ty = Type.array ty,
-                       exp = PrimApp
-                             {args = Vector.new1 zeroVar,
-                              prim = Prim.arrayAlloc {raw = false},
-                              targs = Vector.new1 ty}}
-                   val () = List.push (newGlobals, statement)
-                in
-                    zeroArrVar
-                end)
+             let
+                val zeroArrVar = Var.newString "zeroArr"
+                val statement =
+                   Statement.T
+                   {var = SOME zeroArrVar,
+                    ty = Type.array ty,
+                    exp = PrimApp
+                    {args = Vector.new1 zeroVar,
+                     prim = Prim.arrayAlloc {raw = false},
+                     targs = Vector.new1 ty}}
+                val () = List.push (newGlobals, statement)
+             in
+                zeroArrVar
+             end)
       end
 
       (* splitStmts (stmts, arrVars)

--- a/mlton/ssa/share-zero-vec.fun
+++ b/mlton/ssa/share-zero-vec.fun
@@ -40,7 +40,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
       val newGlobals = ref []
       local
          val hs: (Type.t, Var.t) HashTable.t =
-            HashTable.new {hash=Type.hash, equals=Type.equals, cache=false}
+            HashTable.new {hash=Type.hash, equals=Type.equals}
       in
          fun getZeroArrVar (ty: Type.t): Var.t =
             HashTable.lookupOrInsert

--- a/mlton/ssa/share-zero-vec.fun
+++ b/mlton/ssa/share-zero-vec.fun
@@ -37,37 +37,29 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
 
       val shrink = shrinkFunction {globals = globals}
 
-      (* initialize a HashSet for new zero-length array globals *)
       val newGlobals = ref []
       local
-         val hs: {eltTy: Type.t, zeroArrVar: Var.t} HashSet.t =
-            HashSet.new {hash = fn {eltTy, ...} => Type.hash eltTy}
+         val hs: (Type.t, Var.t) HashTable.t =
+            HashTable.new {hash=Type.hash, equals=Type.equals, cache=false}
       in
          fun getZeroArrVar (ty: Type.t): Var.t =
-            let
-               val {zeroArrVar, ...} =
-                  HashSet.lookupOrInsert
-                  (hs, Type.hash ty,
-                   fn {eltTy, ...} => Type.equals (eltTy, ty),
-                   fn () =>
-                   let
-                      val zeroArrVar = Var.newString "zeroArr"
-                      val statement =
-                         Statement.T
-                         {var = SOME zeroArrVar,
-                          ty = Type.array ty,
-                          exp = PrimApp
-                                {args = Vector.new1 zeroVar,
-                                 prim = Prim.arrayAlloc {raw = false},
-                                 targs = Vector.new1 ty}}
-                      val () = List.push (newGlobals, statement)
-                   in
-                      {eltTy = ty,
-                       zeroArrVar = zeroArrVar}
-                   end)
-            in
-               zeroArrVar
-            end
+            HashTable.lookupOrInsert
+            (hs, ty,
+             fn () =>
+                let
+                   val zeroArrVar = Var.newString "zeroArr"
+                   val statement =
+                      Statement.T
+                      {var = SOME zeroArrVar,
+                       ty = Type.array ty,
+                       exp = PrimApp
+                             {args = Vector.new1 zeroVar,
+                              prim = Prim.arrayAlloc {raw = false},
+                              targs = Vector.new1 ty}}
+                   val () = List.push (newGlobals, statement)
+                in
+                    zeroArrVar
+                end)
       end
 
       (* splitStmts (stmts, arrVars)

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -137,7 +137,7 @@ structure Type =
          fun tuple ts =
             if 1 = Vector.length ts
                then Vector.first ts
-            else lookup (Hash.combine [w, Hash.combineVec (Vector.map (ts, hash))], Tuple ts)
+            else lookup (Hash.combine [w, Hash.vectorMap (ts, hash)], Tuple ts)
       end
 
       fun ofConst c =
@@ -425,7 +425,7 @@ structure Exp =
          val select = newHash ()
          val tuple = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
+            Hash.combine [w, Hash.vectorMap (xs, Var.hash)]
       in
          val hash: t -> Word.t =
             fn ConApp {con, args, ...} => hashVars (args, Con.hash con)
@@ -882,7 +882,7 @@ structure Transfer =
          val raisee = newHash ()
          val return = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
+            Hash.combine [w, Hash.vectorMap (xs, Var.hash)]
          fun hash2 (w1: Word.t, w2: Word.t) = Hash.combine [w1, w2]
       in
          val hash: t -> Word.t =

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -102,7 +102,7 @@ structure Type =
             let
                val w = newHash ()
             in
-               fn t => lookup (Hash.combine [w, hash t], f t)
+               fn t => lookup (Hash.combine (w, hash t), f t)
             end
       in
          val array = make Array
@@ -137,7 +137,7 @@ structure Type =
          fun tuple ts =
             if 1 = Vector.length ts
                then Vector.first ts
-            else lookup (Hash.combine [w, Hash.vectorMap (ts, hash)], Tuple ts)
+            else lookup (Hash.combine (w, Hash.vectorMap (ts, hash)), Tuple ts)
       end
 
       fun ofConst c =
@@ -425,15 +425,15 @@ structure Exp =
          val select = newHash ()
          val tuple = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combine [w, Hash.vectorMap (xs, Var.hash)]
+            Hash.combine (w, Hash.vectorMap (xs, Var.hash))
       in
          val hash: t -> Word.t =
             fn ConApp {con, args, ...} => hashVars (args, Con.hash con)
              | Const c => Const.hash c
              | PrimApp {args, ...} => hashVars (args, primApp)
-             | Profile p => Hash.combine [profile, ProfileExp.hash p]
+             | Profile p => Hash.combine (profile, ProfileExp.hash p)
              | Select {tuple, offset} =>
-                  Hash.combine [select, Var.hash tuple + Word.fromInt offset]
+                  Hash.combine (select, Var.hash tuple + Word.fromInt offset)
              | Tuple xs => hashVars (xs, tuple)
              | Var x => Var.hash x
       end
@@ -575,7 +575,7 @@ structure Handler =
             case h of
                Caller => caller
              | Dead => dead
-             | Handle l => Hash.combine [handlee, Label.hash l]
+             | Handle l => Hash.combine (handlee, Label.hash l)
       end
    end
 
@@ -662,7 +662,7 @@ structure Return =
             case r of
                Dead => dead
              | NonTail {cont, handler} =>
-                  Hash.combine [nonTail, Label.hash cont, Handler.hash handler]
+                  Hash.combine3 (nonTail, Label.hash cont, Handler.hash handler)
              | Tail => tail
       end
    end
@@ -882,8 +882,8 @@ structure Transfer =
          val raisee = newHash ()
          val return = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combine [w, Hash.vectorMap (xs, Var.hash)]
-         fun hash2 (w1: Word.t, w2: Word.t) = Hash.combine [w1, w2]
+            Hash.combine (w, Hash.vectorMap (xs, Var.hash))
+         fun hash2 (w1: Word.t, w2: Word.t) = Hash.combine (w1, w2)
       in
          val hash: t -> Word.t =
             fn Arith {args, overflow, success, ...} =>

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -137,7 +137,7 @@ structure Type =
          fun tuple ts =
             if 1 = Vector.length ts
                then Vector.first ts
-            else lookup (Hash.combineVec (Vector.map (ts, hash)), Tuple ts)
+            else lookup (Hash.combine [w, Hash.combineVec (Vector.map (ts, hash))], Tuple ts)
       end
 
       fun ofConst c =
@@ -425,7 +425,7 @@ structure Exp =
          val select = newHash ()
          val tuple = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Vector.fold (xs, w, fn (x, w) => Hash.combine [w, Var.hash x])
+            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
       in
          val hash: t -> Word.t =
             fn ConApp {con, args, ...} => hashVars (args, Con.hash con)
@@ -882,7 +882,7 @@ structure Transfer =
          val raisee = newHash ()
          val return = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combineVec (Vector.map (xs, Var.hash))
+            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
          fun hash2 (w1: Word.t, w2: Word.t) = Hash.combine [w1, w2]
       in
          val hash: t -> Word.t =

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -692,7 +692,7 @@ structure Exp =
                              | SOME c => Con.hash c)
              | PrimApp {args, ...} => hashVars (args, primApp)
              | Select {base, offset} =>
-                  Hash.combine (select, Base.hash (base, Var.hash) + Word.fromInt offset)
+                  Hash.combine3 (select, Base.hash (base, Var.hash), Word.fromInt offset)
              | Var x => Var.hash x
       end
       (* quell unused warning *)

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -234,7 +234,7 @@ structure Type =
          val tuple = newHash ()
          val sequence = newHash ()
          fun hashProd (p, base) =
-            Hash.combineVec (Vector.map (Prod.dest p, fn {elt, ...} => hash elt))
+            Hash.combine [base, Hash.combineVec (Vector.map (Prod.dest p, fn {elt, ...} => hash elt))]
       in
          fun object {args, con}: t =
             let
@@ -679,7 +679,7 @@ structure Exp =
          val select = newHash ()
          val tuple = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combineVec (Vector.map (xs, Var.hash))
+            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
       in
          val hash: t -> Word.t =
             fn Const c => Const.hash c
@@ -1170,7 +1170,7 @@ structure Transfer =
          val raisee = newHash ()
          val return = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combineVec (Vector.map (xs, Var.hash))
+            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
          fun hash2 (w1: Word.t, w2: Word.t) = Hash.combine [w1, w2]
       in
          val hash: t -> Word.t =

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -234,7 +234,7 @@ structure Type =
          val tuple = newHash ()
          val sequence = newHash ()
          fun hashProd (p, base) =
-            Hash.combine [base, Hash.combineVec (Vector.map (Prod.dest p, fn {elt, ...} => hash elt))]
+            Hash.combine [base, Hash.vectorMap (Prod.dest p, fn {elt, ...} => hash elt)]
       in
          fun object {args, con}: t =
             let
@@ -679,7 +679,7 @@ structure Exp =
          val select = newHash ()
          val tuple = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
+            Hash.combine [w, Hash.vectorMap (xs, Var.hash)]
       in
          val hash: t -> Word.t =
             fn Const c => Const.hash c
@@ -1170,7 +1170,7 @@ structure Transfer =
          val raisee = newHash ()
          val return = newHash ()
          fun hashVars (xs: Var.t vector, w: Word.t): Word.t =
-            Hash.combine [w, Hash.combineVec (Vector.map (xs, Var.hash))]
+            Hash.combine [w, Hash.vectorMap (xs, Var.hash)]
          fun hash2 (w1: Word.t, w2: Word.t) = Hash.combine [w1, w2]
       in
          val hash: t -> Word.t =

--- a/mlton/xml/monomorphise.fun
+++ b/mlton/xml/monomorphise.fun
@@ -52,7 +52,7 @@ structure Cache:
          val base = Random.word ()
       in
          fun hash ts =
-            Hash.combine [base, Hash.vectorMap (ts, Stype.hash)]
+            Hash.combine (base, Hash.vectorMap (ts, Stype.hash))
          fun equal (ts, ts') =
             Vector.equals (ts, ts', Stype.equals)
       end

--- a/mlton/xml/monomorphise.fun
+++ b/mlton/xml/monomorphise.fun
@@ -53,8 +53,7 @@ structure Cache:
          val base = Random.word ()
       in
          fun hash ts =
-            Vector.fold (ts, base, fn (t, w) =>
-                         Word.xorb (w * generator, Stype.hash t))
+            Hash.combineVec (Vector.map (ts, Stype.hash))
          fun equal (ts, ts') =
             Vector.equals (ts, ts', Stype.equals)
       end

--- a/mlton/xml/monomorphise.fun
+++ b/mlton/xml/monomorphise.fun
@@ -49,11 +49,10 @@ structure Cache:
       type 'a t = (Stype.t vector * Word.t * 'a) HashSet.t
 
       local
-         val generator: Word.t = 0wx5555
          val base = Random.word ()
       in
          fun hash ts =
-            Hash.combineVec (Vector.map (ts, Stype.hash))
+            Hash.combine [base, Hash.combineVec (Vector.map (ts, Stype.hash))]
          fun equal (ts, ts') =
             Vector.equals (ts, ts', Stype.equals)
       end

--- a/mlton/xml/monomorphise.fun
+++ b/mlton/xml/monomorphise.fun
@@ -52,7 +52,7 @@ structure Cache:
          val base = Random.word ()
       in
          fun hash ts =
-            Hash.combine [base, Hash.combineVec (Vector.map (ts, Stype.hash))]
+            Hash.combine [base, Hash.vectorMap (ts, Stype.hash)]
          fun equal (ts, ts') =
             Vector.equals (ts, ts', Stype.equals)
       end


### PR DESCRIPTION
This patch adds the structures Hash and HashTable. Several, but not all, existing passes have been made to use these structures, generally reducing code size.

HashTable serves as a wrapper to offer a simpler interface for the common usage of HashSets as key-value mappings.

Hash offers operations to combine word hashes. I've tested on self-compiles and speed of hashing appears relatively unchanged. It always uses a Foller-No-Voll-style hash (multiply then xor) everywhere. When updating all locations correctly, there does not seem to be a significant speed difference (from an unscientific test, <0.5% of pre-codegen time on a self-compile).