### PR TITLE
Slightly improved rssa shrink

### DIFF
--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -836,9 +836,9 @@ structure Function =
                 (blocks, [],
                  fn (Block.T {args, kind, label, statements, transfer}, ac) =>
                  let
-                    val {inline, ...} = labelInfo label
+                    val {inline, occurrences, ...} = labelInfo label
                  in
-                    if !inline
+                    if !inline orelse 0 = !occurrences
                        then ac
                     else
                        let

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -819,12 +819,12 @@ structure Function =
             fun expand (ss: Statement.t vector list, t: Transfer.t)
                : Statement.t vector * Transfer.t =
                let
+                  fun getReplace l =
+                     case (! o #replace o labelInfo) l of
+                          SOME l' => getReplace l'
+                        | NONE => l
                   fun replaceTransfer t =
-                     Transfer.replaceLabels (t,
-                        fn l =>
-                           case (! o #replace o labelInfo) l of
-                                SOME l' => l'
-                              | NONE => l)
+                     Transfer.replaceLabels (t, getReplace)
                   fun done () = (Vector.concat (rev ss), replaceTransfer t)
                in
                   case t of

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -857,9 +857,9 @@ structure Function =
                 (blocks, [],
                  fn (Block.T {args, kind, label, statements, transfer}, ac) =>
                  let
-                    val {inline, occurrences, ...} = labelInfo label
+                    val {inline, occurrences, replace, ...} = labelInfo label
                  in
-                    if !inline orelse 0 = !occurrences
+                    if !inline orelse 0 = !occurrences orelse isSome (!replace)
                        then ac
                     else
                        let

--- a/mlton/backend/rssa.fun
+++ b/mlton/backend/rssa.fun
@@ -474,6 +474,23 @@ structure Transfer =
                      test = test})
       end
 
+      fun replaceLabels (t: t, f: Label.t -> Label.t): t =
+         case t of
+               CCall {args, func, return} =>
+                  CCall {args = args,
+                         func = func,
+                         return = Option.map (return, f)}
+             | Call {args, func, return} =>
+                  Call {args = args,
+                        func = func,
+                        return = Return.map (return, f)}
+             | Goto {args, dst} =>
+                  Goto {args = args,
+                        dst = f dst}
+             | Raise zs => Raise zs
+             | Return zs => Return zs
+             | Switch s => Switch (Switch.replaceLabels (s, f))
+
       fun replaceUses (t: t, f: Var.t -> Operand.t): t =
          let
             fun oper z = Operand.replaceVar (z, f)

--- a/mlton/backend/rssa.sig
+++ b/mlton/backend/rssa.sig
@@ -143,6 +143,7 @@ signature RSSA =
             (* in ifZero, the operand should be of type defaultWord *)
             val ifZero: Operand.t * {falsee: Label.t, truee: Label.t} -> t
             val layout: t -> Layout.t
+            val replaceLabels: t * (Label.t -> Label.t) -> t
             val replaceUses: t * (Var.t -> Operand.t) -> t
          end
 

--- a/mlton/backend/switch.fun
+++ b/mlton/backend/switch.fun
@@ -91,4 +91,8 @@ fun foreachLabel (s, f) =
    foldLabelUse (s, (), {label = f o #1,
                          use = fn _ => ()})
 
+fun replaceLabels (T {cases, default, size, test}, f) =
+   T {cases = Vector.map (cases, (fn (w, l) => (w, f l))),
+      default = Option.map (default, f),
+      size = size, test = test}
 end

--- a/mlton/backend/switch.sig
+++ b/mlton/backend/switch.sig
@@ -39,4 +39,5 @@ signature SWITCH =
       val isOk: t * {checkUse: Use.t -> unit,
                      labelIsOk: Label.t -> bool} -> bool
       val layout: t -> Layout.t
+      val replaceLabels: t * (Label.t -> Label.t) -> t
    end


### PR DESCRIPTION
All blocks with 0 occurences are deleted.
All blocks which do nothing but pass their arguments to another block are replaced by jumping to the target block (Most cases are 0 arguments, this handles the exact arguments in the same order for simplicity, which I did notice for some larger argument sets).
Specifically, it is those blocks which perform a fan-in that this would catch but not the inliner.

In theory there may be a block in this case which does nothing but profiling. There's no safe way to handle that that doesn't, but I don't imagine it's an issue in practice.

Here's a few quick sanity benchmarks. Most programs get a good improvement in size and compile time (and should also have improved RSSA output readability, which was half of the reason I wanted this). Boyer gets a 40% speedup for some god-awful reason. Some other programs change runtime by +-5% or are fib.

```
MLton0 -- ~/builds/master/bin/mlton
MLton1 -- ~/builds/shrink/bin/mlton
MLton2 -- ~/builds/master/bin/mlton -codegen c
MLton3 -- ~/builds/shrink/bin/mlton -codegen c
run time ratio
benchmark    MLton1 MLton2 MLton3
barnes-hut     1.01   1.03   1.02
boyer          0.63   1.01   0.62
checksum       1.00   0.96   0.97
count-graphs   0.96   0.77   0.82
DLXSimulator   1.01   1.02   1.01
even-odd       1.00   1.22   1.27
fft            0.98   0.93   0.88
fib            1.23   1.45   1.42
size
benchmark     MLton0  MLton1  MLton2  MLton3
barnes-hut   175,631 172,447 165,480 163,176
boyer        242,945 241,793 230,561 228,545
checksum     117,281 116,321 116,737 115,313
count-graphs 141,921 138,881 139,009 134,225
DLXSimulator 208,492 208,012 203,132 202,388
even-odd     117,105 116,497 116,737 115,553
fft          141,995 136,907 139,670 133,462
fib          117,025 116,401 116,609 115,489
compile time
benchmark    MLton0 MLton1 MLton2 MLton3
barnes-hut     2.94   2.91   3.56   3.51
boyer          3.35   3.31   5.83   5.49
checksum       2.47   2.42   2.63   2.44
count-graphs   2.75   2.58   3.02   2.94
DLXSimulator   3.28   3.16   4.18   4.11
even-odd       2.45   2.44   2.63   2.59
fft            2.57   2.34   2.85   2.78
fib            2.46   2.44   2.41   2.63
run time
benchmark    MLton0 MLton1 MLton2 MLton3
barnes-hut    28.68  29.09  29.42  29.25
boyer         56.46  35.29  57.04  35.21
checksum      25.33  25.23  24.44  24.49
count-graphs  40.56  38.92  31.26  33.20
DLXSimulator  32.50  32.75  32.99  32.86
even-odd      39.10  39.08  47.64  49.84
fft           31.79  31.26  29.68  27.88
fib           14.49  17.79  21.06  20.58
```
