### PR TITLE
Change mutability keyword for SSA2 IR from 'ref' to 'mut'.

### DIFF
--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -67,7 +67,7 @@ structure Prod =
                  (mayAlign o separateRight)
                  (Vector.toListMap (dest p, fn {elt, isMutable} =>
                                     if isMutable
-                                       then seq [layoutElt elt, str " ref"]
+                                       then seq [layoutElt elt, str " mut"]
                                        else layoutElt elt),
                   ","),
                  str ")"]
@@ -79,7 +79,7 @@ structure Prod =
          in
             make <$>
             vector (parseElt >>= (fn elt =>
-                    optional (kw "ref") >>= (fn isMutable =>
+                    optional (kw "mut") >>= (fn isMutable =>
                     pure {elt = elt, isMutable = Option.isSome isMutable})))
 
          end


### PR DESCRIPTION
Ref may imply that the field is separately boxed,
whereas in the SSA2 IR, boxing is separate from mutability,
and is instead indicated by 'tuple' or another object type.

This should make the SSA2 object types easier to read correctly.