### PR TITLE
Fix MLton/mlton#305

### DIFF
--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -1033,14 +1033,10 @@ let
                               val (dsts', srcs') =
                                  Vector.unzip
                                  (Vector.keepAllMap2
-                                  (args, srcs, fn ((arg, _), src) =>
-                                   case varOperandOpt arg of
+                                  (args, srcs, fn ((dst, _), src) =>
+                                   case varOperandOpt dst of
                                       NONE => NONE
-                                    | SOME dst =>
-                                         if Vector.exists (live, fn var =>
-                                                           M.Operand.equals (var, dst))
-                                            then SOME (dst, M.Operand.StackOffset src)
-                                            else NONE))
+                                    | SOME dst => SOME (dst, M.Operand.StackOffset src)))
                            in
                               (M.Kind.Cont {args = Vector.map (srcs, Live.StackOffset),
                                             frameInfo = valOf (frameInfo label)},
@@ -1069,14 +1065,10 @@ let
                               val (dsts', srcs') =
                                  Vector.unzip
                                  (Vector.keepAllMap2
-                                  (args, handles, fn ((arg, _), h) =>
-                                   case varOperandOpt arg of
+                                  (args, handles, fn ((dst, _), h) =>
+                                   case varOperandOpt dst of
                                       NONE => NONE
-                                    | SOME dst =>
-                                         if Vector.exists (live, fn var =>
-                                                           M.Operand.equals (var, dst))
-                                            then SOME (dst, Live.toOperand h)
-                                            else NONE))
+                                    | SOME dst =>SOME (dst, Live.toOperand h)))
                            in
                               (M.Kind.Handler
                                {frameInfo = valOf (frameInfo label),

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -445,6 +445,11 @@ let
       val varOperandOpt: Var.t -> M.Operand.t option =
          VarOperand.operand o #operand o varInfo
       val varOperand: Var.t -> M.Operand.t = valOf o varOperandOpt
+      val varOperand =
+         Trace.trace ("Backend.varOperand",
+                      Var.layout,
+                      M.Operand.layout)
+         varOperand
       (* Hash tables for uniquifying globals. *)
       local
          fun 'a make {equals: 'a * 'a -> bool,


### PR DESCRIPTION
Fix a bug that was introduced by 136f3573c and triggered by the RedPRL program.

An unused `Jump` block argument would not be assigned a location, but the translation of a `Goto` transfer to that block would demand the location (resulting in an uncaught `Option` exception).  The fix is straightforward: only copy the actual arguments that correspond to formal arguments that are used.

Also simplify the code to generate the prologue of `Cont` and `Handler` blocks.