### PR TITLE
Update TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,24 @@ dist: xenial
 
 addons:
   apt:
-    packages:
-      - mlton
+    packages: mlton
   homebrew:
-    packages:
-      - mlton
+    packages: mlton
 
 matrix:
   include:
   - os:   linux
-    env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=true
+    env:  CC=gcc    MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=true
   - os:   linux
-    env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
+    env:  CC=gcc    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
-    env:  CC=clang    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
+    env:  CC=clang  MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
-    env:  CC=clang    MLTON_COMPILE_ARGS="-codegen llvm"   REGRESSION=false
+    env:  CC=clang  MLTON_COMPILE_ARGS="-codegen llvm"   REGRESSION=false
   - os: osx
-    env:  CC=clang    MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=false
+    env:  CC=clang  MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=false
   - os: osx
-    env:  CC=clang    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
+    env:  CC=clang  MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
 
 script:
   - ./bin/travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ addons:
   apt:
     packages:
       - mlton
+  homebrew:
+    packages:
+      - mlton
 
 matrix:
   include:
@@ -23,10 +26,6 @@ matrix:
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=false
   - os: osx
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
-
-install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;        fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mlton; fi
 
 script:
   - ./bin/travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: generic
 
-sudo: required
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,40 +5,30 @@ sudo: required
 matrix:
   include:
   - os:   linux
-    dist: trusty
+    dist: xenial
     addons:
       apt:
-        update: true
-        sources:
-          - ubuntu-toolchain-r-test
         packages:
-          - gcc-5
           - mlton
-    env:  CC=gcc-5    MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=true
+    env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=true
   - os:   linux
-    dist: trusty
+    dist: xenial
     addons:
       apt:
-        update: true
-        sources:
-          - ubuntu-toolchain-r-test
         packages:
-          - gcc-5
           - mlton
-    env:  CC=gcc-5    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
+    env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
-    dist: trusty
+    dist: xenial
     addons:
       apt:
-        update: true
         packages:
           - mlton
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
-    dist: trusty
+    dist: xenial
     addons:
       apt:
-        update: true
         packages:
           - mlton
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen llvm"   REGRESSION=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: generic
 
+dist: xenial
+
 addons:
   apt:
     packages:
@@ -11,16 +13,12 @@ addons:
 matrix:
   include:
   - os:   linux
-    dist: xenial
     env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=true
   - os:   linux
-    dist: xenial
     env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
-    dist: xenial
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
-    dist: xenial
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen llvm"   REGRESSION=false
   - os: osx
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,24 @@ language: generic
 
 sudo: required
 
+addons:
+  apt:
+    packages:
+      - mlton
+
 matrix:
   include:
   - os:   linux
     dist: xenial
-    addons:
-      apt:
-        packages:
-          - mlton
     env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=true
   - os:   linux
     dist: xenial
-    addons:
-      apt:
-        packages:
-          - mlton
     env:  CC=gcc      MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
     dist: xenial
-    addons:
-      apt:
-        packages:
-          - mlton
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen c"      REGRESSION=false
   - os:   linux
     dist: xenial
-    addons:
-      apt:
-        packages:
-          - mlton
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen llvm"   REGRESSION=false
   - os: osx
     env:  CC=clang    MLTON_COMPILE_ARGS="-codegen amd64"  REGRESSION=false


### PR DESCRIPTION
Use Ubuntu Xenial (providing gcc 5.4), removing the need for an explicit `gcc-5` install.
Use `homebrew` addon, rather than `install` stage.
