### PR TITLE
Small engineering refactors, Counter & HashTable

### DIFF
--- a/benchmark/main.sml
+++ b/benchmark/main.sml
@@ -189,7 +189,7 @@ fun batch ab =
   concat [batch_ ab, ".sml"]
 
 local
-   val n = Counter.new 0
+   val next = Counter.generator 0
 in
    fun makeMLton commandPattern =
       case ChoicePattern.expand commandPattern of
@@ -198,7 +198,7 @@ in
             List.map
             (cmds, fn cmd =>
              let
-                val abbrv = "MLton" ^ (Int.toString (Counter.next n))
+                val abbrv = "MLton" ^ (Int.toString (next ()))
              in
                 {name = cmd,
                  abbrv = abbrv,

--- a/lib/mlton/basic/counter.sig
+++ b/lib/mlton/basic/counter.sig
@@ -10,10 +10,11 @@ signature COUNTER =
    sig
       type t
 
+      val equals: t * t -> bool
+      val generator: int -> (unit -> int)
       val new: int -> t
       val next: t -> int
-      val tick: t -> unit
       val reset: t * int -> unit
+      val tick: t -> unit
       val value: t -> int
-      val equals: t * t -> bool
    end

--- a/lib/mlton/basic/counter.sml
+++ b/lib/mlton/basic/counter.sml
@@ -23,4 +23,10 @@ fun next c = value c before tick c
 
 val equals = fn (T r, T r') => r = r'
 
+fun generator i =
+   let val c = new i
+   in
+      fn () => next c
+   end
+
 end

--- a/lib/mlton/basic/directed-graph.sml
+++ b/lib/mlton/basic/directed-graph.sml
@@ -145,12 +145,12 @@ fun layoutDot (T {nodes, ...},
                    title: string}): Layout.t =
    let
       val ns = !nodes
-      val c = Counter.new 0
+      val c = Counter.generator 0
       val {get = nodeId, rem, ...} =
          Property.get
          (Node.plist,
           Property.initFun
-          (fn _ => concat ["n", Int.toString (Counter.next c)]))
+          (fn _ => concat ["n", Int.toString (c ())]))
       val {edgeOptions, nodeOptions, options, title} =
          mkOptions {nodeName = nodeId}
       val nodes =
@@ -598,8 +598,8 @@ structure LoopForest =
                in
                   NodeOption.Label (loop ns)
                end
-            val c = Counter.new 0
-            fun newName () = concat ["n", Int.toString (Counter.next c)]
+            val c = Counter.generator 0
+            fun newName () = concat ["n", Int.toString (c ())]
             val nodes = ref []
             fun loop (T {loops, notInLoop}, root) =
                let
@@ -734,16 +734,16 @@ val stronglyConnectedComponents =
       then stronglyConnectedComponents
    else
    let
-      val c = Counter.new 0
+      val c = Counter.generator 0
    in
       fn g =>
       let
-         val nodeCounter = Counter.new 0
+         val nextNode = Counter.generator 0
          val {get = nodeIndex: Node.t -> int, destroy, ...} =
             Property.destGet
             (Node.plist,
-             Property.initFun (fn _ => Counter.next nodeCounter))
-         val index = Counter.next c
+             Property.initFun (nextNode o ignore))
+         val index = c ()
          val _ =
             File.withOut
             (concat ["graph", Int.toString index, ".dot"], fn out =>
@@ -1054,16 +1054,16 @@ val transpose =
       then transpose
    else
    let
-      val c = Counter.new 0
+      val c = Counter.generator 0
    in
       fn g =>
       let
-         val nodeCounter = Counter.new 0
+         val nextNode = Counter.generator 0
          val {get = nodeIndex: Node.t -> int, destroy, ...} =
             Property.destGet
             (Node.plist,
-             Property.initFun (fn _ => Counter.next nodeCounter))
-         val index = Counter.next c
+             Property.initFun (nextNode o ignore))
+         val index = c ()
          val _ =
             File.withOut
             (concat ["graph", Int.toString index, ".dot"], fn out =>

--- a/lib/mlton/basic/directed-sub-graph.sml
+++ b/lib/mlton/basic/directed-sub-graph.sml
@@ -219,12 +219,12 @@ fun layoutDot (g, {edgeOptions: Edge.t -> Dot.EdgeOption.t list,
                    options,
                    title}): Layout.t =
    let
-      val c = Counter.new 0
+      val c = Counter.generator 0
       val {get = nodeId, destroy, ...} =
          Property.destGet
          (Node.plist,
           Property.initFun
-          (fn _ => concat ["n", Int.toString (Counter.next c)]))
+          (fn _ => concat ["n", Int.toString (c ())]))
       val nodes =
          List.revMap
          (nodes g,
@@ -292,10 +292,10 @@ fun foreachDescendent (g, n, f) =
 
 (* fun removeBackEdges g =
  *    let
- *       val discoverTime = Counter.new 0
+ *       val discoverTime = Counter.generator 0
  *       val {get, destroy, ...} =
  *       Property.newDest
- *       (Node.plist, Property.initFun (fn _ => {time = Counter.next discoverTime,
+ *       (Node.plist, Property.initFun (fn _ => {time = discoverTime (),
  *                                              alive = ref true}))
  *       val ignore = DfsParam.ignore
  *    in dfs
@@ -616,11 +616,10 @@ fun dominators (graph, {root}) =
       val numNodes = List.length (nodes graph)
       val nodes = Array.new (numNodes, n0)
       fun ndfs i = Array.sub (nodes, i)
-      val dfnCounter = ref 0
+      val dfnCounter = Counter.new 0
       fun dfs (v: Node.t): unit =
          let
-            val i = !dfnCounter
-            val _ = Int.inc dfnCounter
+            val i = Counter.next dfnCounter
             val _ = dfn' v := i
             val _ = sdno' v := i
             val _ = Array.update (nodes, i, v)
@@ -639,7 +638,7 @@ fun dominators (graph, {root}) =
          end
       val _ = dfs root
       val _ =
-         if !dfnCounter = numNodes
+         if Counter.value dfnCounter = numNodes
             then ()
          else Error.bug "DirectedSubGraph.dominators: graph is not connected"
       (* compress ancestor path to node v to the node whose label has the

--- a/lib/mlton/basic/hash-table.sig
+++ b/lib/mlton/basic/hash-table.sig
@@ -10,7 +10,10 @@ signature HASH_TABLE =
    sig
       type ('a, 'b) t
 
-      val fold: ('a, 'b) t * 'c * (('a * 'b) * 'c -> 'c) -> 'c
+      val fold: ('a, 'b) t * 'c * ('b * 'c -> 'c) -> 'c
+      val foldi: ('a, 'b) t * 'c * ('a * 'b * 'c -> 'c) -> 'c
+      val foreach: ('a, 'b) t * ('b -> unit) -> unit
+      val foreachi: ('a, 'b) t * ('a * 'b -> unit) -> unit
       val insertIfNew: ('a, 'b) t * 'a * (unit -> 'b) * ('b -> unit) -> 'b
       val layout: ('a * 'b -> Layout.t) -> ('a, 'b) t -> Layout.t
       val lookupOrInsert: ('a, 'b) t * 'a * (unit -> 'b) -> 'b

--- a/lib/mlton/basic/hash-table.sml
+++ b/lib/mlton/basic/hash-table.sml
@@ -5,7 +5,7 @@
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
  *)
-structure HashTable: HASH_TABLE =
+structure HashTable:> HASH_TABLE =
 struct
 
 structure Set = HashSet
@@ -54,8 +54,14 @@ fun removeWhen (T {set, hash, equals, ...}, a, cond) =
 fun remove (t, a) = removeWhen (t, a, fn _ => true)
 fun removeAll (T {set, ...}, f) = Set.removeAll (set, f o toPair)
 
-fun fold (T {set, ...}, b, f) =
+fun foldi (T {set, ...}, b, f) =
    Set.fold (set, b, fn ({key, value, ...}, b) =>
-             f ((key, value), b))
+             f (key, value, b))
+fun fold (t, b, f) =
+   foldi (t, b, fn (_, v, b) => f (v, b))
+fun foreachi (T {set, ...}, f) =
+   Set.foreach (set, fn {key, value, ...} => f (key, value))
+fun foreach (t, f) =
+   foreachi (t, fn (_, v) => f v)
 
 end

--- a/lib/mlton/basic/string.sml
+++ b/lib/mlton/basic/string.sml
@@ -55,20 +55,14 @@ structure String: STRING =
 
       fun memoizeList (init: string -> 'a, l: (t * 'a) list): t -> 'a =
          let
-            val set: (word * t * 'a) HashSet.t = HashSet.new {hash = #1}
+            val set = HashTable.new {hash = hash, equals = equals}
             fun lookupOrInsert (s, f) =
-               let
-                  val hash = hash s
-               in HashSet.lookupOrInsert
-                  (set, hash,
-                   fn (hash', s', _) => hash = hash' andalso s = s',
-                   fn () => (hash, s, f ()))
-               end
+               HashTable.lookupOrInsert (set, s, f)
             val _ =
                List.foreach (l, fn (s, a) =>
                              ignore (lookupOrInsert (s, fn () => a)))
          in
-            fn s => #3 (lookupOrInsert (s, fn () => init s))
+            fn s => lookupOrInsert (s, fn () => init s)
          end
 
       fun memoize init = memoizeList (init, [])

--- a/mlton/atoms/c-function.fun
+++ b/mlton/atoms/c-function.fun
@@ -309,9 +309,9 @@ fun cPrototype (T {convention, prototype = (args, return), symbolScope, target,
          case target of
             Direct name => name
           | Indirect => Error.bug "CFunction.cPrototype: Indirect"
-      val c = Counter.new 0
+      val c = Counter.generator 0
       fun arg t =
-         concat [CType.toString t, " x", Int.toString (Counter.next c)]
+         concat [CType.toString t, " x", Int.toString (c ())]
       val return =
          case return of
             NONE => "void"

--- a/mlton/atoms/ffi.fun
+++ b/mlton/atoms/ffi.fun
@@ -15,20 +15,13 @@ structure Convention = CFunction.Convention
 structure SymbolScope = CFunction.SymbolScope
 
 local
-   val scopes: (Word.t * String.t * SymbolScope.t) HashSet.t = 
-      HashSet.new {hash = #1}
+   val scopes: (String.t, SymbolScope.t) HashTable.t =
+      HashTable.new {hash = String.hash, equals = String.equals}
 in
    fun checkScope {name, symbolScope} =
-      let
-         val hash = String.hash name
-      in
-         (#3 o HashSet.lookupOrInsert)
-         (scopes, hash,
-          fn (hash', name', _) =>
-          hash = hash' andalso name = name',
-          fn () =>
-          (hash, name, symbolScope))
-      end
+      HashTable.lookupOrInsert
+      (scopes, name,
+       fn () => symbolScope)
 end
 
 val exports: {args: CType.t vector,

--- a/mlton/atoms/ffi.fun
+++ b/mlton/atoms/ffi.fun
@@ -44,11 +44,11 @@ val symbols: {name: string,
 fun numExports () = List.length (!exports)
 
 local
-   val exportCounter = Counter.new 0
+   val nextId = Counter.generator 0
 in
    fun addExport {args, convention, name, res, symbolScope} =
       let
-         val id = Counter.next exportCounter
+         val id = nextId ()
          val _ = List.push (exports, {args = args,
                                       convention = convention,
                                       id = id,

--- a/mlton/atoms/id.fun
+++ b/mlton/atoms/id.fun
@@ -12,7 +12,7 @@ structure UniqueString:
       val unique: string -> string
    end =
    struct
-      val set: {counter: Counter.t,
+      val set: {next: unit -> int,
                 hash: word,
                 original: string} HashSet.t =
          HashSet.new {hash = #hash}
@@ -20,14 +20,14 @@ structure UniqueString:
       fun unique (s: string): string =
          let
             val hash = String.hash s
-            val {counter, ...} =
+            val {next, ...} =
                HashSet.lookupOrInsert
                (set, hash, fn {original, ...} => s = original,
-                fn () => {counter = Counter.new 0,
+                fn () => {next = Counter.generator 0,
                           hash = hash,
                           original = s})
          in
-            concat [s, "_", Int.toString (Counter.next counter)]
+            concat [s, "_", Int.toString (next ())]
          end
    end
 

--- a/mlton/atoms/id.fun
+++ b/mlton/atoms/id.fun
@@ -12,17 +12,17 @@ structure UniqueString:
       val unique: string -> string
    end =
    struct
-      val generators: (string, unit -> int) HashTable.t =
+      val counters: (string, Counter.t) HashTable.t =
          HashTable.new {hash = String.hash, equals = String.equals}
 
       fun unique (original: string): string =
          let
-            val next =
+            val c =
                HashTable.lookupOrInsert
-               (generators, original,
-                fn () => Counter.generator 0)
+               (counters, original,
+                fn () => Counter.new 0)
          in
-            concat [original, "_", Int.toString (next ())]
+            concat [original, "_", Int.toString (Counter.next c)]
          end
    end
 

--- a/mlton/atoms/id.fun
+++ b/mlton/atoms/id.fun
@@ -12,22 +12,17 @@ structure UniqueString:
       val unique: string -> string
    end =
    struct
-      val set: {next: unit -> int,
-                hash: word,
-                original: string} HashSet.t =
-         HashSet.new {hash = #hash}
+      val generators: (string, unit -> int) HashTable.t =
+         HashTable.new {hash = String.hash, equals = String.equals}
 
-      fun unique (s: string): string =
+      fun unique (original: string): string =
          let
-            val hash = String.hash s
-            val {next, ...} =
-               HashSet.lookupOrInsert
-               (set, hash, fn {original, ...} => s = original,
-                fn () => {next = Counter.generator 0,
-                          hash = hash,
-                          original = s})
+            val next =
+               HashTable.lookupOrInsert
+               (generators, original,
+                fn () => Counter.generator 0)
          in
-            concat [s, "_", Int.toString (next ())]
+            concat [original, "_", Int.toString (next ())]
          end
    end
 

--- a/mlton/atoms/prim.fun
+++ b/mlton/atoms/prim.fun
@@ -1159,31 +1159,22 @@ in
 end
 
 local
-   val table: {hash: word,
-               prim: unit t,
-               string: string} HashSet.t =
-      HashSet.new {hash = #hash}
+   val table : (string, unit t) HashTable.t =
+      HashTable.new {hash = String.hash, equals = String.equals}
    val () =
       List.foreach (all, fn prim =>
                     let
                        val string = toString prim
-                       val hash = String.hash string
-                       val _ =
-                          HashSet.lookupOrInsert (table, hash,
-                                                  fn _ => false,
-                                                  fn () => {hash = hash,
-                                                            prim = prim,
-                                                            string = string})
                     in
-                       ()
+                       (ignore o HashTable.lookupOrInsert)
+                       (table, string, fn () => prim)
                     end)
 in
    val fromString: string -> 'a t option =
       fn name =>
       Option.map
-      (HashSet.peek
-       (table, String.hash name, fn {string, ...} => name = string),
-       fn {prim, ...} => cast prim)
+      (HashTable.peek (table, name),
+       cast)
 end
 
 local

--- a/mlton/atoms/profile-label.fun
+++ b/mlton/atoms/profile-label.fun
@@ -24,10 +24,10 @@ functor ProfileLabel (S: PROFILE_LABEL_STRUCTS): PROFILE_LABEL =
          PropertyList.equals (plist pl1, plist pl2)
 
       local
-         val c = Counter.new 0
+         val c = Counter.generator 0
       in
          fun new () = T {plist = PropertyList.new (),
-                         uniq = Counter.next c}
+                         uniq = c ()}
       end
 
       fun toString pl = concat ["MLtonProfile", Int.toString (uniq pl)]

--- a/mlton/atoms/source-info.fun
+++ b/mlton/atoms/source-info.fun
@@ -73,22 +73,13 @@ in
 end
 
 local
-   val set: {hash: word,
-             name: string,
-             sourceInfo: t} HashSet.t =
-      HashSet.new {hash = #hash}
+   val table: (string, t) HashTable.t =
+      HashTable.new {equals = String.equals,
+                     hash = String.hash}
 in   
    fun fromC (name: string) =
-      let
-         val hash = String.hash name
-      in
-         #sourceInfo
-         (HashSet.lookupOrInsert
-          (set, hash, fn {hash = h, ...} => hash = h,
-           fn () => {hash = hash,
-                     name = name,
-                     sourceInfo = new (C name)}))
-      end
+      HashTable.lookupOrInsert
+      (table, name, fn () => new (C name))
 end
 
 fun function {name, region} =

--- a/mlton/atoms/symbol.fun
+++ b/mlton/atoms/symbol.fun
@@ -10,32 +10,26 @@ struct
 
 open S
 
-datatype t = T of {hash: word,
-                   name: string,
+datatype t = T of {name: string,
                    plist: PropertyList.t}
 
 local
    fun make f (T r) = f r
 in
-   val hash = make #hash
    val plist = make #plist
    val name = make #name
 end
 
-val table: t HashSet.t = HashSet.new {hash = hash}
+val table: (string, t) HashTable.t =
+   HashTable.new {equals = String.equals, hash = String.hash}
 
 fun fromString s =
-   let
-      val hash = String.hash s
-   in
-      HashSet.lookupOrInsert
-      (table, hash, fn T {name, ...} => s = name,
-       fn () => T {hash = hash,
-                   name = s,
-                   plist = PropertyList.new ()})
-   end
+   HashTable.lookupOrInsert
+   (table, s, fn () =>
+    T {name = s, 
+       plist = PropertyList.new ()})
 
-fun foreach f = HashSet.foreach (table, f)
+fun foreach f = HashTable.foreach (table, f)
 
 val toString = name
 

--- a/mlton/atoms/symbol.sig
+++ b/mlton/atoms/symbol.sig
@@ -25,7 +25,6 @@ signature SYMBOL =
       val equals: t * t -> bool
       val foreach: (t -> unit) -> unit
       val fromString: string -> t
-      val hash: t -> word
       val itt: t
       val layout: t -> Layout.t
       val plist: t -> PropertyList.t

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -340,8 +340,8 @@ fun toMachine (rssa: Rssa.Program.t) =
                    (table, value, fn () =>
                     M.Global.new (ty value)))
                fun all () =
-                  HashTable.fold
-                  (table, [], fn ((value, global), ac) =>
+                  HashTable.foldi
+                  (table, [], fn (value, global, ac) =>
                    (global, value) :: ac)
             in
                (all, get)

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -168,7 +168,7 @@ fun toMachine (rssa: Rssa.Program.t) =
       (* Frame info *)
       local
          val frameInfos: M.FrameInfo.t list ref = ref []
-         val frameInfosCounter = Counter.new 0
+         val nextFrameInfo = Counter.generator 0
          val _ = ByteSet.reset ()
          val table =
             let
@@ -188,14 +188,14 @@ fun toMachine (rssa: Rssa.Program.t) =
                               hash = hash}
             end
          val frameOffsets: M.FrameOffsets.t list ref = ref []
-         val frameOffsetsCounter = Counter.new 0
+         val nextFrameOffset = Counter.generator 0
          val {get = getFrameOffsets: ByteSet.t -> M.FrameOffsets.t, ...} =
             Property.get
             (ByteSet.plist,
              Property.initFun
              (fn offsets =>
               let
-                 val index = Counter.next frameOffsetsCounter
+                 val index = nextFrameOffset ()
                  val offsets =
                     QuickSort.sortVector
                     (Vector.fromList (ByteSet.toList offsets),
@@ -260,7 +260,7 @@ fun toMachine (rssa: Rssa.Program.t) =
                val frameOffsets = getFrameOffsets (ByteSet.fromList offsets)
                fun new () =
                   let
-                     val index = Counter.next frameInfosCounter
+                     val index = nextFrameInfo ()
                      val frameInfo =
                         M.FrameInfo.new
                         {frameOffsets = frameOffsets,

--- a/mlton/backend/implement-profiling.fun
+++ b/mlton/backend/implement-profiling.fun
@@ -154,7 +154,7 @@ fun transform program =
       val infoNodes: InfoNode.t list ref = ref []
       val sourceNames: string list ref = ref []
       local
-         val sourceNameCounter = Counter.new 0
+         val nextSourceName = Counter.generator 0
          val sep =
             if profile = ProfileCallStack
                then " "
@@ -164,15 +164,15 @@ fun transform program =
                           Property.initFun
                           (fn si =>
                            (List.push (sourceNames, SourceInfo.toString' (si, sep))
-                            ; Counter.next sourceNameCounter)))
-         val sourceCounter = Counter.new 0
-      in         
+                            ; nextSourceName ())))
+         val nextSource = Counter.generator 0
+      in
          fun sourceInfoNode (si: SourceInfo.t) =
             let
                val infoNode =
                   InfoNode.T {info = si,
                               sourceNameIndex = sourceNameIndex si,
-                              sourceIndex = Counter.next sourceCounter,
+                              sourceIndex = nextSource (),
                               successors = ref []}
                val _ = List.push (infoNodes, infoNode)
             in
@@ -270,7 +270,7 @@ fun transform program =
                {equals = equals,
                 hash = hash}
             end
-         val c = Counter.new 0
+         val c = Counter.generator 0
       in
          fun sourceSeqIndex (s: sourceSeq): int =
             let
@@ -279,7 +279,7 @@ fun transform program =
                HashTable.lookupOrInsert
                (table, s, fn () =>
                 (List.push (sourceSeqs, s)
-                 ; Counter.next c))
+                 ; c ()))
             end
       end
       (* Ensure that [SourceInfo.unknown] is index 0. *)

--- a/mlton/backend/implement-profiling.fun
+++ b/mlton/backend/implement-profiling.fun
@@ -270,7 +270,7 @@ fun transform program =
                {equals = equals,
                 hash = hash}
             end
-         val c = Counter.generator 0
+         val nextSourceSeqIndex = Counter.generator 0
       in
          fun sourceSeqIndex (s: sourceSeq): int =
             let
@@ -279,7 +279,7 @@ fun transform program =
                HashTable.lookupOrInsert
                (table, s, fn () =>
                 (List.push (sourceSeqs, s)
-                 ; c ()))
+                 ; nextSourceSeqIndex ()))
             end
       end
       (* Ensure that [SourceInfo.unknown] is index 0. *)

--- a/mlton/backend/objptr-tycon.fun
+++ b/mlton/backend/objptr-tycon.fun
@@ -20,9 +20,9 @@ in
 end
 
 local
-   val c = Counter.new 0
+   val c = Counter.generator 0
 in
-   fun new () = T {index = ref (Counter.next c)}
+   fun new () = T {index = ref (c ())}
 end
 
 fun setIndex (T {index = r}, i) = r := i

--- a/mlton/backend/rssa-restore.fun
+++ b/mlton/backend/rssa-restore.fun
@@ -238,18 +238,18 @@ fun restoreFunction {main: Function.t}
                   else ()
 
         (* init violations *)
-        val index = ref 0
+        val index = Counter.new 0
         val violations
           = Vector.fromListMap
             (!violations, fn x =>
              let
                val vi = varInfo x
-               val _ = VarInfo.index vi := (!index)
-               val _ = Int.inc index
+               val i = Counter.next index
+               val _ = VarInfo.index vi := i
              in
                x
              end)
-        val numViolations = !index
+        val numViolations = Counter.value index
 
         (* Diagnostics *)
         val _ = Control.diagnostics

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -663,13 +663,11 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
 
       val newObjectTypes = ref []
       local
-         val h = HashSet.new {hash = fn {bits, ...} =>
-                              Bits.toWord bits}
+         val h = HashTable.new {hash = Bits.toWord, equals = Bits.equals }
       in
          fun allocRawOpt width =
-            (#opt o HashSet.lookupOrInsert)
-            (h, Bits.toWord width,
-             fn {bits, ...} => Bits.equals (bits, width),
+            HashTable.lookupOrInsert
+            (h, width,
              fn () =>
              let
                 val rawElt = Type.bits width
@@ -677,11 +675,11 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                 val rawOpt = ObjptrTycon.new ()
                 val () =
                    ObjptrTycon.setIndex
-                   (rawOpt, Vector.length objectTypes + HashSet.size h)
+                   (rawOpt, Vector.length objectTypes + HashTable.size h)
                 val () =
                    List.push (newObjectTypes, rawTy)
              in
-                {bits = width, opt = rawOpt}
+                rawOpt
              end)
       end
 

--- a/mlton/codegen/amd64-codegen/amd64-liveness.fun
+++ b/mlton/codegen/amd64-codegen/amd64-liveness.fun
@@ -314,20 +314,20 @@ struct
             end
 
             local
-              val num = Counter.new 1
+              val nextNum = Counter.generator 1
             in
               fun topo_sort label
                 = let
                     val {topo, pred, ...} = getBlockInfo label
                   in
                     if !topo = 0
-                      then (topo := Counter.next num;
+                      then (topo := nextNum ();
                             push_todo label;
                             List.foreach(!pred, topo_sort))
                       else ()
                   end
               fun topo_root label
-                = (get_topo label := Counter.next num;
+                = (get_topo label := nextNum ();
                    push_todo label)
             end
 

--- a/mlton/codegen/amd64-codegen/amd64.fun
+++ b/mlton/codegen/amd64-codegen/amd64.fun
@@ -695,7 +695,7 @@ struct
     struct
       structure Class =
         struct
-          val counter = Counter.new 0
+          val nextCounter = Counter.generator 0
           datatype t = T of {counter: int,
                              name: string}
 
@@ -709,7 +709,7 @@ struct
 
           fun new {name}
             = let
-                val class = T {counter = Counter.next counter,
+                val class = T {counter = nextCounter (),
                                name = name}
               in
                 class
@@ -848,7 +848,7 @@ struct
            => utilized
 
       local
-        val counter = Counter.new 0
+        val nextCounter = Counter.generator 0
         val table: t HashSet.t ref = ref (HashSet.new {hash = hash})
       in
         val construct 
@@ -863,7 +863,7 @@ struct
                    fn () => T {memloc = memloc,
                                hash = hash,
                                plist = PropertyList.new (),
-                               counter = Counter.next counter,
+                               counter = nextCounter (),
                                utilized = utilizedU memloc})
                 end
 
@@ -1160,14 +1160,13 @@ struct
            end
 
       local
-        val num : int ref = ref 0
+        val nextNum = Counter.generator 0
       in
-        val temp = fn {size} => (Int.inc num;
-                                 imm {base = Immediate.zero,
-                                      index = Immediate.int (!num),
-                                      scale = Scale.One,
-                                      size = size,
-                                      class = Class.Temp})
+        val temp = fn {size} => imm {base = Immediate.zero,
+                                     index = Immediate.int (nextNum ()),
+                                     scale = Scale.One,
+                                     size = size,
+                                     class = Class.Temp}
       end
 
       (*
@@ -2653,16 +2652,11 @@ struct
     struct
       structure Id = 
         struct
-          val num : int ref = ref 0
+          val nextNum = Counter.generator 0
           datatype t = T of {num : int,
                              plist: PropertyList.t}
-          fun new () = let
-                         val id = T {num = !num,
-                                     plist = PropertyList.new ()}
-                         val _ = Int.inc num
-                       in
-                         id
-                       end
+          fun new () = T {num = nextNum (),
+                          plist = PropertyList.new ()}
           val plist = fn T {plist, ...} => plist
           val layout
             = let

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -859,7 +859,7 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, ...},
                      then
                         let
                            val _ = print "\t{\n"
-                           val c = Counter.new 0
+                           val c = Counter.generator 0
                            val args =
                               Vector.toListMap
                               (args, fn z =>
@@ -869,7 +869,7 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, ...},
                                         val ty = Operand.ty z
                                         val tmp =
                                            concat ["tmp",
-                                                   Int.toString (Counter.next c)]
+                                                   Int.toString (c ())]
                                         val _ =
                                            print
                                            (concat

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -859,7 +859,7 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, ...},
                      then
                         let
                            val _ = print "\t{\n"
-                           val c = Counter.generator 0
+                           val nextTmp = Counter.generator 0
                            val args =
                               Vector.toListMap
                               (args, fn z =>
@@ -869,7 +869,7 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, ...},
                                         val ty = Operand.ty z
                                         val tmp =
                                            concat ["tmp",
-                                                   Int.toString (c ())]
+                                                   Int.toString (nextTmp ())]
                                         val _ =
                                            print
                                            (concat

--- a/mlton/codegen/llvm-codegen/llvm-codegen.fun
+++ b/mlton/codegen/llvm-codegen/llvm-codegen.fun
@@ -278,18 +278,10 @@ fun mkload (lhs, ty, arg) = concat ["\t", lhs, " = load ", getTypeFromPointer ty
  *)
 fun mkstore (ty, arg, loc) = concat ["\tstore ", ty, " ", arg, ", ", ty, "* ", loc, "\n"]
 
-val temporaryNum = ref 0
+val tempCounter = Counter.new 0
 
-fun getAndIncTemp () =
-   let
-      val i = !temporaryNum
-      val () = Int.inc temporaryNum
-   in
-      i
-   end
-
-fun resetLLVMTemp () = temporaryNum := 0
-fun nextLLVMTemp () = concat ["%t", Int.toString (getAndIncTemp ())]
+fun resetLLVMTemp () = Counter.reset (tempCounter, 0)
+fun nextLLVMTemp () = concat ["%t", Int.toString (Counter.next tempCounter)]
 
 fun temporaryName (ty: CType.t, index: int): string =
     concat ["%temp", CType.name ty, "_", Int.toString index]

--- a/mlton/codegen/x86-codegen/x86-generate-transfers.fun
+++ b/mlton/codegen/x86-codegen/x86-generate-transfers.fun
@@ -465,25 +465,17 @@ struct
                                    {registers = [Register.esp]})
 
         local
-           val set: (word * String.t * Label.t) HashSet.t =
-              HashSet.new {hash = #1}
+           val set: (String.t, Label.t) HashTable.t =
+              HashTable.new {hash = String.hash, equals = String.equals}
         in
            fun makeDarwinSymbolStubLabel name =
-              let
-                 val hash = String.hash name
-              in
-                 (#3 o HashSet.lookupOrInsert)
-                 (set, hash,
-                  fn (hash', name', _) =>
-                  hash = hash' andalso name = name',
-                  fn () =>
-                  (hash, name,
-                   Label.newString (concat ["L_", name, "_stub"])))
-              end
+               (HashTable.lookupOrInsert)
+               (set, name, fn () =>
+                Label.newString (concat ["L_", name, "_stub"]))
 
            fun makeDarwinSymbolStubs () =
-              HashSet.fold
-              (set, [], fn ((_, name, label), assembly) =>
+              HashTable.foldi
+              (set, [], fn (name, label, assembly) =>
                  (Assembly.pseudoop_symbol_stub ()) ::
                  (Assembly.label label) ::
                  (Assembly.pseudoop_indirect_symbol (Label.fromString name)) ::

--- a/mlton/codegen/x86-codegen/x86-liveness.fun
+++ b/mlton/codegen/x86-codegen/x86-liveness.fun
@@ -314,20 +314,20 @@ struct
             end
 
             local
-              val num = Counter.new 1
+              val nextNum = Counter.generator 1
             in
               fun topo_sort label
                 = let
                     val {topo, pred, ...} = getBlockInfo label
                   in
                     if !topo = 0
-                      then (topo := Counter.next num;
+                      then (topo := nextNum ();
                             push_todo label;
                             List.foreach(!pred, topo_sort))
                       else ()
                   end
               fun topo_root label
-                = (get_topo label := Counter.next num;
+                = (get_topo label := nextNum ();
                    push_todo label)
             end
 

--- a/mlton/codegen/x86-codegen/x86.fun
+++ b/mlton/codegen/x86-codegen/x86.fun
@@ -549,7 +549,7 @@ struct
     struct
       structure Class =
         struct
-          val counter = Counter.new 0
+          val nextCounter = Counter.generator 0
           datatype t = T of {counter: int,
                              name: string}
 
@@ -563,7 +563,7 @@ struct
 
           fun new {name}
             = let
-                val class = T {counter = Counter.next counter,
+                val class = T {counter = nextCounter (),
                                name = name}
               in
                 class
@@ -701,7 +701,7 @@ struct
            => utilized
 
       local
-        val counter = Counter.new 0
+        val nextCounter = Counter.generator 0
         val table: t HashSet.t ref = ref (HashSet.new {hash = hash})
       in
         val construct 
@@ -716,7 +716,7 @@ struct
                    fn () => T {memloc = memloc,
                                hash = hash,
                                plist = PropertyList.new (),
-                               counter = Counter.next counter,
+                               counter = nextCounter (),
                                utilized = utilizedU memloc})
                 end
 
@@ -1013,14 +1013,13 @@ struct
            end
 
       local
-        val num : int ref = ref 0
+        val nextNum = Counter.generator 0
       in
-        val temp = fn {size} => (Int.inc num;
-                                 imm {base = Immediate.zero,
-                                      index = Immediate.int (!num),
-                                      scale = Scale.One,
-                                      size = size,
-                                      class = Class.Temp})
+        val temp = fn {size} => imm {base = Immediate.zero,
+                                     index = Immediate.int (nextNum ()),
+                                     scale = Scale.One,
+                                     size = size,
+                                     class = Class.Temp}
       end
 
       (*
@@ -2881,16 +2880,11 @@ struct
     struct
       structure Id = 
         struct
-          val num : int ref = ref 0
+          val nextNum = Counter.generator 0
           datatype t = T of {num : int,
                              plist: PropertyList.t}
-          fun new () = let
-                         val id = T {num = !num,
-                                     plist = PropertyList.new ()}
-                         val _ = Int.inc num
-                       in
-                         id
-                       end
+          fun new () = T {num = nextNum (),
+                          plist = PropertyList.new ()}
           val plist = fn T {plist, ...} => plist
           val layout
             = let

--- a/mlton/elaborate/elaborate-env.fun
+++ b/mlton/elaborate/elaborate-env.fun
@@ -1266,9 +1266,7 @@ structure Time:>
 
       val op >= : t * t -> bool = op >=
 
-      val c = Counter.new 0
-
-      fun next () = Counter.next c
+      val next = Counter.generator 0
 
       val next = 
          Trace.trace 

--- a/mlton/elaborate/type-env.fun
+++ b/mlton/elaborate/type-env.fun
@@ -369,11 +369,7 @@ structure Unknown =
 
       fun equals (u, u') = id u = id u'
 
-      local
-         val c = Counter.new 0
-      in
-         val newId = fn () => Counter.next c
-      end
+      val newId = Counter.generator 0
 
       fun new {canGeneralize} =
          T {canGeneralize = canGeneralize,
@@ -408,11 +404,7 @@ structure Spine:
                          body: {fields: Field.t list ref,
                                 more: bool ref} Set.t}
 
-      local
-         val c = Counter.new 0
-      in
-         val newId = fn () => Counter.next c
-      end
+      val newId = Counter.generator 0
       
       fun new fields = T {id = newId (),
                           body = Set.singleton {fields = ref fields,

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1552,11 +1552,10 @@ fun commandLine (args: string list): unit =
                   fun compileSrc sel =
                      let
                         val outputs: File.t list ref = ref []
-                        val r = ref 0
+                        val r = Counter.generator 0
                         fun make (style: style, suf: string) () =
                            let
-                              val suf = concat [".", Int.toString (!r), suf]
-                              val _ = Int.inc r
+                              val suf = concat [".", Int.toString (r ()), suf]
                               val file = (if !keepGenerated
                                              orelse stop = Place.Generated
                                              then maybeOutBase

--- a/mlton/ssa/common-subexp.fun
+++ b/mlton/ssa/common-subexp.fun
@@ -31,9 +31,9 @@ fun transform (Program.T {globals, datatypes, functions, main}) =
                               Property.initRaise ("varIndex", Var.layout))
       val setVarIndex =
          let
-            val c = Counter.new 0
+            val c = Counter.generator 0
          in
-            fn x => setVarIndex (x, Counter.next c)
+            fn x => setVarIndex (x, c ())
          end
       (* Keep track of the replacements of variables. *)
       val {get = replace: Var.t -> Var.t option, set = setReplace, ...} =

--- a/mlton/ssa/duplicate-globals.fun
+++ b/mlton/ssa/duplicate-globals.fun
@@ -121,15 +121,13 @@ struct
                   end
                (* globals that are used in other globals,
                 * we want to avoid duplicating to help reduce churn/improve diagonstic data *)
-               val usedGlobals: Var.t HashSet.t =
-                  HashSet.new {hash=Var.hash}
+               val usedGlobals: (Var.t, unit) HashTable.t =
+                  HashTable.new {equals=Var.equals, hash=Var.hash}
                val _ = Vector.map (globals, fn Statement.T {exp, ...} =>
                   Exp.foreachVar (exp, fn var =>
-                        ignore (HashSet.lookupOrInsert (usedGlobals, Var.hash var,
-                           fn var' => Var.equals (var, var'),
-                           fn () => var))))
+                        ignore (HashTable.lookupOrInsert (usedGlobals, var, ignore))))
                fun isUsedInGlobals global =
-                  case HashSet.peek (usedGlobals, Var.hash global, fn var' => Var.equals (global, var')) of
+                  case HashTable.peek (usedGlobals, global) of
                        NONE => false
                      | SOME _ => true
                fun shouldKeepOriginal (Statement.T {var=varOpt, ...}) =

--- a/mlton/ssa/global.fun
+++ b/mlton/ssa/global.fun
@@ -44,24 +44,19 @@ fun make () =
                     (!binds, fn {var, ty, exp} =>
                      Statement.T {var = SOME var, ty = ty, exp = exp}))
                    before binds := []
-      val set: (word * bind) HashSet.t = HashSet.new {hash = #1}
+      val table: (Exp.t, bind) HashTable.t =
+         HashTable.new {equals = expEquals,
+                        hash = Exp.hash}
       fun new (ty: Type.t, exp: Exp.t): Var.t =
-         let
-            val hash = hash exp
-         in
-            #var
-            (#2
-             (HashSet.lookupOrInsert
-              (set, hash,
-               fn (_, {exp = exp', ...}) => expEquals (exp, exp'),
-               fn () => 
-               let
-                  val x = Var.newString "global"
-                  val bind = {var = x, ty = ty, exp = exp}
-               in List.push (binds, bind)
-                  ; (hash, bind)
-               end)))
-         end
+         #var
+         (HashTable.lookupOrInsert
+          (table, exp, fn () =>
+           let
+              val x = Var.newString "global"
+              val bind = {var = x, ty = ty, exp = exp}
+           in List.push (binds, bind)
+              ; bind
+           end))
    in {new = new, all = all}
    end
 end

--- a/mlton/ssa/loop-unroll.fun
+++ b/mlton/ssa/loop-unroll.fun
@@ -20,9 +20,6 @@ in
   structure Forest = LoopForest
 end
 
-fun ++ (v: int ref): unit =
-  v := (!v) + 1
-
 
 structure Histogram =
   struct
@@ -53,18 +50,18 @@ structure Histogram =
       end
   end
 
-val loopCount = ref 0
-val optCount = ref 0
-val total = ref 0
-val partial = ref 0
-val multiHeaders = ref 0
-val varEntryArg = ref 0
-val variantTransfer = ref 0
-val unsupported = ref 0
-val ccTransfer = ref 0
-val varBound = ref 0
-val infinite = ref 0
-val boundDom = ref 0
+val loopCount = Counter.new 0
+val optCount = Counter.new 0
+val total = Counter.new 0
+val partial = Counter.new 0
+val multiHeaders = Counter.new 0
+val varEntryArg = Counter.new 0
+val variantTransfer = Counter.new 0
+val unsupported = Counter.new 0
+val ccTransfer = Counter.new 0
+val varBound = Counter.new 0
+val infinite = Counter.new 0
+val boundDom = Counter.new 0
 val histogram = ref (Histogram.new ())
 
 type BlockInfo = Label.t * (Var.t * Type.t) vector
@@ -317,8 +314,8 @@ fun logsi (s: string, i: int): unit =
 fun logs (s: string): unit =
    logsi(s, 0)
 
-fun logstat (x: int ref, s: string): unit =
-  logs (concat[Int.toString(!x), " ", s])
+fun logstat (x: Counter.t, s: string): unit =
+  logs (concat [Int.toString(Counter.value x), " ", s])
 
 fun listPop lst =
   case lst of
@@ -535,7 +532,7 @@ fun checkArg ((argVar, _), argIndex, entryArg, header, loopBody,
               loadVar: Var.t * bool -> IntInf.t option, domInfo, depth) =
    case entryArg of
       NONE => (logsi ("Can't unroll: entry arg not constant", depth) ;
-               ++varEntryArg ;
+               Counter.tick varEntryArg ;
                NONE)
    | SOME (entryX, entryXSigned) =>
       let
@@ -581,12 +578,12 @@ fun checkArg ((argVar, _), argIndex, entryArg, header, loopBody,
                         end))
          then
             (logsi ("Can't unroll: variant transfer to head of loop", depth) ;
-             ++variantTransfer ;
+             Counter.tick variantTransfer ;
              NONE)
          else if (!unsupportedTransfer) then
             (logsi ("Can't unroll: unsupported transfer to head of loop",
                     depth) ;
-             ++unsupported ;
+             Counter.tick unsupported ;
              NONE)
          else
             let
@@ -595,7 +592,7 @@ fun checkArg ((argVar, _), argIndex, entryArg, header, loopBody,
                case varChain (argVar, loopVar, loopBody, loadVar, x) of
                  NONE => (logsi ("Can't unroll: can't compute transfer",
                                  depth) ; 
-                          ++ccTransfer ;
+                          Counter.tick ccTransfer ;
                           NONE)
                | SOME (step) =>
                   let
@@ -664,7 +661,7 @@ fun checkArg ((argVar, _), argIndex, entryArg, header, loopBody,
                     case transferVarBlock of
                       NONE =>
                         (logsi ("Can't unroll: can't determine bound", depth) ;
-                         ++varBound ;
+                         Counter.tick varBound ;
                          NONE)
                     | SOME(bound, block, signed) =>
                         let
@@ -690,7 +687,7 @@ fun checkArg ((argVar, _), argIndex, entryArg, header, loopBody,
                                           invert = not contIsTrue})
                           else
                             (logsi ("Can't unroll: bound doesn't dominate", depth) ;
-                             ++boundDom ;
+                             Counter.tick boundDom ;
                              NONE)
                         end
                   end
@@ -782,7 +779,7 @@ fun findOpportunity(functionBody: Block.t vector,
       end
    else
       (logsi ("Can't optimize: loop has more than 1 header", depth) ;
-       multiHeaders := (!multiHeaders) + 1 ;
+       Counter.tick multiHeaders;
        NONE)
 
 fun makeHeader(oldHeader, (newVars, newStmts), newEntry) =
@@ -1076,7 +1073,7 @@ fun expandLoop (oldHeader, loopBlocks, loop, tBlock, argi, argSize, oldArg,
 fun optimizeLoop(allBlocks, headerNodes, loopNodes,
                  nodeBlock, loadGlobal, domInfo, depth) =
    let
-      val () = ++loopCount
+      val () = Counter.tick loopCount
       val headers = Vector.map (headerNodes, nodeBlock)
       val loopBlocks = Vector.map (loopNodes, nodeBlock)
       val loopBlockNames = Vector.map (loopBlocks, Block.label)
@@ -1092,13 +1089,13 @@ fun optimizeLoop(allBlocks, headerNodes, loopNodes,
       | SOME (argi, tBlock, loop) =>
           if Loop.isInfiniteLoop loop then
             (logsi ("Can't unroll: infinite loop", depth) ;
-             ++infinite ;
+             Counter.tick infinite ;
              logsi (concat["Index: ", Int.toString argi, Loop.toString loop],
                     depth) ;
              ([], []))
           else
             let
-              val () = ++optCount
+              val () = Counter.tick optCount
               val oldHeader = Vector.sub (headers, 0)
               val oldArgs = Block.args oldHeader
               val (oldArg, oldType) = Vector.sub (oldArgs, argi)
@@ -1122,7 +1119,7 @@ fun optimizeLoop(allBlocks, headerNodes, loopNodes,
             in
               if totalUnroll then
                 let
-                  val () = ++total
+                  val () = Counter.tick total
                   val () = logsi ("Completely unrolling loop", depth)
                   val newEntry = Label.newNoname()
                   val (newHeader, argLabels) =
@@ -1153,7 +1150,7 @@ fun optimizeLoop(allBlocks, headerNodes, loopNodes,
                 end
               else
                 let
-                  val () = ++partial
+                  val () = Counter.tick partial
                   val () = logsi ("Partially unrolling loop", depth)
                   val () = logsi (concat["Body expansion: ",
                                          IntInf.toString exBody,
@@ -1360,18 +1357,11 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                       | _ => NONE)
                 | _ => NONE)
          end
-      val () = loopCount := 0
-      val () = total := 0
-      val () = partial := 0
-      val () = optCount := 0
-      val () = multiHeaders := 0
-      val () = varEntryArg := 0
-      val () = variantTransfer := 0
-      val () = unsupported := 0
-      val () = ccTransfer := 0
-      val () = varBound := 0
-      val () = infinite := 0
-      val () = boundDom := 0
+      val () =
+        List.foreach
+        ([loopCount, total, partial, optCount, multiHeaders, varEntryArg,
+          variantTransfer, unsupported, ccTransfer, varBound, infinite, boundDom],
+         fn c => Counter.reset (c, 0))
       val () = histogram := Histogram.new ()
       val () = logs (concat["Unrolling loops. Unrolling factor = ",
                     Int.toString (!Control.loopUnrollLimit)])

--- a/mlton/ssa/loop-unroll.fun
+++ b/mlton/ssa/loop-unroll.fun
@@ -26,23 +26,22 @@ fun ++ (v: int ref): unit =
 
 structure Histogram =
   struct
-    type t = (IntInf.t * int ref) HashSet.t
+    type t = (IntInf.t, int ref) HashTable.t
 
     fun inc (set: t, key: IntInf.t): unit =
       let
-        val _ = HashSet.insertIfNew (set, IntInf.hash key,
-                                     (fn (k, _) => k = key),
-                                     (fn () => (key, ref 1)),
-                                     (fn (_, r) => ++r))
+        val _ = HashTable.insertIfNew (set, key,
+                                       (fn () => ref 1),
+                                       Int.inc)
       in
         ()
       end
 
     fun new (): t =
-      HashSet.new {hash = fn (k, _) => IntInf.hash k}
+      HashTable.new {hash = IntInf.hash, equals = IntInf.equals}
 
     fun toList (set: t): (IntInf.t * int ref) list =
-      HashSet.toList set
+      HashTable.toList set
 
     fun toString (set: t) : string =
       let

--- a/mlton/ssa/restore.fun
+++ b/mlton/ssa/restore.fun
@@ -246,18 +246,17 @@ fun restoreFunction {globals: Statement.t vector}
                   else ()
 
         (* init violations *)
-        val index = ref 0
+        val index = Counter.new 0
         val violations
           = Vector.fromListMap
             (!violations, fn x =>
              let
                val vi = varInfo x
-               val _ = VarInfo.index vi := (!index)
-               val _ = Int.inc index
+               val _ = VarInfo.index vi := (Counter.next index)
              in
                x
              end)
-        val numViolations = !index
+        val numViolations = Counter.value index
 
         (* Diagnostics *)
         val _ = Control.diagnostics

--- a/mlton/ssa/restore.fun
+++ b/mlton/ssa/restore.fun
@@ -523,11 +523,14 @@ fun restoreFunction {globals: Statement.t vector}
                            exp = exp}
             end
         local
-          type t = {dst: Label.t,
-                    phiArgs: Var.t vector,
-                    route: Label.t,
-                    hash: Word.t}
-          val routeTable : t HashSet.t = HashSet.new {hash = #hash}
+          val routeTable: ({dst: Label.t, phiArgs: Var.t vector}, Label.t) HashTable.t =
+             HashTable.new {equals = (fn ({dst = dst1, phiArgs = phiArgs1},
+                                          {dst = dst2, phiArgs = phiArgs2}) =>
+                                      Label.equals (dst1, dst2)
+                                      andalso
+                                      Vector.equals (phiArgs1, phiArgs2, Var.equals)),
+                            hash = (fn {dst, phiArgs} =>
+                                    Hash.combine (Label.hash dst, Hash.vectorMap (phiArgs, Var.hash)))}
         in
           fun route dst
             = let
@@ -539,38 +542,28 @@ fun restoreFunction {globals: Statement.t vector}
                   else let
                          val phiArgs = Vector.map
                                         (phiArgs, valOf o VarInfo.peekVar o varInfo)
-                         val hash = Hash.combine (Label.hash dst, Hash.vectorMap (phiArgs, Var.hash))
-                         val {route, ...} 
-                           = HashSet.lookupOrInsert
-                             (routeTable, hash, 
-                              fn {dst = dst', phiArgs = phiArgs', ... } =>
-                              Label.equals (dst, dst') 
-                              andalso
-                              Vector.equals (phiArgs, phiArgs', Var.equals),
-                              fn () =>
-                              let
-                                val route = Label.new dst
-                                val args = Vector.map 
-                                           (LabelInfo.args' li, fn (x,ty) =>
-                                            (Var.new x, ty))
-                                val args' = Vector.concat 
-                                            [Vector.map(args, #1),
-                                             phiArgs]
-                                val block = Block.T
-                                            {label = route,
-                                             args = args,
-                                             statements = Vector.new0 (),
-                                             transfer = Goto {dst = dst,
-                                                              args = args'}}
-                                val _ = List.push (blocks, block)
-                              in
-                                {dst = dst,
-                                 phiArgs = phiArgs,
-                                 route = route,
-                                 hash = hash}
-                              end)
                        in
-                         route
+                          HashTable.lookupOrInsert
+                          (routeTable, {dst = dst, phiArgs = phiArgs},
+                           fn () =>
+                           let
+                              val route = Label.new dst
+                              val args = Vector.map
+                                         (LabelInfo.args' li, fn (x,ty) =>
+                                          (Var.new x, ty))
+                              val args' = Vector.concat
+                                          [Vector.map(args, #1),
+                                           phiArgs]
+                              val block = Block.T
+                                          {label = route,
+                                           args = args,
+                                           statements = Vector.new0 (),
+                                           transfer = Goto {dst = dst,
+                                                            args = args'}}
+                              val _ = List.push (blocks, block)
+                           in
+                              route
+                           end)
                        end
               end
         end

--- a/mlton/ssa/restore2.fun
+++ b/mlton/ssa/restore2.fun
@@ -522,11 +522,14 @@ fun restoreFunction {globals: Statement.t vector}
                            exp = exp}
             end
         local
-          type t = {dst: Label.t,
-                    phiArgs: Var.t vector,
-                    route: Label.t,
-                    hash: Word.t}
-          val routeTable : t HashSet.t = HashSet.new {hash = #hash}
+          val routeTable: ({dst: Label.t, phiArgs: Var.t vector}, Label.t) HashTable.t =
+             HashTable.new {equals = (fn ({dst = dst1, phiArgs = phiArgs1},
+                                          {dst = dst2, phiArgs = phiArgs2}) =>
+                                      Label.equals (dst1, dst2)
+                                      andalso
+                                      Vector.equals (phiArgs1, phiArgs2, Var.equals)),
+                            hash = (fn {dst, phiArgs} =>
+                                    Hash.combine (Label.hash dst, Hash.vectorMap (phiArgs, Var.hash)))}
         in
           fun route dst
             = let
@@ -537,39 +540,29 @@ fun restoreFunction {globals: Statement.t vector}
                   then dst
                   else let
                          val phiArgs = Vector.map
-                                        (phiArgs, valOf o VarInfo.peekVar o varInfo)
-                         val hash = Hash.combine (Label.hash dst, Hash.vectorMap (phiArgs, Var.hash))
-                         val {route, ...} 
-                           = HashSet.lookupOrInsert
-                             (routeTable, hash, 
-                              fn {dst = dst', phiArgs = phiArgs', ... } =>
-                              Label.equals (dst, dst') 
-                              andalso
-                              Vector.equals (phiArgs, phiArgs', Var.equals),
-                              fn () =>
-                              let
-                                val route = Label.new dst
-                                val args = Vector.map 
-                                           (LabelInfo.args' li, fn (x,ty) =>
-                                            (Var.new x, ty))
-                                val args' = Vector.concat 
-                                            [Vector.map(args, #1),
-                                             phiArgs]
-                                val block = Block.T
-                                            {label = route,
-                                             args = args,
-                                             statements = Vector.new0 (),
-                                             transfer = Goto {dst = dst,
-                                                              args = args'}}
-                                val _ = List.push (blocks, block)
-                              in
-                                {dst = dst,
-                                 phiArgs = phiArgs,
-                                 route = route,
-                                 hash = hash}
-                              end)
+                                       (phiArgs, valOf o VarInfo.peekVar o varInfo)
                        in
-                         route
+                          HashTable.lookupOrInsert
+                          (routeTable, {dst = dst, phiArgs = phiArgs},
+                           fn () =>
+                           let
+                              val route = Label.new dst
+                              val args = Vector.map
+                                         (LabelInfo.args' li, fn (x,ty) =>
+                                          (Var.new x, ty))
+                              val args' = Vector.concat
+                                          [Vector.map(args, #1),
+                                           phiArgs]
+                              val block = Block.T
+                                          {label = route,
+                                           args = args,
+                                           statements = Vector.new0 (),
+                                           transfer = Goto {dst = dst,
+                                                            args = args'}}
+                              val _ = List.push (blocks, block)
+                           in
+                              route
+                           end)
                        end
               end
         end

--- a/mlton/ssa/restore2.fun
+++ b/mlton/ssa/restore2.fun
@@ -245,18 +245,17 @@ fun restoreFunction {globals: Statement.t vector}
                   else ()
 
         (* init violations *)
-        val index = ref 0
+        val index = Counter.new 0
         val violations
           = Vector.fromListMap
             (!violations, fn x =>
              let
                val vi = varInfo x
-               val _ = VarInfo.index vi := (!index)
-               val _ = Int.inc index
+               val _ = VarInfo.index vi := (Counter.next index)
              in
                x
              end)
-        val numViolations = !index
+        val numViolations = Counter.value index
 
         (* Diagnostics *)
         val _ = Control.diagnostics

--- a/mlton/ssa/simplify.fun
+++ b/mlton/ssa/simplify.fun
@@ -134,10 +134,10 @@ local
    type passGen = string -> pass option
 
    fun mkSimplePassGen (name, doit): passGen =
-      let val count = Counter.new 1
+      let val count = Counter.generator 1
       in fn s => if s = name
                     then SOME {name = concat [name, "#",
-                                              Int.toString (Counter.next count)],
+                                              Int.toString (count ())],
                                doit = doit,
                                execute = true}
                     else NONE
@@ -146,7 +146,7 @@ local
    val inlinePassGen =
       let
          datatype t = Bool of bool | IntOpt of int option
-         val count = Counter.new 1
+         val count = Counter.generator 1
          fun nums s =
             Exn.withEscape
             (fn escape =>
@@ -184,7 +184,7 @@ local
                        SOME {name = concat ["inlineNonRecursive(", 
                                             Int.toString product, ",",
                                             Int.toString small, ")#",
-                                            Int.toString (Counter.next count)],
+                                            Int.toString (count ())],
                              doit = (fn p => 
                                      Inline.inlineNonRecursive 
                                      (p, {small = small, product = product})),
@@ -203,7 +203,7 @@ local
                                             Bool.toString loops, ",",
                                             Bool.toString repeat, ",",
                                             Option.toString Int.toString size, ")#",
-                                            Int.toString (Counter.next count)],
+                                            Int.toString (count ())],
                              doit = (fn p => 
                                      Inline.inlineLeaf
                                      (p, {loops = loops, repeat = repeat, size = size})),

--- a/mlton/ssa/simplify2.fun
+++ b/mlton/ssa/simplify2.fun
@@ -38,10 +38,10 @@ local
    type passGen = string -> pass option
 
    fun mkSimplePassGen (name, doit): passGen =
-      let val count = Counter.new 1
+      let val count = Counter.generator 1
       in fn s => if s = name
                     then SOME {name = concat [name, "#",
-                                              Int.toString (Counter.next count)],
+                                              Int.toString (count ())],
                                doit = doit,
                                execute = true}
                     else NONE

--- a/mlton/ssa/type-check.fun
+++ b/mlton/ssa/type-check.fun
@@ -113,16 +113,15 @@ fun checkScopes (program as
                             hash: 'a -> word,
                             numExhaustiveCases: IntInf.t) =
                      let
-                        val table = HashSet.new {hash = hash}
+                        val table = HashTable.new {equals = equals, hash = hash}
                         val _ =
                            Vector.foreach
                            (cases, fn (x, _) =>
                             let
                                val _ =
-                                  HashSet.insertIfNew
-                                  (table, hash x, fn y => equals (x, y),
-                                   fn () => x,
-                                   fn _ => Error.bug "Ssa.TypeCheck.loopTransfer: redundant branch in case")
+                                  HashTable.insertIfNew
+                                  (table, x, ignore, fn _ =>
+                                   Error.bug "Ssa.TypeCheck.loopTransfer: redundant branch in case")
                             in
                                ()
                             end)

--- a/mlton/ssa/type-check2.fun
+++ b/mlton/ssa/type-check2.fun
@@ -137,16 +137,15 @@ fun checkScopes (program as
                             hash: 'a -> word,
                             numExhaustiveCases: IntInf.t) =
                      let
-                        val table = HashSet.new {hash = hash}
+                        val table = HashTable.new {equals = equals, hash = hash}
                         val _ =
                            Vector.foreach
                            (cases, fn (x, _) =>
                             let
                                val _ =
-                                  HashSet.insertIfNew
-                                  (table, hash x, fn y => equals (x, y),
-                                   fn () => x,
-                                   fn _ => Error.bug "Ssa2.TypeCheck2.loopTransfer: redundant branch in case")
+                                  HashTable.insertIfNew
+                                  (table, x, ignore, fn _ =>
+                                   Error.bug "Ssa2.TypeCheck2.loopTransfer: redundant branch in case")
                             in
                                ()
                             end)

--- a/mlton/xml/monomorphise.fun
+++ b/mlton/xml/monomorphise.fun
@@ -47,7 +47,7 @@ structure Cache:
       val toList: 'a t -> (Stype.t vector * 'a) list
    end =
    struct
-      type 'a t = (Stype.t vector * Word.t * 'a) HashSet.t
+      type 'a t = (Stype.t vector, 'a) HashTable.t
 
       local
          val base = Random.word ()
@@ -58,18 +58,12 @@ structure Cache:
             Vector.equals (ts, ts', Stype.equals)
       end
 
-      fun new () : 'a t = HashSet.new {hash = #2}
+      fun new () : 'a t = HashTable.new {hash = hash, equals = equal}
 
       fun getOrAdd (c, ts, th) =
-         let
-            val hash = hash ts
-         in
-            (#3 o HashSet.lookupOrInsert)
-            (c, hash, fn (ts', _, _) => equal (ts, ts'), 
-             fn () => (ts, hash, th ()))
-         end
+         HashTable.lookupOrInsert (c, ts, th)
 
-      fun toList c = HashSet.fold (c, [], fn ((ts, _, v), l) => (ts, v) :: l)
+      val toList = HashTable.toList
    end
 
 fun monomorphise (Xprogram.T {datatypes, body, ...}): Sprogram.t =

--- a/mlton/xml/sxml-simplify.fun
+++ b/mlton/xml/sxml-simplify.fun
@@ -59,10 +59,10 @@ local
    type passGen = string -> pass option
 
    fun mkSimplePassGen (name, doit): passGen =
-      let val count = Counter.new 1
+      let val next = Counter.generator 1
       in fn s => if s = name
                     then SOME {name = name ^ "#" ^ 
-                               (Int.toString (Counter.next count)),
+                               (Int.toString (next ())),
                                doit = doit,
                                execute = true}
                     else NONE
@@ -70,7 +70,7 @@ local
 
    val polyvariancePassGen =
       let
-         val count = Counter.new 1
+         val next = Counter.generator 1
          fun nums s =
             if s = ""
                then SOME []
@@ -98,7 +98,7 @@ local
                                             Int.toString rounds, ",",
                                             Int.toString small, ",",
                                             Int.toString product, ")#",
-                                            Int.toString (Counter.next count)],
+                                            Int.toString (next ())],
                              doit = polyvariance (hofo, rounds, small, product),
                              execute = true}
                     val s = String.dropPrefix (s, String.size "polyvariance")

--- a/mlton/xml/xml-simplify.fun
+++ b/mlton/xml/xml-simplify.fun
@@ -33,10 +33,10 @@ local
    type passGen = string -> pass option
 
    fun mkSimplePassGen (name, doit): passGen =
-      let val count = Counter.new 1
+      let val count = Counter.generator 1
       in fn s => if s = name
                     then SOME {name = concat [name, "#",
-                                              Int.toString (Counter.next count)],
+                                              Int.toString (count ())],
                                doit = doit,
                                execute = true}
                     else NONE


### PR DESCRIPTION
Added Counter.generator: int -> (unit -> int) for the common case of needing a unique value generator without reset / peek.
As a best effort, replaced several uses of Counter.new with Counter.generator, and some uses of int refs with Counter.generator or Counter.new. I believe some of this was a bit overzealous.

While doing this, I noticed a few HashSets that could be moved to using HashTables, so that is also included. As a consequence, the interface of HashTable has grown slightly, and fold has changed type (there is now a fold/foldi distinction; consistency of naming/use seems more beneficial than using the letter k instead of i).