### PR TITLE
Eliminate global `MLton_FFI_opArgsResPtr`

### DIFF
--- a/basis-library/mlton/thread.sml
+++ b/basis-library/mlton/thread.sml
@@ -236,7 +236,7 @@ in
                fun workerLoop () =
                   let
                      (* Atomic 1 *)
-                     val p = Primitive.MLton.FFI.getOpArgsResPtr ()
+                     val p = Primitive.MLton.FFI.getOpArgsResPtr (gcState ())
                      val _ = atomicEnd ()
                      (* Atomic 0 *)
                      val i = MLtonPointer.getInt32 (MLtonPointer.getPointer (p, 0), 0)

--- a/basis-library/primitive/prim-mlton.sml
+++ b/basis-library/primitive/prim-mlton.sml
@@ -108,7 +108,7 @@ structure Exn =
 
 structure FFI =
    struct
-      val getOpArgsResPtr = #1 _symbol "MLton_FFI_opArgsResPtr" private: Pointer.t GetSet.t;
+      val getOpArgsResPtr = _import "GC_getCallFromCOpArgsResPtr" runtime private: GCState.t -> Pointer.t;
       val numExports = _build_const "MLton_FFI_numExports": Int32.int;
    end
 

--- a/include/amd64-main.h
+++ b/include/amd64-main.h
@@ -46,12 +46,13 @@ static GC_frameIndex returnAddressToFrameIndex (GC_returnAddress ra) {
 PRIVATE void MLton_jumpToSML (pointer jump);
 
 #define MLtonCallFromC()                                                \
-static void MLton_callFromC () {                                        \
+static void MLton_callFromC (CPointer localOpArgsResPtr) {              \
         pointer jump;                                                   \
         GC_state s = MLton_gcState();                                   \
                                                                         \
         if (DEBUG_AMD64CODEGEN)                                         \
                 fprintf (stderr, "MLton_callFromC() starting\n");       \
+        s->callFromCOpArgsResPtr = localOpArgsResPtr;                   \
         GC_setSavedThread (s, GC_getCurrentThread (s));                 \
         s->atomicState += 3;                                            \
         if (s->signalsInfo.signalIsPending)                             \

--- a/include/c-main.h
+++ b/include/c-main.h
@@ -23,11 +23,12 @@ static GC_frameIndex returnAddressToFrameIndex (GC_returnAddress ra) {
 }
 
 #define MLtonCallFromC()                                                \
-static void MLton_callFromC () {                                        \
+static void MLton_callFromC (CPointer localOpArgsResPtr) {              \
         uintptr_t nextBlock;                                            \
         GC_state s = MLton_gcState();                                   \
         if (DEBUG_CCODEGEN)                                             \
                 fprintf (stderr, "MLton_callFromC() starting\n");       \
+        s->callFromCOpArgsResPtr = localOpArgsResPtr;                   \
         GC_setSavedThread (s, GC_getCurrentThread (s));                 \
         s->atomicState += 3;                                            \
         if (s->signalsInfo.signalIsPending)                             \

--- a/include/x86-main.h
+++ b/include/x86-main.h
@@ -51,12 +51,13 @@ static GC_frameIndex returnAddressToFrameIndex (GC_returnAddress ra) {
 PRIVATE void MLton_jumpToSML (pointer jump);
 
 #define MLtonCallFromC()                                                \
-static void MLton_callFromC () {                                        \
+static void MLton_callFromC (CPointer localOpArgsResPtr) {              \
         pointer jump;                                                   \
         GC_state s = MLton_gcState();                                   \
                                                                         \
         if (DEBUG_X86CODEGEN)                                           \
                 fprintf (stderr, "MLton_callFromC() starting\n");       \
+        s->callFromCOpArgsResPtr = localOpArgsResPtr;                   \
         GC_setSavedThread (s, GC_getCurrentThread (s));                 \
         s->atomicState += 3;                                            \
         if (s->signalsInfo.signalIsPending)                             \

--- a/mlton/atoms/ffi.fun
+++ b/mlton/atoms/ffi.fun
@@ -91,8 +91,7 @@ fun declareExports {print} =
      end);
     if List.isEmpty (!exports)
        then ()
-       else (print "MLtonCallFromC ()\n";
-             print "PRIVATE Pointer MLton_FFI_opArgsResPtr;\n");
+       else print "MLtonCallFromC ()\n";
     List.foreach
     (!exports, fn {args, convention, id, name, res, symbolScope} =>
      let
@@ -105,7 +104,7 @@ fun declareExports {print} =
             in
                (concat [t, " ", x],
                 concat ["\tlocalOpArgsRes[", Int.toString (i + 1), "] = ",
-                        "(Pointer)(&", x, ");\n"])
+                        "(CPointer)(&", x, ");\n"])
             end)
         val (headerSymbolScope, symbolScope) =
            case symbolScope of
@@ -131,18 +130,17 @@ fun declareExports {print} =
      in
         List.push (headers, concat [headerSymbolScope, "(", prototype, ";)"])
         ; print (concat [symbolScope, " ", prototype, " {\n"])
-        ; print (concat ["\tPointer localOpArgsRes[", Int.toString n,"];\n"])
-        ; print (concat ["\tMLton_FFI_opArgsResPtr = (Pointer)(localOpArgsRes);\n"])
+        ; print (concat ["\tCPointer localOpArgsRes[", Int.toString n,"];\n"])
         ; print (concat ["\tInt32 localOp = ", Int.toString id, ";\n",
-                         "\tlocalOpArgsRes[0] = (Pointer)(&localOp);\n"])
+                         "\tlocalOpArgsRes[0] = (CPointer)(&localOp);\n"])
         ; Vector.foreach (args, fn (_, set) => print set)
         ; (case res of
               NONE => ()
             | SOME t =>
                  print (concat ["\t", CType.toString t, " localRes;\n",
                                 "\tlocalOpArgsRes[", Int.toString (Vector.length args + 1), "] = ",
-                                "(Pointer)(&localRes);\n"]))
-        ; print ("\tMLton_callFromC ();\n")
+                                "(CPointer)(&localRes);\n"]))
+        ; print ("\tMLton_callFromC (localOpArgsRes);\n")
         ; (case res of
               NONE => ()
             | SOME _ => print "\treturn localRes;\n")

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009,2012 Matthew Fluet.
+/* Copyright (C) 2009,2012,2019 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -161,6 +161,10 @@ pointer GC_getCallFromCHandlerThread (GC_state s) {
 void GC_setCallFromCHandlerThread (GC_state s, pointer p) {
   objptr op = pointerToObjptr (p, s->heap.start);
   s->callFromCHandlerThread = op;
+}
+
+pointer GC_getCallFromCOpArgsResPtr (GC_state s) {
+  return s->callFromCOpArgsResPtr;
 }
 
 pointer GC_getCurrentThread (GC_state s) {

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -27,6 +27,7 @@ struct GC_state {
   int atMLtonsLength;
   uint32_t atomicState;
   objptr callFromCHandlerThread; /* Handler for exported C calls (in heap). */
+  pointer callFromCOpArgsResPtr; /* Pass op, args, and res from exported C call */
   struct GC_callStackState callStackState;
   bool canMinor; /* TRUE iff there is space for a minor gc. */
   struct GC_controls controls;
@@ -99,6 +100,8 @@ PRIVATE size_t GC_getLastMajorStatisticsBytesLive (GC_state s);
 
 PRIVATE pointer GC_getCallFromCHandlerThread (GC_state s);
 PRIVATE void GC_setCallFromCHandlerThread (GC_state s, pointer p);
+PRIVATE pointer GC_getCallFromCOpArgsResPtr (GC_state s);
+
 PRIVATE pointer GC_getCurrentThread (GC_state s);
 PRIVATE pointer GC_getSavedThread (GC_state s);
 PRIVATE void GC_setSavedThread (GC_state s, pointer p);


### PR DESCRIPTION
Instead, introduce a `pointer callFromCOpArgsResPtr` field in `struct
GC_state`.  This makes the value per gcState, which minimizes the diff
between MLton and the CMU MultiMLton project.