### PR TITLE
Fix bug in simplification of `x -? x`

### DIFF
--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -2164,7 +2164,7 @@ fun ('a, 'b) apply (p: 'a t,
                               | Word_quot (s, _) => word (WordX.one s)
                               | Word_rem (s, _) => word (WordX.zero s)
                               | Word_sub s => word (WordX.zero s)
-                              | Word_subCheckP (s, _) => word (WordX.zero s)
+                              | Word_subCheckP _ => f
                               | Word_xorb s => word (WordX.zero s)
                               | _ => Unknown
                           end


### PR DESCRIPTION
A cut-n-paste error had `x -? x` returning `0`, rather than `false`.

Closes MLton/mlton#294 (introduced by 11c33d8).