### PR TITLE
Support OpenBSD 6.4.

### DIFF
--- a/mlton/codegen/amd64-codegen/amd64-codegen.fun
+++ b/mlton/codegen/amd64-codegen/amd64-codegen.fun
@@ -76,7 +76,7 @@ struct
              * hold the C stack pointer.  We only need to do this in programs
              * that handle signals.
              *)
-            handlesSignals andalso let open Control.Target in !os = Cygwin end
+            let open Control.Target in !os = OpenBSD orelse (handlesSignals andalso !os = Cygwin) end
 
         val makeC = outputC
         val makeS = outputS

--- a/mlton/codegen/x86-codegen/x86-codegen.fun
+++ b/mlton/codegen/x86-codegen/x86-codegen.fun
@@ -76,7 +76,7 @@ struct
              * hold the C stack pointer.  We only need to do this in programs
              * that handle signals.
              *)
-            handlesSignals andalso let open Control.Target in !os = Cygwin end
+            let open Control.Target in !os = OpenBSD orelse (handlesSignals andalso !os = Cygwin) end
         
         val (picMungeLabel, picBase) = x86AllocateRegisters.picRelative ()
 

--- a/runtime/gc/signals.c
+++ b/runtime/gc/signals.c
@@ -26,7 +26,7 @@ void initSignalStack (GC_state s) {
 #if NEEDS_SIGALTSTACK_EXEC
     prot = prot | PROT_EXEC;
 #endif
-    void *ss_sp = GC_mmapAnon_safe_protect (NULL, 2 * ss_size, prot, psize, psize);
+    void *ss_sp = GC_mmapAnonStack (NULL, 2 * ss_size, prot, psize, psize);
     altstack.ss_sp = (void*)((pointer)ss_sp + ss_size);
     altstack.ss_size = ss_size;
     altstack.ss_flags = 0;

--- a/runtime/gc/virtual-memory.c
+++ b/runtime/gc/virtual-memory.c
@@ -7,16 +7,20 @@
  * See the file MLton-LICENSE for details.
  */
 
-void *GC_mmapAnon_safe (void *p, size_t length) {
+void *GC_mmapAnonFlags_safe (void *p, size_t length, int flags) {
   void *result;
 
-  result = GC_mmapAnon (p, length);
+  result = GC_mmapAnonFlags (p, length, flags);
   if ((void*)-1 == result) {
     GC_displayMem ();
     die ("Out of memory.  Unable to allocate %s bytes.\n",
          uintmaxToCommaString(length));
   }
   return result;
+}
+
+void *GC_mmapAnon_safe (void *p, size_t length) {
+  return GC_mmapAnonFlags_safe (p, length, 0);
 }
 
 static inline void GC_memcpy (pointer src, pointer dst, size_t size) {

--- a/runtime/platform.h
+++ b/runtime/platform.h
@@ -130,9 +130,17 @@ PRIVATE __attribute__ ((noreturn)) void MLton_heapCheckTooLarge (void);
 PRIVATE void GC_displayMem (void);
 
 PRIVATE void *GC_mmapAnon (void *start, size_t length);
+PRIVATE void *GC_mmapAnonFlags (void *start, size_t length, int flags);
 PRIVATE void *GC_mmapAnon_safe (void *start, size_t length);
+PRIVATE void *GC_mmapAnonFlags_safe (void *start, size_t length, int flags);
 PRIVATE void *GC_mmapAnon_safe_protect (void *start, size_t length, int prot,
-                                         size_t dead_low, size_t dead_high);
+                                        size_t dead_low, size_t dead_high);
+PRIVATE void *GC_mmapAnonStack (void *start, size_t length, int prot,
+                                size_t dead_low, size_t dead_high);
+PRIVATE void *GC_mmapAnonFlags_safe_protect (void *start, size_t length,
+                                             int prot, int flags,
+                                             size_t dead_low,
+                                             size_t dead_high);
 PRIVATE void *GC_mremap (void *start, size_t oldLength, size_t newLength);
 PRIVATE void GC_release (void *base, size_t length);
 

--- a/runtime/platform/mmap-protect.c
+++ b/runtime/platform/mmap-protect.c
@@ -1,8 +1,12 @@
-void *GC_mmapAnon_safe_protect (void *start, size_t length, int prot,
-                                size_t dead_low, size_t dead_high) {
+void *GC_mmapAnonFlags_safe_protect (void *start, size_t length,
+                                     int prot, int flags,
+                                     size_t dead_low,
+                                     size_t dead_high) {
         void *base,*low,*result,*high;
+        size_t totlen;
 
-        base = GC_mmapAnon_safe (start, length + dead_low + dead_high);
+        totlen = length + dead_low + dead_high;
+        base = GC_mmapAnonFlags_safe (start, totlen, flags);
         low = base;
         if (mprotect (low, dead_low, PROT_NONE))
                 diee ("mprotect failed");
@@ -13,4 +17,11 @@ void *GC_mmapAnon_safe_protect (void *start, size_t length, int prot,
         if (mprotect (high, dead_high, PROT_NONE))
                 diee ("mprotect failed");
         return result;
+}
+
+void *GC_mmapAnon_safe_protect (void *start, size_t length, int prot,
+                                size_t dead_low, size_t dead_high) {
+	return GC_mmapAnonFlags_safe_protect (start, length,
+	                                      prot, 0,
+	                                      dead_low, dead_high);
 }

--- a/runtime/platform/mmap.c
+++ b/runtime/platform/mmap.c
@@ -1,6 +1,10 @@
-static inline void *mmapAnon (void *start, size_t length) {
+static inline void *mmapAnonFlags (void *start, size_t length, int flags) {
         return mmap (start, length, PROT_READ | PROT_WRITE, 
-                        MAP_PRIVATE | MAP_ANON, -1, 0);
+                        MAP_PRIVATE | MAP_ANON | flags, -1, 0);
+}
+
+static inline void *mmapAnon (void *start, size_t length) {
+        return mmapAnonFlags (start, length, 0);
 }
 
 static void munmap_safe (void *base, size_t length) {

--- a/runtime/platform/openbsd.c
+++ b/runtime/platform/openbsd.c
@@ -5,7 +5,29 @@
 #include "mmap-protect.c"
 #include "nonwin.c"
 #include "sysctl.c"
-#include "use-mmap.c"
+#include "mmap.c"
+
+void GC_release (void *base, size_t length) {
+        munmap_safe (base, length);
+}
+
+void *GC_mmapAnon (void *start, size_t length) {
+        return mmapAnonFlags (start, length, MAP_STACK);
+}
+
+void *GC_mmapAnonFlags (void *start, size_t length, int flags) {
+	return mmapAnonFlags (start, length, flags | MAP_STACK);
+}
+
+void *GC_mmapAnonStack (void *start, size_t length, int prot,
+                        size_t dead_low, size_t dead_high) {
+	int flags = 0;
+#ifdef MAP_STACK
+	flags |= MAP_STACK;
+#endif
+	return GC_mmapAnonFlags_safe_protect (start, length, prot, flags,
+	                                   dead_low, dead_high);
+}
 
 static void catcher (__attribute__ ((unused)) int signo,
                      __attribute__ ((unused)) siginfo_t* info,

--- a/runtime/platform/use-mmap.c
+++ b/runtime/platform/use-mmap.c
@@ -7,3 +7,13 @@ void GC_release (void *base, size_t length) {
 void *GC_mmapAnon (void *start, size_t length) {
         return mmapAnon (start, length);
 }
+
+void *GC_mmapAnonFlags (void *start, size_t length, int flags) {
+	return mmapAnonFlags(start, length, flags);
+}
+
+void *GC_mmapAnonStack (void *start, size_t length, int prot,
+                        size_t dead_low, size_t dead_high) {
+	return GC_mmapAnonFlags_safe_protect (start, length, prot, 0,
+	                                      dead_low, dead_high);
+}


### PR DESCRIPTION
OpenBSD 6.4 introduced checking that the contents of the
hardware stack pointer point into a region of memory mapped
with the `MAP_STACK` mmap(2) flag.  If, on entry to the
kernel, the %rsp on AMD64 or %esp on x86 contain other data,
the program will be killed.

Without this, executables build with mlton such as `mllex`
were dumping core.

We support this by:

1) Unconditionally reserving %rsp/%esp in builds targeting
   OpenBSD.
2) Providing plumbing support for passing arbitrary flags
   when allocating a signal stack, and passing with the
   `MAP_STACK` flag down that plumbing when defined.

With these changes, building executables for OpenBSD seems
to work as expected.

Thanks to Matthew Fluet for pointing me at the existing
support for reserving %*sp for Cygwin.

Signed-off-by: Dan Cross <crossd@gmail.com>