### PR TITLE
Fix MinGW build

### DIFF
--- a/runtime/util.c
+++ b/runtime/util.c
@@ -8,5 +8,6 @@
 
 #include "util.h"
 
+#define MLTON_UTIL
 #include "util/die.c"
 #include "util/to-string.c"


### PR DESCRIPTION
This refixes #40. #40 was fixed in c8bdb29b911c48d4e295f393ff60c10742f89ce8, but again broken in e1825071074a499d96fc592063d9431bde6191c3.