### PR TITLE
Fix `Chunk<N>` prototype

### DIFF
--- a/include/c-common.h
+++ b/include/c-common.h
@@ -19,7 +19,7 @@
 #define ChunkName(n) Chunk ## n
 
 #define DeclareChunk(n)                         \
-        PRIVATE uintptr_t ChunkName(n)(CPointer gcState, Pointer stackTop, Pointer frontier, uintptr_t nextBlock)
+        PRIVATE uintptr_t ChunkName(n)(CPointer gcState, CPointer stackTop, CPointer frontier, uintptr_t nextBlock)
 
 #define Chunkp(n) &(ChunkName(n))
 


### PR DESCRIPTION
The `stackTop` and `frontier` arguments should be `CPointer`, not `Pointer`.