### PR TITLE
Add static allocation support in Rssa through codegen

### DIFF
--- a/include/amd64-main.h
+++ b/include/amd64-main.h
@@ -80,6 +80,7 @@ PUBLIC int MLton_main (int argc, char* argv[]) {                        \
         Initialize (s, al, mg, mfs, mmc, pk, ps);                       \
         if (s->amOriginal) {                                            \
                 real_Init();                                            \
+                static_Init();                                            \
                 jump = (pointer)&ml;                                    \
         } else {                                                        \
                 jump = *(pointer*)(s->stackTop - GC_RETURNADDRESS_SIZE); \
@@ -97,6 +98,7 @@ PUBLIC void LIB_OPEN(LIBNAME) (int argc, char* argv[]) {                \
         Initialize (s, al, mg, mfs, mmc, pk, ps);                       \
         if (s->amOriginal) {                                            \
                 real_Init();                                            \
+                static_Init();                                            \
                 jump = (pointer)&ml;                                    \
         } else {                                                        \
                 jump = *(pointer*)(s->stackTop - GC_RETURNADDRESS_SIZE); \

--- a/include/c-chunk.h
+++ b/include/c-chunk.h
@@ -88,7 +88,7 @@
 #define O(ty, b, o) (*(ty*)((b) + (o)))
 #define X(ty, b, i, s, o) (*(ty*)((b) + ((i) * (s)) + (o)))
 #define S(ty, i) (*(ty*)(StackTop + (i)))
-#define M(ty, i, o) ((ty)(&static_##i) + (o))
+#define M(ty, i, o) ((ty)(&static_##i + (o)))
 
 #define GCState gcState
 #define Frontier frontier

--- a/include/c-main.h
+++ b/include/c-main.h
@@ -56,6 +56,7 @@ PUBLIC int MLton_main (int argc, char* argv[]) {                        \
         Initialize (s, al, mg, mfs, mmc, pk, ps);                       \
         if (s->amOriginal) {                                            \
                 real_Init();                                            \
+                static_Init();                                          \
                 nextBlock = ml;                                         \
         } else {                                                        \
                 /* Return to the saved world */                         \
@@ -75,6 +76,7 @@ PUBLIC void LIB_OPEN(LIBNAME) (int argc, char* argv[]) {                \
         Initialize (s, al, mg, mfs, mmc, pk, ps);                       \
         if (s->amOriginal) {                                            \
                 real_Init();                                            \
+                static_Init();                                          \
                 nextBlock = ml;                                         \
         } else {                                                        \
                 /* Return to the saved world */                         \

--- a/include/common-main.h
+++ b/include/common-main.h
@@ -37,12 +37,12 @@
         s->magic = mg;                                                  \
         s->maxFrameSize = mfs;                                          \
         s->mutatorMarksCards = mmc;                                     \
+        s->objectInits = objectInits;                                   \
+        s->objectInitsLength = cardof(objectInits);                     \
         s->objectTypes = objectTypes;                                   \
         s->objectTypesLength = cardof(objectTypes);                     \
         s->returnAddressToFrameIndex = returnAddressToFrameIndex;       \
         s->saveGlobals = saveGlobals;                                   \
-        s->objectInits = objectInits;                                   \
-        s->objectInitsLength = cardof(objectInits);                     \
         s->sourceMaps.profileLabelInfos = profileLabelInfos;            \
         s->sourceMaps.profileLabelInfosLength = cardof(profileLabelInfos); \
         s->sourceMaps.sourceNames = sourceNames;                        \

--- a/include/common-main.h
+++ b/include/common-main.h
@@ -22,10 +22,6 @@
 #define DeclareProfileLabel(l)                  \
         extern char l __attribute__ ((weak))
 
-#define BeginVectorInits static struct GC_vectorInit vectorInits[] = {
-#define VectorInitElem(es, gi, l, w) { es, gi, l, w },
-#define EndVectorInits };
-
 #define LoadArray(a, f) if (fread (a, sizeof(*a), cardof(a), f) != cardof(a)) return -1;
 #define SaveArray(a, f) if (fwrite(a, sizeof(*a), cardof(a), f) != cardof(a)) return -1;
 
@@ -45,8 +41,8 @@
         s->objectTypesLength = cardof(objectTypes);                     \
         s->returnAddressToFrameIndex = returnAddressToFrameIndex;       \
         s->saveGlobals = saveGlobals;                                   \
-        s->vectorInits = vectorInits;                                   \
-        s->vectorInitsLength = cardof(vectorInits);                     \
+        s->objectInits = objectInits;                                   \
+        s->objectInitsLength = cardof(objectInits);                     \
         s->sourceMaps.profileLabelInfos = profileLabelInfos;            \
         s->sourceMaps.profileLabelInfosLength = cardof(profileLabelInfos); \
         s->sourceMaps.sourceNames = sourceNames;                        \

--- a/include/x86-main.h
+++ b/include/x86-main.h
@@ -85,6 +85,7 @@ PUBLIC int MLton_main (int argc, char* argv[]) {                        \
         Initialize (s, al, mg, mfs, mmc, pk, ps);                       \
         if (s->amOriginal) {                                            \
                 real_Init();                                            \
+                static_Init();                                            \
                 jump = (pointer)&ml;                                    \
         } else {                                                        \
                 jump = *(pointer*)(s->stackTop - GC_RETURNADDRESS_SIZE); \
@@ -102,6 +103,7 @@ PUBLIC void LIB_OPEN(LIBNAME) (int argc, char* argv[]) {                \
         Initialize (s, al, mg, mfs, mmc, pk, ps);                       \
         if (s->amOriginal) {                                            \
                 real_Init();                                            \
+                static_Init();                                            \
                 jump = (pointer)&ml;                                    \
         } else {                                                        \
                 jump = *(pointer*)(s->stackTop - GC_RETURNADDRESS_SIZE); \

--- a/mlton/atoms/real-x.sig
+++ b/mlton/atoms/real-x.sig
@@ -37,7 +37,6 @@ signature REAL_X =
       val castToWord: t -> WordX.t option
       val cos: t -> t option
       val decon: t -> decon option
-      val disableCF: unit -> bool
       val div: t * t -> t option
       val equal: t * t -> bool option
       val equals: t * t -> bool

--- a/mlton/atoms/real-x.sig
+++ b/mlton/atoms/real-x.sig
@@ -37,6 +37,7 @@ signature REAL_X =
       val castToWord: t -> WordX.t option
       val cos: t -> t option
       val decon: t -> decon option
+      val disableCF: unit -> bool
       val div: t * t -> t option
       val equal: t * t -> bool option
       val equals: t * t -> bool

--- a/mlton/atoms/sources.cm
+++ b/mlton/atoms/sources.cm
@@ -26,6 +26,7 @@ signature PRIM_CONS
 signature PRIM_TYCONS
 signature PROFILE_LABEL
 signature REAL_SIZE
+signature REAL_X
 signature RECORD
 signature SYMBOL
 signature TYCON

--- a/mlton/atoms/sources.mlb
+++ b/mlton/atoms/sources.mlb
@@ -106,6 +106,7 @@ in
    signature PRIM_TYCONS
    signature PROFILE_LABEL
    signature REAL_SIZE
+   signature REAL_X
    signature RECORD
    signature SYMBOL
    signature TYCON

--- a/mlton/atoms/word-x-vector.fun
+++ b/mlton/atoms/word-x-vector.fun
@@ -123,9 +123,6 @@ fun fromString s =
 
 fun length v = Vector.length (elements v)
 
-fun size v = Bytes.fromInt
-   (length v * ((Bytes.toInt o WordSize.bytes o elementSize) v))
-
 fun sub (v, i) = Vector.sub (elements v, i)
 
 fun tabulate ({elementSize}, n, f) =

--- a/mlton/atoms/word-x-vector.sig
+++ b/mlton/atoms/word-x-vector.sig
@@ -34,7 +34,6 @@ signature WORD_X_VECTOR =
       val length: t -> int
       val parse: t Parse.t
       val sub: t * int -> WordX.t
-      val size: t -> Bytes.t
       val tabulate: {elementSize: WordSize.t} * int * (int -> WordX.t) -> t
       val toListMap: t * (WordX.t -> 'a) -> 'a list
       val toString: t -> string

--- a/mlton/backend/backend-atoms.fun
+++ b/mlton/backend/backend-atoms.fun
@@ -27,8 +27,10 @@ structure BackendAtoms =
 
       structure Static = Static (structure ObjptrTycon = ObjptrTycon
                                  structure Runtime = Runtime
-                                 structure WordX = WordX
+                                 structure RealSize = RealSize
+                                 structure RealX = RealX
                                  structure WordSize = WordSize
+                                 structure WordX = WordX
                                  structure WordXVector = WordXVector)
       structure Type = RepType
    end

--- a/mlton/backend/backend-atoms.sig
+++ b/mlton/backend/backend-atoms.sig
@@ -37,16 +37,11 @@ signature BACKEND_ATOMS' =
       sharing CType = Type.CType
       sharing Label = Type.Label
       sharing Prim = Type.Prim
-      sharing RealSize = Type.RealSize
-      sharing WordSize = Type.WordSize
-      sharing WordX = Type.WordX
-      sharing WordXVector = Type.WordXVector
-
-      sharing RealSize = Static.RealSize
+      sharing RealSize = Static.RealSize = Type.RealSize
       sharing RealX = Static.RealX
-      sharing WordSize = Static.WordSize
-      sharing WordX = Static.WordX
-      sharing WordXVector = Static.WordXVector
+      sharing WordSize = Static.WordSize = Type.WordSize
+      sharing WordX = Static.WordX = Type.WordX
+      sharing WordXVector = Static.WordXVector = Type.WordXVector
    end
 
 signature BACKEND_ATOMS =

--- a/mlton/backend/backend-atoms.sig
+++ b/mlton/backend/backend-atoms.sig
@@ -41,6 +41,9 @@ signature BACKEND_ATOMS' =
       sharing WordSize = Type.WordSize
       sharing WordX = Type.WordX
       sharing WordXVector = Type.WordXVector
+
+      sharing RealSize = Static.RealSize
+      sharing RealX = Static.RealX
       sharing WordSize = Static.WordSize
       sharing WordX = Static.WordX
       sharing WordXVector = Static.WordXVector

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -455,7 +455,7 @@ fun toMachine (rssa: Rssa.Program.t) =
                   in
                     (* Native codegens can't handle this;
                      * Dead code may treat small constant
-                     * intInfs are large and take offsets *)
+                     * intInfs as large and take offsets *)
                      if isWord base
                      then bogusOp ty
                      else M.Operand.Offset {base = base,

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -751,8 +751,10 @@ fun toMachine (rssa: Rssa.Program.t) =
                                                    set (z, casts)
                                               | VarOperand.Allocate _ =>
                                                    normal ())
-                                       | R.Operand.Static s =>
-                                            set (globalStatic s, casts)
+                                       | R.Operand.Static (s as {static, ...}) =>
+                                            if M.Static.location static <> M.Static.Location.Heap
+                                               then set (globalStatic s, casts)
+                                               else normal ()
                                        | _ => normal ()
                                 in
                                    loop (src, [])

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -383,19 +383,6 @@ fun toMachine (rssa: Rssa.Program.t) =
                          {index=i, offset=offset, ty=ty}
                 end)
       end
-      fun bogusOp (t: Type.t): M.Operand.t =
-         case Type.deReal t of
-            NONE => let
-                       val bogusWord =
-                          M.Operand.Word
-                          (WordX.zero
-                           (WordSize.fromBits (Type.width t)))
-                    in
-                       case Type.deWord t of
-                          NONE => M.Operand.Cast (bogusWord, t)
-                        | SOME _ => bogusWord
-                    end
-          | SOME s => globalReal (RealX.zero s)
       fun constOperand (c: Const.t): M.Operand.t =
          let
             datatype z = datatype Const.t

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -73,7 +73,6 @@ structure VarOperand =
       val operand: t -> M.Operand.t option =
          fn Allocate {operand, ...} => !operand
           | Const oper => SOME oper
-
    end
 
 structure ByteSet = UniqueSet (val cacheSize: int = 1
@@ -641,7 +640,6 @@ fun toMachine (rssa: Rssa.Program.t) =
          in
             get
          end
-
       fun genFunc (f: Function.t, isMain: bool): unit =
          let
             val f = eliminateDeadCode f

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -359,7 +359,7 @@ fun toMachine (rssa: Rssa.Program.t) =
           * late and mutable statics can't be unique *)
          val (allStatics, globalStatic) =
             (fn () => Vector.fromListRev (!staticsRef),
-             fn {static as M.Static.T {location, metadata, ...}, ty} =>
+             fn {static as M.Static.T {location, ...}, ty} =>
                 let
                    val static = M.Static.map (static,
                      fn v =>
@@ -374,7 +374,7 @@ fun toMachine (rssa: Rssa.Program.t) =
                          | _ => NONE
                    val _ = List.push (staticsRef, (static, g))
 
-                   val offset = WordXVector.size metadata
+                   val offset = M.Static.metadataSize static
                 in
                    case g of
                         SOME g' => M.Operand.Global g'

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -359,7 +359,7 @@ fun toMachine (rssa: Rssa.Program.t) =
           * late and mutable statics can't be unique *)
          val (allStatics, globalStatic) =
             (fn () => Vector.fromListRev (!staticsRef),
-             fn {static as M.Static.T {location, header, ...}, ty} =>
+             fn {static as M.Static.T {location, metadata, ...}, ty} =>
                 let
                    val static = M.Static.map (static,
                      fn v =>
@@ -374,7 +374,7 @@ fun toMachine (rssa: Rssa.Program.t) =
                          | _ => NONE
                    val _ = List.push (staticsRef, (static, g))
 
-                   val offset = WordXVector.size header
+                   val offset = WordXVector.size metadata
                 in
                    case g of
                         SOME g' => M.Operand.Global g'

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -370,7 +370,7 @@ fun toMachine (rssa: Rssa.Program.t) =
 
                    val g =
                       case location of
-                           M.Static.Heap => SOME (M.Global.new ty)
+                           M.Static.Location.Heap => SOME (M.Global.new ty)
                          | _ => NONE
                    val _ = List.push (staticsRef, (static, g))
 
@@ -1155,7 +1155,8 @@ fun toMachine (rssa: Rssa.Program.t) =
                val size = WordXVector.elementSize v
                val tycon = ObjptrTycon.wordVector (WordSize.bits size)
             in
-               (M.Static.vector {data=v, tycon=tycon, location=M.Static.Heap}, SOME g)
+               (M.Static.vector {data=v, tycon=tycon,
+                location=M.Static.Location.Heap}, SOME g)
             end)
       val machine =
          M.Program.T

--- a/mlton/backend/bounce-vars.fun
+++ b/mlton/backend/bounce-vars.fun
@@ -353,12 +353,10 @@ fun transformFunc func =
                      val src = Operand.Var {var=src, ty=ty}
                      val dst = (dst, ty)
                   in
-                     Statement.Bind {dst=dst, src=src,
-                     (* This is a bit of a hack, but makes it clear
-                      * to the shrinker that these variables should
-                      * block copy-propagation. It is preserved by
-                      * RestoreRssa *)
-                     isMutable= true}
+                     Statement.Bind
+                        {dst=dst,
+                         pinned=true,
+                         src=src}
                   end)
             (* Due to the loop forest construction, (i.e. shouldAvoid)
              * The kind of a block on the edge is always Kind.Jump

--- a/mlton/backend/limit-check.fun
+++ b/mlton/backend/limit-check.fun
@@ -850,7 +850,7 @@ fun transform (Program.T {functions, handlesSignals, main, objectTypes, profileI
       val newStart = Label.newNoname ()
       fun define x = Statement.Bind
          {dst = (x, Type.cpointer ()),
-          isMutable = false,
+          pinned = false,
           src = Operand.Static
             {static=Static.T
                {data=Static.Data.Object [Static.Data.Word (WordX.one WordSize.bool)],

--- a/mlton/backend/limit-check.fun
+++ b/mlton/backend/limit-check.fun
@@ -854,8 +854,8 @@ fun transform (Program.T {functions, handlesSignals, main, objectTypes, profileI
           src = Operand.Static
             {static=Static.T
                {data=Static.Data.Object [Static.Data.Word (WordX.one WordSize.bool)],
-                header=WordXVector.fromList ({elementSize=WordSize.objptr ()}, []),
-                location=Static.MutStatic},
+                location=Static.MutStatic,
+                metadata=WordXVector.fromList ({elementSize=WordSize.objptr ()}, [])},
              ty=Type.cpointer ()}}
       val block =
          Block.T {args = Vector.new0 (),

--- a/mlton/backend/limit-check.fun
+++ b/mlton/backend/limit-check.fun
@@ -853,8 +853,9 @@ fun transform (Program.T {functions, handlesSignals, main, objectTypes, profileI
           pinned = false,
           src = Operand.Static
             {static=Static.T
-               {data=Static.Data.Object [Static.Data.Word (WordX.one WordSize.bool)],
-                location=Static.MutStatic,
+               {data=Static.Data.Object
+                  [Static.Data.Elem.Word (WordX.one WordSize.bool)],
+                location=Static.Location.MutStatic,
                 metadata=WordXVector.fromList ({elementSize=WordSize.objptr ()}, [])},
              ty=Type.cpointer ()}}
       val block =

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -294,7 +294,6 @@ structure Operand =
       val rec isDestination =
          fn Cast (z, _) => isDestination z
           | Contents _ => true
-          | GCState => true
           | Global _ => true
           | Offset _ => true
           | SequenceOffset _ => true

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -1015,7 +1015,6 @@ structure Program =
                Vector.sub (objectTypes, ObjptrTycon.index opt)
             open Layout
 
-
             fun checkGlobal (name, global, isOk, layoutVal) =
                let
                   val ty = Global.ty global
@@ -1099,9 +1098,9 @@ structure Program =
                       | Offset {base, offset, ty} =>
                            (checkOperand (base, alloc)
                             ; Type.offsetIsOk {base = Operand.ty base,
-                                                 offset = offset,
-                                                 tyconTy = tyconTy,
-                                                 result = ty})
+                                               offset = offset,
+                                               tyconTy = tyconTy,
+                                               result = ty})
                       | Real _ => true
                       | StackOffset (so as StackOffset.T {offset, ty, ...}) =>
                            Bytes.<= (Bytes.+ (offset, Type.bytes ty), maxFrameSize)
@@ -1139,11 +1138,11 @@ structure Program =
                            (checkOperand (base, alloc)
                             ; checkOperand (index, alloc)
                             ; Type.sequenceOffsetIsOk {base = Operand.ty base,
-                                                         index = Operand.ty index,
-                                                         offset = offset,
-                                                         tyconTy = tyconTy,
-                                                         result = ty,
-                                                         scale = scale})
+                                                       index = Operand.ty index,
+                                                       offset = offset,
+                                                       tyconTy = tyconTy,
+                                                       result = ty,
+                                                       scale = scale})
                       | Static {index, ty, ...} =>
                            0 <= index andalso index < Vector.length statics
                            andalso

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -1145,7 +1145,7 @@ structure Program =
                                                          result = ty,
                                                          scale = scale})
                       | Static {index, ty, ...} =>
-                           0 < index andalso index < Vector.length statics
+                           0 <= index andalso index < Vector.length statics
                            andalso
                            (Type.isCPointer ty orelse Type.isObjptr ty)
                       | StackTop => true

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -1565,10 +1565,13 @@ structure ConRep =
                (case Component.staticTuple (component, {src=src}) of
                   Static.Data.Word w =>
                    let
-                      val shift = (WordX.resize
-                                    (tag, WordSize.shiftArg))
-                      val w = WordX.lshift (w, shift)
+		      val shift = (WordX.fromIntInf
+                                   (Bits.toIntInf
+                                    (WordSize.bits
+                                     (WordX.size tag)),
+                                   WordSize.shiftArg))
                       val w = WordX.resize (w, width)
+                      val w = WordX.lshift (w, shift)
                       val mask = WordX.resize (tag, width)
                    in
                       (Elem o Static.Data.Word o WordX.orb) (w, mask)

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -354,7 +354,7 @@ structure WordRep =
                   NONE => []
                 | SOME src =>
                      [Bind {dst = (dstVar, dstTy),
-                            isMutable = false,
+                            pinned = false,
                             src = src}]
                      :: statements
          in
@@ -470,7 +470,7 @@ structure Component =
                      Statement.resize (src {index = index}, #2 dst)
                in
                   ss @ [Bind {dst = dst,
-                              isMutable = false,
+                              pinned = false,
                               src = src}]
                end
           | Word wr => WordRep.tuple (wr, {dst = dst, src = src})
@@ -552,7 +552,7 @@ structure Unpack =
                   end
          in
             ss1 @ ss2 @ ss3 @ [Bind {dst = (dst, dstTy),
-                                     isMutable = false,
+                                     pinned = false,
                                      src = src}]
          end
 
@@ -707,7 +707,7 @@ structure Select =
                   val (src, ss') = Statement.resize (src, dstTy)
                in
                   ss @ ss' @ [Bind {dst = (dst, dstTy),
-                                    isMutable = false,
+                                    pinned = false,
                                     src = src}]
                end
          in
@@ -730,7 +730,7 @@ structure Select =
                                         ty = ty}
                   in
                      ss @ (Bind {dst = (tmpVar, ty),
-                                 isMutable = false,
+                                 pinned = false,
                                  src = src}
                            :: Unpack.select (rest, {dst = dst, src = tmpOp}))
                   end
@@ -1531,7 +1531,7 @@ structure ConRep =
                                              (Operand.ty tmp))))
                   val (s2, tmp) = Statement.orb (tmp, mask)
                   val s3 = Bind {dst = (dstVar, dstTy),
-                                 isMutable = false,
+                                 pinned = false,
                                  src = tmp}
                in
                   component @ [s1, s2, s3]
@@ -1545,7 +1545,7 @@ structure ConRep =
                                            (Type.width dstTy)))
                in
                   [Bind {dst = (dstVar, dstTy),
-                         isMutable = false,
+                         pinned = false,
                          src = src}]
                end
           | Tuple tr => TupleRep.tuple (tr, {dst = dst, src = src})

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -27,6 +27,7 @@ in
    structure ObjptrTycon = ObjptrTycon
    structure Prim = Prim
    structure RealSize = RealSize
+   structure RealX = RealX
    structure Runtime = Runtime
    structure Scale = Scale
    structure Statement = Statement
@@ -491,11 +492,16 @@ structure Component =
                   val src = fn i =>
                      case src i of
                         Static.Data.Word w => w
-                      | _ =>
-                           Error.bug "PackedRepresentation.Component.staticTuple: bad component"
-               in
-                  (Static.Data.Word o WordRep.staticTuple) (wr, {src = src})
-               end
+
+                       | Static.Data.Real r =>
+                          (case RealX.castToWord r of
+                               SOME w => w
+                             | NONE => Error.bug
+                             "PackedRepresentation.Component.staticTuple: unexpected real")
+                       | _ => Error.bug "PackedRepresentation.Component.staticTuple: bad component"
+                in
+                   (Static.Data.Word o WordRep.staticTuple) (wr, {src = src})
+                end
    end
 
 structure Unpack =

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -491,7 +491,7 @@ structure Component =
                   val src = fn i =>
                      case src i of
                         Static.Data.Word w => w
-                      | Static.Data.Address _ =>
+                      | _ =>
                            Error.bug "PackedRepresentation.Component.staticTuple: bad component"
                in
                   (Static.Data.Word o WordRep.staticTuple) (wr, {src = src})

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -367,7 +367,6 @@ structure WordRep =
           layout o #1, List.layout Statement.layout)
          tuple
 
-
       fun staticTuple (T {components, rep, ...},
                  {src: {index: int} -> WordX.t}): WordX.t =
          let
@@ -1122,6 +1121,7 @@ structure TupleRep =
                Component.tuple (c, {dst = dst, src = src})
           | Indirect pr =>
                ObjptrRep.tuple (pr, {dst = #1 dst, src = src})
+
       val tuple =
          Trace.trace2
          ("PackedRepresentation.TupleRep.tuple",
@@ -1136,7 +1136,6 @@ structure TupleRep =
                Elem (Component.staticTuple (c, {src = src}))
           | Indirect pr =>
                Static (ObjptrRep.staticTuple (pr, {location = location, src = src}))
-
 
       (* TupleRep.make decides how to layout a series of types in an object,
        * or in the case of a sequence, in a sequence element.
@@ -1590,7 +1589,6 @@ structure ConRep =
                end
           | Tag {tag, ...} => (Elem o Static.Data.Word o WordX.resize) (tag, width)
           | Tuple tr => TupleRep.staticTuple (tr, {location = location, src = src})
-
    end
 
 structure Block =

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -37,7 +37,6 @@ in
    structure Var = Var
    structure WordSize = WordSize
    structure WordX = WordX
-   structure WordXVector = WordXVector
 end
 structure S = Ssa2
 local

--- a/mlton/backend/rep-type.fun
+++ b/mlton/backend/rep-type.fun
@@ -240,7 +240,7 @@ structure Type =
           | _ => NONE
 
       val deObjptrs: t -> ObjptrTycon.t vector option =
-         fn t => 
+         fn t =>
          case node t of
             Objptr opts => SOME opts
           | _ => NONE

--- a/mlton/backend/representation.sig
+++ b/mlton/backend/representation.sig
@@ -19,9 +19,12 @@ signature REPRESENTATION =
    sig
       include REPRESENTATION_STRUCTS
 
-      datatype 'a staticOrElem =
-         Static of 'a Rssa.Static.t
-       | Elem of 'a Rssa.Static.Data.elem
+      structure StaticOrElem:
+         sig
+            datatype t =
+               Static of Rssa.Var.t Rssa.Static.t
+             | Elem of Rssa.Var.t Rssa.Static.Data.elem
+         end
 
       val compute:
          Ssa2.Program.t
@@ -34,22 +37,22 @@ signature REPRESENTATION =
                        tycon: Ssa2.Tycon.t} -> (Rssa.Statement.t list
                                                 * Rssa.Transfer.t
                                                 * Rssa.Block.t list),
-             object: {args: 'a vector,
+             object: {args: Ssa2.Var.t vector,
                       con: Ssa2.Con.t option,
                       dst: Rssa.Var.t * Rssa.Type.t,
                       objectTy: Ssa2.Type.t,
-                      oper: 'a -> Rssa.Operand.t} -> Rssa.Statement.t list,
+                      oper: Ssa2.Var.t -> Rssa.Operand.t} -> Rssa.Statement.t list,
              objectTypes: (Rssa.ObjptrTycon.t * Rssa.ObjectType.t) vector,
              select: {base: Rssa.Operand.t Ssa2.Base.t,
                       baseTy: Ssa2.Type.t,
                       dst: Rssa.Var.t * Rssa.Type.t,
                       offset: int} -> Rssa.Statement.t list,
-             static: {args: 'a vector,
+             static: {args: Ssa2.Var.t vector,
                       con: Ssa2.Con.t option,
-                      elem: 'a -> 'b Rssa.Static.Data.elem,
+                      elem: Ssa2.Var.t -> Rssa.Var.t Rssa.Static.Data.elem,
                       location: Rssa.Static.location,
                       objectTy: Ssa2.Type.t} ->
-                      'b staticOrElem,
+                      StaticOrElem.t,
              toRtype: Ssa2.Type.t -> Rssa.Type.t option,
              update: {base: Rssa.Operand.t Ssa2.Base.t,
                       baseTy: Ssa2.Type.t,

--- a/mlton/backend/representation.sig
+++ b/mlton/backend/representation.sig
@@ -52,7 +52,7 @@ signature REPRESENTATION =
                       elem: Ssa2.Var.t -> Rssa.Var.t Rssa.Static.Data.Elem.t,
                       location: Rssa.Static.Location.t,
                       objectTy: Ssa2.Type.t} ->
-                      StaticOrElem.t,
+                      StaticOrElem.t option,
              toRtype: Ssa2.Type.t -> Rssa.Type.t option,
              update: {base: Rssa.Operand.t Ssa2.Base.t,
                       baseTy: Ssa2.Type.t,

--- a/mlton/backend/representation.sig
+++ b/mlton/backend/representation.sig
@@ -23,7 +23,7 @@ signature REPRESENTATION =
          sig
             datatype t =
                Static of Rssa.Var.t Rssa.Static.t
-             | Elem of Rssa.Var.t Rssa.Static.Data.elem
+             | Elem of Rssa.Var.t Rssa.Static.Data.Elem.t
          end
 
       val compute:
@@ -49,8 +49,8 @@ signature REPRESENTATION =
                       offset: int} -> Rssa.Statement.t list,
              static: {args: Ssa2.Var.t vector,
                       con: Ssa2.Con.t option,
-                      elem: Ssa2.Var.t -> Rssa.Var.t Rssa.Static.Data.elem,
-                      location: Rssa.Static.location,
+                      elem: Ssa2.Var.t -> Rssa.Var.t Rssa.Static.Data.Elem.t,
+                      location: Rssa.Static.Location.t,
                       objectTy: Ssa2.Type.t} ->
                       StaticOrElem.t,
              toRtype: Ssa2.Type.t -> Rssa.Type.t option,

--- a/mlton/backend/rssa-restore.fun
+++ b/mlton/backend/rssa-restore.fun
@@ -520,8 +520,8 @@ fun restoreFunction {main: Function.t}
              val tupleDst = (dstVar, dstTy)
           in
            case st of
-                Statement.Bind {src, isMutable, ...} =>
-                   Statement.Bind {dst=tupleDst, isMutable=isMutable, src=src}
+                Statement.Bind {src, pinned, ...} =>
+                   Statement.Bind {dst=tupleDst, pinned=pinned, src=src}
               | Statement.Move {src, ...} =>
                    Statement.Move {dst=Operand.Var dst, src=src}
               | Statement.Object {header, size, ...} =>

--- a/mlton/backend/rssa-tree.fun
+++ b/mlton/backend/rssa-tree.fun
@@ -178,7 +178,7 @@ structure Statement =
    struct
       datatype t =
          Bind of {dst: Var.t * Type.t,
-                  isMutable: bool,
+                  pinned: bool,
                   src: Operand.t}
        | Move of {dst: Operand.t,
                   src: Operand.t}
@@ -238,9 +238,9 @@ structure Statement =
                Operand.replaceVar (z, f)
          in
             case s of
-               Bind {dst, isMutable, src} =>
+               Bind {dst, pinned, src} =>
                   Bind {dst = dst,
-                        isMutable = isMutable,
+                        pinned = pinned,
                         src = oper src}
              | Move {dst, src} => Move {dst = oper dst, src = oper src}
              | Object _ => s
@@ -846,7 +846,7 @@ structure Function =
                                     Vector.map2
                                     (formals, args, fn (dst, src) =>
                                      Bind {dst = dst,
-                                           isMutable = false,
+                                           pinned = false,
                                            src = src})
                               in
                                  expand (statements :: binds :: ss, replaceTransfer transfer)
@@ -1077,8 +1077,8 @@ structure Program =
                       ; SOME s)
                in
                   case s of
-                     Bind {dst = (dst, dstTy), isMutable, src} =>
-                        if isMutable
+                     Bind {dst = (dst, dstTy), pinned, src} =>
+                        if pinned
                            then keep ()
                         else
                            let

--- a/mlton/backend/rssa-tree.sig
+++ b/mlton/backend/rssa-tree.sig
@@ -55,7 +55,7 @@ signature RSSA_TREE =
          sig
             datatype t =
                Bind of {dst: Var.t * Type.t,
-                        isMutable: bool,
+                        pinned: bool,
                         src: Operand.t}
              | Move of {dst: Operand.t,
                         src: Operand.t}

--- a/mlton/backend/rssa-tree.sig
+++ b/mlton/backend/rssa-tree.sig
@@ -198,8 +198,7 @@ signature RSSA_TREE =
                      main: Function.t,
                      objectTypes: ObjectType.t vector,
                      profileInfo: {sourceMaps: SourceMaps.t,
-                                   getFrameSourceSeqIndex: Label.t -> int option} option
-                     }
+                                   getFrameSourceSeqIndex: Label.t -> int option} option}
 
             val clear: t -> unit
             val checkHandlers: t -> unit

--- a/mlton/backend/sources.cm
+++ b/mlton/backend/sources.cm
@@ -33,6 +33,8 @@ objptr-tycon.fun
 object-type.sig
 rep-type.sig
 rep-type.fun
+static.sig
+static.fun
 
 backend-atoms.sig
 backend-atoms.fun
@@ -40,8 +42,6 @@ backend-atoms.fun
 switch.sig
 switch.fun
 err.sml
-static.sig
-static.fun
 
 rssa-tree.sig
 rssa-tree.fun

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1783,11 +1783,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                            let
                               val location = getLocation (ty, false)
                            in
-                              if Vector.exists (args, fn v =>
-                                        case globalStatic v of
-                                             NONE => true
-                                           | SOME (Real _) => RealX.disableCF ()
-                                           | _ => false)
+                              if Vector.exists (args, Option.isNone o globalStatic)
                               (* For objects, there's no reason to statically initalize,
                                * since they're so small and irregular *)
                               orelse location = Static.Location.Heap

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1785,7 +1785,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                                                       ty = ty} of
                                                         NONE => keep ()
                                                       | SOME soe => static soe
-                                                else ()
+                                                else keep ()
                                            end)
                       | S.Exp.PrimApp {args, prim, ...} =>
                            (case Prim.name prim of

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1693,7 +1693,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
 
             fun getObjptrTycon ty =
                let
-                  fun fail () = Error.bug "translateGlobalStatics.makeSequenceHeader"
+                  fun fail () = Error.bug "translateGlobalStatics.getObjptrTycon"
                in
                   case toRtype ty of
                      SOME t =>

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1743,6 +1743,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                   elem=fn v =>
                   case globalStatic v of
                      SOME static => static
+
                    | NONE => Error.bug "translateGlobalStatics.makeObject.elem",
                   location=location,
                   objectTy=ty}
@@ -1795,10 +1796,15 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                       | S.Exp.Inject {variant, ...} =>
                            copy variant
                       | S.Exp.Object {args, con} =>
+
                            let
                               val location = getLocation (ty, false)
                            in
-                              if Vector.exists (args, Option.isNone o globalStatic)
+                              if Vector.exists (args, fn v =>
+                                        case globalStatic v of
+                                             NONE => true
+                                           | SOME (Real _) => RealX.disableCF ()
+                                           | _ => false)
                               (* For objects, there's no reason to statically initalize,
                                * since they're so small and irregular *)
                               orelse location = Static.Heap

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1804,6 +1804,12 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                            end
                                       | _ => keep ()
                                   end
+                             | Prim.Name.MLton_bogus =>
+                                  (case toRtype ty of
+                                      NONE => keep ()
+                                    | SOME ty => (case Type.deReal ty of
+                                                     NONE => word (Type.bogusWord ty)
+                                                   | SOME s => real (RealX.zero s)))
                              | _ => keep ())
                       | S.Exp.Var v => copy v
                       | S.Exp.Select _ => keep ()

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1648,7 +1648,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
          let
             val statics = ref []
             val keeps = ref []
-            datatype elem = datatype Static.Data.elem
+            datatype elem = datatype Static.Data.Elem.t
             datatype z = datatype PackedRepresentation.StaticOrElem.t
             val {get = globalStatic: Var.t -> Var.t elem option,
                  set = setGlobalStatic, destroy = destGlobalStatics} =
@@ -1684,10 +1684,10 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                            (S.Prod.dest args, validArg))
                      then
                         if S.Prod.someIsMutable args
-                           then Static.MutStatic
-                        else Static.ImmStatic
+                           then Static.Location.MutStatic
+                        else Static.Location.ImmStatic
                      else
-                        Static.Heap
+                        Static.Location.Heap
                   | _ => Error.bug
                      "translateGlobalStatics.getLocation: non-object"
 
@@ -1737,7 +1737,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                   NONE => pushKeep st
                 | SOME var =>
                   let
-                     datatype location = datatype Static.location
+                     datatype location = datatype Static.Location.t
                      fun copy var' =
                         (setGlobalStatic (var, globalStatic var');
                          pushKeep st)
@@ -1791,7 +1791,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                            | _ => false)
                               (* For objects, there's no reason to statically initalize,
                                * since they're so small and irregular *)
-                              orelse location = Static.Heap
+                              orelse location = Static.Location.Heap
                                  then keep ()
                               else static (makeObject, false, {args=args, con=con})
                            end

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1619,8 +1619,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
       fun translateFunction (f: S.Function.t): Function.t =
          let
             val _ =
-               S.Function.foreachVar (f,
-                  fn (x, t) => setVarInfo (x, {ty = t}))
+               S.Function.foreachVar (f, fn (x, t) => setVarInfo (x, {ty = t}))
             val {args, blocks, name, raises, returns, start, ...} =
                S.Function.dest f
             val _ =
@@ -1796,7 +1795,6 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                       | S.Exp.Inject {variant, ...} =>
                            copy variant
                       | S.Exp.Object {args, con} =>
-
                            let
                               val location = getLocation (ty, false)
                            in

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1760,6 +1760,9 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                      fun word w =
                         (setGlobalStatic (var, SOME (Word w));
                          pushKeep st)
+                     fun real r =
+                        (setGlobalStatic (var, SOME (Real r));
+                         pushKeep st)
                      fun 'a static (mk: S.Type.t * location * 'a ->
                                     Var.t PackedRepresentation.staticOrElem, isEmpty, a: 'a) =
                         let
@@ -1787,6 +1790,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                            (case c of
                                Const.WordVector wxv => static (makeWordXVector, false, wxv)
                              | Const.Word w => word w
+                             | Const.Real r => real r
                              | _ => keep ())
                       | S.Exp.Inject {variant, ...} =>
                            copy variant

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -962,7 +962,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                            NONE => none ()
                          | SOME ty =>
                               add (Bind {dst = (valOf var, ty),
-                                         isMutable = false,
+                                         pinned = false,
                                          src = f ty})
                      fun move (src: Operand.t) = maybeMove (fn _ => src)
                   in
@@ -1184,7 +1184,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                                  ty = Type.objptrHeader ()}),
                                          src = ObjptrTycon arrOpt},
                                         Bind {dst = (valOf var, arrTy),
-                                              isMutable = false,
+                                              pinned = false,
                                               src = Operand.cast (rawarr, arrTy)})
                                     end
                                | Array_toVector =>
@@ -1204,7 +1204,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                                  ty = Type.objptrHeader ()}),
                                          src = ObjptrTycon vecOpt},
                                         Bind {dst = (valOf var, vecTy),
-                                              isMutable = false,
+                                              pinned = false,
                                               src = Operand.cast (sequence, vecTy)})
                                     end
                                | Array_uninit =>
@@ -1872,7 +1872,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                   (statics, fn (v, rty, static) =>
                   Statement.Bind
                   {dst=(v, rty),
-                   isMutable=false,
+                   pinned=false,
                    src=Operand.Static {static=static, ty=rty}}),
                 transfer=Transfer.Goto {args=Vector.new0 (), dst=start}}
           in

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1649,7 +1649,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
             val statics = ref []
             val keeps = ref []
             datatype elem = datatype Static.Data.elem
-            datatype z = datatype PackedRepresentation.staticOrElem
+            datatype z = datatype PackedRepresentation.StaticOrElem.t
             val {get = globalStatic: Var.t -> Var.t elem option,
                  set = setGlobalStatic, destroy = destGlobalStatics} =
                Property.destGetSetOnce
@@ -1764,7 +1764,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                         (setGlobalStatic (var, SOME (Real r));
                          pushKeep st)
                      fun 'a static (mk: S.Type.t * location * 'a ->
-                                    Var.t PackedRepresentation.staticOrElem, isEmpty, a: 'a) =
+                                    PackedRepresentation.StaticOrElem.t, isEmpty, a: 'a) =
                         let
                            val location = getLocation (ty, isEmpty)
                            val s = mk (ty, location, a)

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -1802,6 +1802,7 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                            end
                                       | _ => keep ()
                                   end
+                             | Prim.Name.Array_toVector => copy (Vector.first args)
                              | Prim.Name.MLton_bogus =>
                                   (case toRtype ty of
                                       NONE => keepWithStatic' NONE

--- a/mlton/backend/static.fun
+++ b/mlton/backend/static.fun
@@ -116,11 +116,13 @@ functor Static (S: STATIC_STRUCTS): STATIC =
             location = location,
             metadata = sequenceMetadata (tycon, WordXVector.length data)}
 
-      fun sequence {length, location, totalSize, tycon} =
-         T {data = Data.Empty totalSize,
-            location = location,
-            metadata = sequenceMetadata (tycon, length)}
-
-
+      fun sequence {eltSize, length, location, tycon} =
+         let
+            val dataSize = Bytes.fromInt (length * Bytes.toInt eltSize)
+         in
+            T {data = Data.Empty dataSize,
+               location = location,
+               metadata = sequenceMetadata (tycon, length)}
+         end
 
    end

--- a/mlton/backend/static.fun
+++ b/mlton/backend/static.fun
@@ -46,9 +46,9 @@ functor Static (S: STATIC_STRUCTS): STATIC =
             end
 
          val size =
-            fn Empty bytes => (WordSize.word8, Bytes.toInt bytes)
-             | Vector v => (WordXVector.elementSize v, WordXVector.length v)
-             | Object es => (WordSize.objptr (), List.length es)
+            fn Empty bytes => bytes
+             | Vector v => Bytes.fromInt (Bytes.toInt (WordSize.bytes (WordXVector.elementSize v)) * WordXVector.length v)
+             | Object es => Bytes.fromInt (Bytes.toInt (WordSize.bytes (WordSize.objptr ())) * List.length es)
       end
       structure Location = struct
          datatype t =
@@ -84,6 +84,7 @@ functor Static (S: STATIC_STRUCTS): STATIC =
              ("metadata", List.layout (fn w => WordX.layout (w, {suffix = true})) metadata)]
          end
 
+      fun dataSize (T {data, ...}) = Data.size data
       fun metadataSize (T {metadata, ...}) =
          List.fold (metadata, Bytes.zero, fn (w, b) =>
                     Bytes.+ (WordSize.bytes (WordX.size w), b))

--- a/mlton/backend/static.fun
+++ b/mlton/backend/static.fun
@@ -55,23 +55,24 @@ functor Static (S: STATIC_STRUCTS): STATIC =
             MutStatic (* Mutable static, .data/.bss *)
           | ImmStatic (* Immutable static, .rodata, must be statically initialized *)
           | Heap (* Dynamically allocated in main *)
+
+         val layout =
+            fn MutStatic => Layout.str "MutStatic"
+             | ImmStatic => Layout.str "ImmStatic"
+             | Heap => Layout.str "Heap"
       end
       datatype 'a t =
          T of {data: 'a Data.t,
                location: Location.t,
                metadata: WordXVector.t} (* mapped in-order *)
 
-      val layoutLocation =
-         fn MutStatic => Layout.str "MutStatic"
-          | ImmStatic => Layout.str "ImmStatic"
-          | Heap => Layout.str "Heap"
       fun map (T {data, metadata, location}, f) =
          T {data=Data.map (data, f), metadata=metadata, location=location}
       fun layout layoutI (T {data, metadata, location}) =
          let open Layout
          in record
             [("data", Data.layout layoutI data),
-             ("location", layoutLocation location),
+             ("location", Location.layout location),
              ("metadata", WordXVector.layout metadata)]
          end
 

--- a/mlton/backend/static.fun
+++ b/mlton/backend/static.fun
@@ -71,12 +71,11 @@ functor Static (S: STATIC_STRUCTS): STATIC =
              ("location", layoutLocation location)]
          end
 
-
       fun object {elems, tycon, location} =
          let
             val header = Runtime.typeIndexToHeader (ObjptrTycon.index tycon)
             val header = WordX.fromIntInf (Word.toIntInf header, WordSize.objptrHeader ())
-            val header =  WordXVector.fromList
+            val header = WordXVector.fromList
                ({elementSize = WordSize.objptrHeader ()}, [header])
          in
             T
@@ -92,7 +91,7 @@ functor Static (S: STATIC_STRUCTS): STATIC =
             val wordSize = WordSize.objptr ()
             val length = WordX.fromIntInf (Int.toIntInf (WordXVector.length data), wordSize)
             val capacity = WordX.zero wordSize
-            val header =  WordXVector.fromList
+            val header = WordXVector.fromList
                ({elementSize = WordSize.objptrHeader ()}, [capacity, length, header])
          in
             T

--- a/mlton/backend/static.fun
+++ b/mlton/backend/static.fun
@@ -66,6 +66,14 @@ functor Static (S: STATIC_STRUCTS): STATIC =
                location: Location.t,
                metadata: WordX.t list} (* mapped in-order *)
 
+      local
+         fun mk sel (T r) = sel r
+      in
+         fun data s = mk #data s
+         fun location s = mk #location s
+         fun metadata s = mk #metadata s
+      end
+
       fun map (T {data, metadata, location}, f) =
          T {data=Data.map (data, f), metadata=metadata, location=location}
       fun layout layoutI (T {data, metadata, location}) =

--- a/mlton/backend/static.fun
+++ b/mlton/backend/static.fun
@@ -13,6 +13,7 @@ functor Static (S: STATIC_STRUCTS): STATIC =
          datatype 'a elem =
             Address of 'a (* must be statically allocated *)
           | Word of WordX.t (* must be pointer-sized *)
+          | Real of RealX.t
          datatype 'a t =
             Empty of Bytes.t
           | Object of ('a elem) list
@@ -23,13 +24,15 @@ functor Static (S: STATIC_STRUCTS): STATIC =
                  Empty b => Empty b
                | Object es => (Object o List.map) (es,
                   fn Address a => Address (f a)
-                   | Word wx => Word wx)
+                   | Word wx => Word wx
+                   | Real rx => Real rx)
                | Vector wxv => Vector wxv
 
          fun layoutElem layoutI =
             let open Layout
             in fn Address i => layoutI i
                 | Word w => WordX.layout (w, {suffix=true})
+                | Real r => RealX.layout (r, {suffix=true})
             end
 
          fun layout layoutI =

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -59,9 +59,9 @@ signature STATIC =
       val object: {elems: ('a Data.Elem.t) list,
                    location: Location.t,
                    tycon: ObjptrTycon.t} -> 'a t
-      val sequence: {length: int,
+      val sequence: {eltSize: Bytes.t,
+                     length: int,
                      location: Location.t,
-                     totalSize: Bytes.t,
                      tycon: ObjptrTycon.t} -> 'a t
       val vector: {data: WordXVector.t,
                    location: Location.t,

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -44,8 +44,8 @@ signature STATIC =
        | Heap (* Dynamically allocated in main *)
       datatype 'a t =
          T of {data: 'a Data.t,
-               header: WordXVector.t, (* mapped in-order *)
-               location: location}
+               location: location,
+               metadata: WordXVector.t} (* mapped in-order *)
 
       val object: {elems: ('a Data.elem) list,
                    location: location,

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -48,11 +48,15 @@ signature STATIC =
                location: location}
 
       val object: {elems: ('a Data.elem) list,
-                   tycon: ObjptrTycon.t,
-                   location: location} -> 'a t
+                   location: location,
+                   tycon: ObjptrTycon.t} -> 'a t
+      val sequence: {length: int,
+                     location: location,
+                     totalSize: Bytes.t,
+                     tycon: ObjptrTycon.t} -> 'a t
       val vector: {data: WordXVector.t,
-                   tycon: ObjptrTycon.t,
-                   location: location} -> 'a t
+                   location: location,
+                   tycon: ObjptrTycon.t} -> 'a t
 
       val map: ('a t * ('a -> 'b)) -> 'b t
       val layout: ('a -> Layout.t) -> 'a t -> Layout.t

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -52,6 +52,10 @@ signature STATIC =
                location: Location.t,
                metadata: WordX.t list} (* mapped in-order *)
 
+      val data: 'a t -> 'a Data.t
+      val location: 'a t -> Location.t
+      val metadata: 'a t -> WordX.t list
+
       val object: {elems: ('a Data.Elem.t) list,
                    location: Location.t,
                    tycon: ObjptrTycon.t} -> 'a t

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -5,11 +5,14 @@
  *)
 
 signature STATIC_STRUCTS = sig
-   structure WordX: WORD_X
+   structure RealSize: REAL_SIZE
+   structure RealX: REAL_X
    structure WordSize: WORD_SIZE
+   structure WordX: WORD_X
    structure WordXVector: WORD_X_VECTOR
    structure ObjptrTycon: OBJPTR_TYCON
    structure Runtime: RUNTIME
+   sharing RealX.RealSize = RealSize
    sharing WordX.WordSize = WordSize
    sharing WordXVector.WordSize = WordSize
    sharing WordXVector.WordX = WordX
@@ -23,6 +26,7 @@ signature STATIC =
          datatype 'a elem =
             Address of 'a (* must be statically allocated *)
           | Word of WordX.t
+          | Real of RealX.t
 
          datatype 'a t =
             Empty of Bytes.t

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -37,7 +37,6 @@ signature STATIC =
 
          val map: ('a t * ('a -> 'b)) -> 'b t
          val layout: ('a -> Layout.t) -> 'a t -> Layout.t
-         val size: 'a t -> WordSize.t * int
       end
 
 
@@ -53,8 +52,10 @@ signature STATIC =
                metadata: WordX.t list} (* mapped in-order *)
 
       val data: 'a t -> 'a Data.t
+      val dataSize: 'a t -> Bytes.t
       val location: 'a t -> Location.t
       val metadata: 'a t -> WordX.t list
+      val metadataSize: 'a t -> Bytes.t
 
       val object: {elems: ('a Data.Elem.t) list,
                    location: Location.t,
@@ -68,6 +69,5 @@ signature STATIC =
                    tycon: ObjptrTycon.t} -> 'a t
 
       val map: ('a t * ('a -> 'b)) -> 'b t
-      val metadataSize: 'a t -> Bytes.t
       val layout: ('a -> Layout.t) -> 'a t -> Layout.t
    end

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -5,13 +5,13 @@
  *)
 
 signature STATIC_STRUCTS = sig
+   structure ObjptrTycon: OBJPTR_TYCON
    structure RealSize: REAL_SIZE
    structure RealX: REAL_X
+   structure Runtime: RUNTIME
    structure WordSize: WORD_SIZE
    structure WordX: WORD_X
    structure WordXVector: WORD_X_VECTOR
-   structure ObjptrTycon: OBJPTR_TYCON
-   structure Runtime: RUNTIME
    sharing RealX.RealSize = RealSize
    sharing WordX.WordSize = WordSize
    sharing WordXVector.WordSize = WordSize
@@ -57,4 +57,3 @@ signature STATIC =
       val map: ('a t * ('a -> 'b)) -> 'b t
       val layout: ('a -> Layout.t) -> 'a t -> Layout.t
    end
-

--- a/mlton/backend/static.sig
+++ b/mlton/backend/static.sig
@@ -50,7 +50,7 @@ signature STATIC =
       datatype 'a t =
          T of {data: 'a Data.t,
                location: Location.t,
-               metadata: WordXVector.t} (* mapped in-order *)
+               metadata: WordX.t list} (* mapped in-order *)
 
       val object: {elems: ('a Data.Elem.t) list,
                    location: Location.t,
@@ -64,5 +64,6 @@ signature STATIC =
                    tycon: ObjptrTycon.t} -> 'a t
 
       val map: ('a t * ('a -> 'b)) -> 'b t
+      val metadataSize: 'a t -> Bytes.t
       val layout: ('a -> Layout.t) -> 'a t -> Layout.t
    end

--- a/mlton/codegen/amd64-codegen/amd64-mlton-basic.fun
+++ b/mlton/codegen/amd64-codegen/amd64-mlton-basic.fun
@@ -280,7 +280,6 @@ struct
        (static_labels, i, fn () => make i)
   end
 
-
   structure Field = Runtime.GCField
   fun make' (offset: int, size, class) =
      let

--- a/mlton/codegen/amd64-codegen/amd64-translate.fun
+++ b/mlton/codegen/amd64-codegen/amd64-translate.fun
@@ -246,7 +246,7 @@ struct
                   in
                      fromSizes (sizes, origin)
                   end
-             | Static {index, offset, ty} =>
+             | Static {index, offset, ...} =>
                   let
                      val offset = Bytes.toInt offset
                      val base = amd64.Immediate.labelPlusInt

--- a/mlton/codegen/amd64-codegen/amd64-translate.fun
+++ b/mlton/codegen/amd64-codegen/amd64-translate.fun
@@ -125,14 +125,14 @@ struct
                                index = index,
                                scale = scale,
                                size = amd64.Size.BYTE,
-                               class = amd64MLton.Classes.Code}
+                               class = amd64MLton.Classes.Heap}
                          | (_, SOME base, _, SOME index) =>
                               amd64.MemLoc.basic
                               {base = base,
                                index = index,
                                scale = scale,
                                size = amd64.Size.BYTE,
-                               class = amd64MLton.Classes.Code}
+                               class = amd64MLton.Classes.Heap}
 
                          | _ => Error.bug (concat ["amd64Translate.Operand.toAMD64Operand: ",
                                                    "strange SequenceOffset: base: ",

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -146,12 +146,10 @@ structure WordXVector =
 structure Static =
    struct
       local
-         structure WordSize' = WordSize
          structure WordX' = WordX
          structure WordXVector' = WordXVector
       in
          open Static
-         structure WordSize = WordSize'
          structure WordX = WordX'
          structure WordXVector = WordXVector'
       end
@@ -321,13 +319,6 @@ fun outputDeclarations
          in
             ()
          end
-      local
-         val cid = Counter.new 0
-         val cvar = Counter.new 0
-      in
-         val nextId = fn () => Counter.next cid
-         val nextStaticVar = fn () => Counter.next cvar
-      end
       fun staticVar i =
          "static_" ^ Int.toString i
       fun headerSize i =
@@ -339,7 +330,7 @@ fun outputDeclarations
 
       fun declareStatics () =
          (Vector.foreachi
-          (statics, fn (i, (Machine.Static.T {data, header, location}, g)) =>
+          (statics, fn (i, (Machine.Static.T {data, header, location}, _)) =>
              let
                 val dataC = Static.Data.toC staticAddress data
                 datatype dataType =
@@ -394,7 +385,7 @@ fun outputDeclarations
 
          (print "static struct GC_objectInit objectInits[] = {\n"
           ; (Vector.foreachi
-             (statics, fn (i, (Machine.Static.T {data, header, location}, g)) =>
+             (statics, fn (i, (Machine.Static.T {data, header, ...}, g)) =>
              let
                 val (dataWidth, dataSize) = Static.Data.size data
                 val dataBytes = dataSize * (Bytes.toInt (WordSize.bytes dataWidth))
@@ -414,7 +405,7 @@ fun outputDeclarations
       fun declareStaticInits () =
          (print "static void static_Init() {\n"
           ; (Vector.foreachi
-             (statics, fn (i, (Machine.Static.T {data, header, location}, g)) =>
+             (statics, fn (i, (Machine.Static.T {data, header, location}, _)) =>
              let
                 val shouldInit =
                    (case location of
@@ -1280,7 +1271,7 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, statics, ...
 
       fun declareStatics (prefix: string, print) =
          Vector.foreachi (statics,
-            fn (i, (Static.T {header, ...}, _)) =>
+            fn (i, (Static.T _, _)) =>
                print (concat [prefix, "PointerAux static_", C.int i, ";\n"]))
 
       fun outputChunks chunks =

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -57,16 +57,6 @@ structure C =
          call ("\tPush", [bytes size], print)
    end
 
-structure RealSize =
-   struct
-      open RealSize
-
-      fun toC (rs: t): string =
-         case rs of
-            R32 => "32"
-          | R64 => "64"
-   end
-
 structure RealX =
    struct
       open RealX
@@ -93,29 +83,12 @@ structure RealX =
          end
    end
 
-structure WordSize =
-   struct
-      open WordSize
-
-      fun toC (ws: t): string =
-         case prim ws of
-            W8 => "8"
-          | W16 => "16"
-          | W32 => "32"
-          | W64 => "64"
-   end
-
 structure WordX =
    struct
-      local
-         structure Z = WordSize
-      in
-         open WordX
-         structure WordSize = Z
-      end
+      open WordX
 
       fun toC (w: t): string =
-         concat ["(Word", WordSize.toC (size w), ")(",
+         concat ["(Word", WordSize.toString (size w), ")(",
                  toString (w, {suffix = false}), "ull)"]
    end
 
@@ -353,22 +326,20 @@ fun outputDeclarations
                    case data of
                       Static.Data.Object es =>
                          (TObject o List.map) (es,
-                           fn Static.Data.Real r => "Real" ^ RealSize.toC (RealX.size r)
-                            | Static.Data.Word w => "Word" ^ WordSize.toC (WordX.size w)
+                           fn Static.Data.Real r => "Real" ^ RealSize.toString (RealX.size r)
+                            | Static.Data.Word w => "Word" ^ WordSize.toString (WordX.size w)
                             | Static.Data.Address _ => "Pointer")
                     | Static.Data.Vector v =>
-                         TVector ("Word" ^ WordSize.toC (WordXVector.elementSize v), WordXVector.length v)
+                         TVector ("Word" ^ WordSize.toString (WordXVector.elementSize v), WordXVector.length v)
                     | Static.Data.Empty b =>
-                         TVector ("Word" ^ WordSize.toC WordSize.byte, Bytes.toInt b)
+                         TVector ("Word" ^ WordSize.toString WordSize.byte, Bytes.toInt b)
                 val dataDescr =
                    case dataType of
                       TObject strings => (concat o List.mapi) (strings,
                            fn (i, s) => concat [s, " data_", C.int i, "; "])
                     | TVector (str, length) => concat [str, " data[", C.int length, "];"]
-
-
                 val headerElems = Int.toString (WordXVector.length header)
-                val headerTypeStr = "Word" ^ (WordSize.toC o WordSize.objptr) ()
+                val headerTypeStr = "Word" ^ (WordSize.toString o WordSize.objptr) ()
                 val qualifier =
                    let datatype z = datatype Machine.Static.location in
                    case location of

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -396,7 +396,6 @@ fun outputDeclarations
                    | NONE => print (decl ^ ";\n")
              end))
       fun declareHeapStatics () =
-
          (print "static struct GC_objectInit objectInits[] = {\n"
           ; (Vector.foreachi
              (statics, fn (i, (Machine.Static.T {data, header, ...}, g)) =>
@@ -420,25 +419,25 @@ fun outputDeclarations
          (print "static void static_Init() {\n"
           ; (Vector.foreachi
              (statics, fn (i, (Machine.Static.T {data, header, location}, _)) =>
-             let
-                val shouldInit =
-                   (case location of
-                      Machine.Static.Heap => false
-                    | _ => true)
+              let
+                 val shouldInit =
+                    (case location of
+                        Machine.Static.Heap => false
+                      | _ => true)
                     andalso
-                   (case data of
-                      Machine.Static.Data.Empty _ => true
-                    | _ => false)
-                val headerBytes = WordXVector.size header
-             in
-                if shouldInit
-                then C.call ("memcpy",
-                           ["&" ^ staticVar i,
-                            "&" ^ WordXVector.literal header,
-                            C.bytes headerBytes],
-                           print)
-                else ()
-             end))
+                    (case data of
+                        Machine.Static.Data.Empty _ => true
+                      | _ => false)
+                 val headerBytes = WordXVector.size header
+              in
+                 if shouldInit
+                    then C.call ("\tmemcpy",
+                                 ["&" ^ staticVar i,
+                                  "&" ^ WordXVector.literal header,
+                                  C.bytes headerBytes],
+                                 print)
+                    else ()
+              end))
           ; print "};\n")
 
       fun declareReals () =

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -352,12 +352,12 @@ fun outputDeclarations
                       | Heap => "const static " (* Will just be handed to GC by address *)
                    end
 
-                val structName = concat
+                val decl = concat
                    [ qualifier, "struct { ",
                      headerTypeStr, " header[", headerElems, "]; ",
                      dataDescr,
-                   "}\n"]
-                val decl = concat [structName, " ", staticVar i]
+                     "}\n",
+                     staticVar i ]
              in
                 case dataC of
                      SOME init =>
@@ -378,7 +378,7 @@ fun outputDeclarations
                 case g of
                      NONE => ()
                    | SOME g' =>
-                      (print o concat) ["{ ",
+                      (print o concat) ["\t{ ",
                               C.int (Global.index g'), ", ",
                               C.int headerBytes, ", ",
                               C.int (headerBytes + dataBytes), ", ",

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -268,7 +268,7 @@ fun declareGlobals (prefix: string, print) =
              val s = CType.toString t
              val n = Global.numberOfType t
           in
-             if n > 0
+             if n > 0 orelse CType.equals (t, CType.Objptr)
                 then print (concat [prefix, s, " global", s, " [", C.int n, "];\n"])
                 else ()
           end)

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -149,9 +149,9 @@ structure Static =
              | Object es =>
                   let
                      val elemToC =
-                        fn Real rx => RealX.toC rx
-                         | Word wx => WordX.toC wx
-                         | Address i => indexToC i
+                        fn Elem.Real rx => RealX.toC rx
+                         | Elem.Word wx => WordX.toC wx
+                         | Elem.Address i => indexToC i
                   in
                      (SOME o String.concatWith)
                      (List.map (es, elemToC),
@@ -326,9 +326,9 @@ fun outputDeclarations
                    case data of
                       Static.Data.Object es =>
                          (TObject o List.map) (es,
-                           fn Static.Data.Real r => "Real" ^ RealSize.toString (RealX.size r)
-                            | Static.Data.Word w => "Word" ^ WordSize.toString (WordX.size w)
-                            | Static.Data.Address _ => "Pointer")
+                           fn Static.Data.Elem.Real r => "Real" ^ RealSize.toString (RealX.size r)
+                            | Static.Data.Elem.Word w => "Word" ^ WordSize.toString (WordX.size w)
+                            | Static.Data.Elem.Address _ => "Pointer")
                     | Static.Data.Vector v =>
                          TVector ("Word" ^ WordSize.toString (WordXVector.elementSize v), WordXVector.length v)
                     | Static.Data.Empty b =>
@@ -341,7 +341,7 @@ fun outputDeclarations
                 val metadataElems = Int.toString (WordXVector.length metadata)
                 val metadataTypeStr = "Word" ^ (WordSize.toString o WordSize.objptr) ()
                 val qualifier =
-                   let datatype z = datatype Machine.Static.location in
+                   let datatype z = datatype Machine.Static.Location.t in
                    case location of
                         MutStatic => ""
                       | ImmStatic =>
@@ -393,7 +393,7 @@ fun outputDeclarations
               let
                  val shouldInit =
                     (case location of
-                        Machine.Static.Heap => false
+                        Machine.Static.Location.Heap => false
                       | _ => true)
                     andalso
                     (case data of
@@ -1257,7 +1257,7 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, statics, ...
          Vector.foreachi
          (statics, fn (i, (Static.T {location, ...}, _)) =>
           case location of
-             Static.Heap => ()
+             Static.Location.Heap => ()
            | _ => print (concat [prefix, "PointerAux static_", C.int i, ";\n"]))
 
       fun outputChunks chunks =

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -57,6 +57,16 @@ structure C =
          call ("\tPush", [bytes size], print)
    end
 
+structure RealSize =
+   struct
+      open RealSize
+
+      fun toC (rs: t): string =
+         case rs of
+            R32 => "32"
+          | R64 => "64"
+   end
+
 structure RealX =
    struct
       open RealX
@@ -146,10 +156,12 @@ structure WordXVector =
 structure Static =
    struct
       local
+         structure RealX' = RealX
          structure WordX' = WordX
          structure WordXVector' = WordXVector
       in
          open Static
+         structure RealX = RealX'
          structure WordX = WordX'
          structure WordXVector = WordXVector'
       end
@@ -164,7 +176,8 @@ structure Static =
              | Object es =>
                   let
                      val elemToC =
-                        fn Word wx => WordX.toC wx
+                        fn Real rx => RealX.toC rx
+                         | Word wx => WordX.toC wx
                          | Address i => indexToC i
                   in
                      (SOME o String.concatWith)
@@ -340,7 +353,8 @@ fun outputDeclarations
                    case data of
                       Static.Data.Object es =>
                          (TObject o List.map) (es,
-                           fn Static.Data.Word w => "Word" ^ WordSize.toC (WordX.size w)
+                           fn Static.Data.Real r => "Real" ^ RealSize.toC (RealX.size r)
+                            | Static.Data.Word w => "Word" ^ WordSize.toC (WordX.size w)
                             | Static.Data.Address _ => "Pointer")
                     | Static.Data.Vector v =>
                          TVector ("Word" ^ WordSize.toC (WordXVector.elementSize v), WordXVector.length v)

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -1254,9 +1254,11 @@ fun output {program as Machine.Program.T {chunks, frameInfos, main, statics, ...
          end
 
       fun declareStatics (prefix: string, print) =
-         Vector.foreachi (statics,
-            fn (i, (Static.T _, _)) =>
-               print (concat [prefix, "PointerAux static_", C.int i, ";\n"]))
+         Vector.foreachi
+         (statics, fn (i, (Static.T {location, ...}, _)) =>
+          case location of
+             Static.Heap => ()
+           | _ => print (concat [prefix, "PointerAux static_", C.int i, ";\n"]))
 
       fun outputChunks chunks =
          let

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -374,10 +374,9 @@ fun outputDeclarations
       fun declareHeapStatics () =
          (print "static struct GC_objectInit objectInits[] = {\n"
           ; (Vector.foreachi
-             (statics, fn (i, (static as Machine.Static.T {data, ...}, g)) =>
+             (statics, fn (i, (static, g)) =>
              let
-                val (dataWidth, dataSize) = Static.Data.size data
-                val dataBytes = dataSize * (Bytes.toInt (WordSize.bytes dataWidth))
+                val dataBytes = Bytes.toInt (Static.dataSize static)
                 val metadataBytes = Bytes.toInt (Static.metadataSize static)
              in
                 case g of

--- a/mlton/codegen/llvm-codegen/llvm-codegen.fun
+++ b/mlton/codegen/llvm-codegen/llvm-codegen.fun
@@ -1290,9 +1290,9 @@ fun outputLLVMDeclarations (statics, print) =
                           kw, " ", staticType, "\n"]
             in
                case location of
-                  Static.ImmStatic => doit "constant"
-                | Static.MutStatic => doit "global"
-                | Static.Heap => ""
+                  Static.Location.ImmStatic => doit "constant"
+                | Static.Location.MutStatic => doit "global"
+                | Static.Location.Heap => ""
             end)
     in
         print (concat [llvmIntrinsics, "\n", mltypes, "\n", ctypes (),

--- a/mlton/codegen/x86-codegen/x86-mlton-basic.fun
+++ b/mlton/codegen/x86-codegen/x86-mlton-basic.fun
@@ -332,6 +332,15 @@ struct
 
   val gcState_label = Label.fromString "gcState"
 
+  local
+     val static_labels = HashTable.new
+      {hash=Hash.permute o Word.fromInt, equals=Int.equals}
+     fun make i = Label.fromString ("static_" ^ Int.toString i)
+  in
+     fun static_label i = HashTable.lookupOrInsert
+       (static_labels, i, fn () => make i)
+  end
+
   structure Field = Runtime.GCField
   fun make' (offset: int, size, class) =
      let

--- a/mlton/codegen/x86-codegen/x86-mlton-basic.sig
+++ b/mlton/codegen/x86-codegen/x86-mlton-basic.sig
@@ -100,6 +100,9 @@ signature X86_MLTON_BASIC =
     val local_base : x86.CType.t -> x86.Label.t
     val global_base : x86.CType.t -> x86.Label.t
 
+    (* Machine statics *)
+    val static_label: int -> x86.Label.t
+
     (* gcState relative locations defined in gc.h *)
     val gcState_label: x86.Label.t
     val gcState_offset: {offset: int, ty: x86.CType.t} -> x86.Operand.t

--- a/mlton/codegen/x86-codegen/x86-translate.fun
+++ b/mlton/codegen/x86-codegen/x86-translate.fun
@@ -246,7 +246,7 @@ struct
                   in
                      fromSizes (sizes, origin)
                   end
-              | Static {index, offset, ty} =>
+              | Static {index, offset, ...} =>
                   let
                      val offset = Bytes.toInt offset
                      val base = x86.Immediate.labelPlusInt

--- a/mlton/codegen/x86-codegen/x86-translate.fun
+++ b/mlton/codegen/x86-codegen/x86-translate.fun
@@ -82,224 +82,223 @@ struct
                 scale = x86.Scale.One,
                 size = size}, size), offset + x86.Size.toBytes size))
       in
-         val rec toX86Operand : t -> (x86.Operand.t * x86.Size.t) vector =
-            fn SequenceOffset {base, index, offset, scale, ty}
-               => let
-                     val base = toX86Operand base
-                     val _ = Assert.assert("x86Translate.Operand.toX86Operand: Array/base",
-                                           fn () => Vector.length base = 1)
-                     val base = getOp0 base
-                     val index = toX86Operand index
-                     val _ = Assert.assert("x86Translate.Operand.toX86Operand: Array/index",
-                                          fn () => Vector.length index = 1)
-                     val index = getOp0 index
-                     val scale =
-                        case scale of
-                           Scale.One => x86.Scale.One
-                         | Scale.Two => x86.Scale.Two
-                         | Scale.Four => x86.Scale.Four
-                         | Scale.Eight => x86.Scale.Eight
-                     val ty = Type.toCType ty
-                     val origin =
-                        case (x86.Operand.deMemloc base,
-                              x86.Operand.deImmediate base,
-                              x86.Operand.deImmediate index,
-                              x86.Operand.deMemloc index) of
-                           (SOME base, _, SOME index, _) =>
-                              x86.MemLoc.simple 
-                              {base = base,
-                               index = index,
-                               scale = scale,
-                               size = x86.Size.BYTE,
-                               class = x86MLton.Classes.Heap}
-                         | (SOME base, _, _, SOME index) =>
-                              x86.MemLoc.complex 
-                              {base = base,
-                               index = index,
-                               scale = scale,
-                               size = x86.Size.BYTE,
-                               class = x86MLton.Classes.Heap}
-                         | (_, SOME base, SOME index, _) =>
-                              x86.MemLoc.imm
-                              {base = base,
-                               index = index,
-                               scale = scale,
-                               size = x86.Size.BYTE,
-                               class = x86MLton.Classes.Heap}
-                         | (_, SOME base, _, SOME index) =>
-                              x86.MemLoc.basic
-                              {base = base,
-                               index = index,
-                               scale = scale,
-                               size = x86.Size.BYTE,
-                               class = x86MLton.Classes.Heap}
-
-                         | _ => Error.bug (concat ["x86Translate.Operand.toX86Operand: ",
-                                                   "strange SequenceOffset: base: ",
-                                                   x86.Operand.toString base,
-                                                   " index: ",
-                                                   x86.Operand.toString index])
-                     val origin =
-                        if Bytes.isZero offset
-                           then origin
-                           else x86.MemLoc.shift
-                                {origin = origin,
-                                 disp = x86.Immediate.int (Bytes.toInt offset),
-                                 scale = x86.Scale.One,
-                                 size = x86.Size.BYTE}
-                     val sizes = x86.Size.fromCType ty
-                  in
-                    fromSizes (sizes, origin)
-                  end
-             | Cast (z, _) => toX86Operand z
-             | Contents {oper, ty} =>
-                  let
-                     val ty = Type.toCType ty
-                     val base = toX86Operand oper
-                     val _ = Assert.assert("x86Translate.Operand.toX86Operand: Contents/base",
-                                           fn () => Vector.length base = 1)
-                     val base = getOp0 base
-                     val origin =
-                        case x86.Operand.deMemloc base of
-                           SOME base =>
-                              x86.MemLoc.simple 
-                              {base = base,
-                               index = x86.Immediate.zero,
-                               scale = x86.Scale.One,
-                               size = x86.Size.BYTE,
-                               class = x86MLton.Classes.Heap}
-                         | _ => Error.bug (concat
-                                           ["x86Translate.Operand.toX86Operand: ",
-                                            "strange Contents: base: ",
-                                            x86.Operand.toString base])    
-                     val sizes = x86.Size.fromCType ty
-                  in
-                     fromSizes (sizes, origin)
-                  end
-             | Frontier => 
-                  let 
-                     val frontier = x86MLton.gcState_frontierContentsOperand ()
-                  in
-                     Vector.new1 (frontier, valOf (x86.Operand.size frontier))
-                  end
-             | GCState => 
-                  Vector.new1 (x86.Operand.immediate_label x86MLton.gcState_label,
-                               x86MLton.pointerSize)
-             | Global g => Global.toX86Operand g
-             | Label l => 
-                  Vector.new1 (x86.Operand.immediate_label l, x86MLton.pointerSize)
-             | Null => 
-                  Vector.new1 (x86.Operand.immediate_zero, x86MLton.wordSize)
-             | Offset {base = GCState, offset, ty} =>
-                  let
-                     val offset = Bytes.toInt offset
-                     val ty = Type.toCType ty
-                     val offset = x86MLton.gcState_offset {offset = offset, ty = ty}
-                  in
-                     Vector.new1 (offset, valOf (x86.Operand.size offset))
-                  end
-             | Offset {base, offset, ty} =>
-                  let
-                     val offset = Bytes.toInt offset
-                    val ty = Type.toCType ty
-                    val base = toX86Operand base
-                    val _ = Assert.assert("x86Translate.Operand.toX86Operand: Offset/base",
-                                          fn () => Vector.length base = 1)
-                    val base = getOp0 base
-                    val origin =
-                       (case (x86.Operand.deMemloc base,
-                              x86.Operand.deImmediate base) of
-                          (SOME base, _) =>
-                            x86.MemLoc.simple
-                            {base = base,
-                             index = x86.Immediate.int offset,
-                             scale = x86.Scale.One,
-                             size = x86.Size.BYTE,
-                             class = x86MLton.Classes.Heap}
-                        | (_, SOME base) =>
-                            x86.MemLoc.imm
-                            {base = base,
-                             index = x86.Immediate.int offset,
-                             scale = x86.Scale.One,
-                             size = x86.Size.BYTE,
-                             class = x86MLton.Classes.Heap}
-                        | _ => Error.bug (concat ["x86Translate.Operand.toX86Operand: ",
-                                                  "strange Offset: base: ",
-                                                  x86.Operand.toString base]))
-                     val sizes = x86.Size.fromCType ty
-                  in
-                     fromSizes (sizes, origin)
-                  end
-             | Real _ => Error.bug "x86Translate.Operand.toX86Operand: Real unimplemented"
-             | StackOffset (StackOffset.T {offset, ty}) =>
-                  let
-                     val offset = Bytes.toInt offset
-                     val ty = Type.toCType ty
-                     val origin =
-                        x86.MemLoc.simple 
-                        {base = x86MLton.gcState_stackTopContents (), 
-                         index = x86.Immediate.int offset,
-                         scale = x86.Scale.One,
-                         size = x86.Size.BYTE,
-                         class = x86MLton.Classes.Stack}
-                     val sizes = x86.Size.fromCType ty
-                  in
-                     fromSizes (sizes, origin)
-                  end
-              | Static {index, offset, ...} =>
-                  let
-                     val offset = Bytes.toInt offset
-                     val base = x86.Immediate.labelPlusInt
-                           (x86MLton.static_label index, offset)
-                  in
-                     Vector.new1 (x86.Operand.immediate base, x86MLton.pointerSize)
-                  end
-             | StackTop => 
-                  let 
-                     val stackTop = x86MLton.gcState_stackTopContentsOperand ()
-                  in
-                     Vector.new1 (stackTop, valOf (x86.Operand.size stackTop))
-                  end
-             | Temporary t =>
-                  let
-                     val ty = Machine.Type.toCType (Temporary.ty t)
-                     val index = Machine.Temporary.index t
-                     val base = x86.Immediate.label (x86MLton.local_base ty)
-                     val origin =
-                        x86.MemLoc.imm
-                        {base = base,
-                         index = x86.Immediate.int index,
-                         scale = x86.Scale.fromCType ty,
-                         size = x86.Size.BYTE,
-                         class = x86MLton.Classes.Locals}
-                     val sizes = x86.Size.fromCType ty
-                  in
-                     fromSizes (sizes, origin)
-                  end
-             | Word w =>
-                  let
-                     fun single size =
-                        Vector.new1 (x86.Operand.immediate_word w, size)
-                  in
-                     case WordSize.prim (WordX.size w) of
-                        W8 => single x86.Size.BYTE
-                      | W16 => single x86.Size.WORD
-                      | W32 => single x86.Size.LONG
-                      | W64 =>
-                           let
-                              val lo = WordX.resize (w, WordSize.word32)
-                              val w = WordX.rshift (w, 
-                                                    WordX.fromIntInf (32, WordSize.word64),
-                                                    {signed = true})
-                              val hi = WordX.resize (w, WordSize.word32)
-                           in
-                              Vector.new2
-                              ((x86.Operand.immediate_word lo, x86.Size.LONG),
-                               (x86.Operand.immediate_word hi, x86.Size.LONG))
-                           end
-                  end
+      val rec toX86Operand : t -> (x86.Operand.t * x86.Size.t) vector =
+         fn SequenceOffset {base, index, offset, scale, ty}
+            => let
+                  val base = toX86Operand base
+                  val _ = Assert.assert("x86Translate.Operand.toX86Operand: SequenceOffset/base",
+                                        fn () => Vector.length base = 1)
+                  val base = getOp0 base
+                  val index = toX86Operand index
+                  val _ = Assert.assert("x86Translate.Operand.toX86Operand: SequenceOffset/index",
+                                       fn () => Vector.length index = 1)
+                  val index = getOp0 index
+                  val scale =
+                     case scale of
+                        Scale.One => x86.Scale.One
+                      | Scale.Two => x86.Scale.Two
+                      | Scale.Four => x86.Scale.Four
+                      | Scale.Eight => x86.Scale.Eight
+                  val ty = Type.toCType ty
+                  val origin =
+                     case (x86.Operand.deImmediate base,
+                           x86.Operand.deMemloc base,
+                           x86.Operand.deImmediate index,
+                           x86.Operand.deMemloc index) of
+                        (SOME base, _, SOME index, _) =>
+                           x86.MemLoc.imm
+                           {base = base,
+                            index = index,
+                            scale = scale,
+                            size = x86.Size.BYTE,
+                            class = x86MLton.Classes.Heap}
+                      | (SOME base, _, _, SOME index) =>
+                           x86.MemLoc.basic
+                           {base = base,
+                            index = index,
+                            scale = scale,
+                            size = x86.Size.BYTE,
+                            class = x86MLton.Classes.Heap}
+                      | (_, SOME base, SOME index, _) =>
+                           x86.MemLoc.simple
+                           {base = base,
+                            index = index,
+                            scale = scale,
+                            size = x86.Size.BYTE,
+                            class = x86MLton.Classes.Heap}
+                      | (_, SOME base, _, SOME index) =>
+                           x86.MemLoc.complex
+                           {base = base,
+                            index = index,
+                            scale = scale,
+                            size = x86.Size.BYTE,
+                            class = x86MLton.Classes.Heap}
+                      | _ => Error.bug (concat ["x86Translate.Operand.toX86Operand: ",
+                                                "strange SequenceOffset: base: ",
+                                                x86.Operand.toString base,
+                                                " index: ",
+                                                x86.Operand.toString index])
+                  val origin =
+                     if Bytes.isZero offset
+                        then origin
+                        else x86.MemLoc.shift
+                             {origin = origin,
+                              disp = x86.Immediate.int (Bytes.toInt offset),
+                              scale = x86.Scale.One,
+                              size = x86.Size.BYTE}
+                  val sizes = x86.Size.fromCType ty
+               in
+                 fromSizes (sizes, origin)
+               end
+          | Cast (z, _) => toX86Operand z
+          | Contents {oper, ty} =>
+               let
+                  val ty = Type.toCType ty
+                  val base = toX86Operand oper
+                  val _ = Assert.assert("x86Translate.Operand.toX86Operand: Contents/base",
+                                        fn () => Vector.length base = 1)
+                  val base = getOp0 base
+                  val origin =
+                     case x86.Operand.deMemloc base of
+                        SOME base =>
+                           x86.MemLoc.simple 
+                           {base = base,
+                            index = x86.Immediate.zero,
+                            scale = x86.Scale.One,
+                            size = x86.Size.BYTE,
+                            class = x86MLton.Classes.Heap}
+                      | _ => Error.bug (concat
+                                        ["x86Translate.Operand.toX86Operand: ",
+                                         "strange Contents: base: ",
+                                         x86.Operand.toString base])    
+                  val sizes = x86.Size.fromCType ty
+               in
+                  fromSizes (sizes, origin)
+               end
+          | Frontier => 
+               let 
+                  val frontier = x86MLton.gcState_frontierContentsOperand ()
+               in
+                  Vector.new1 (frontier, valOf (x86.Operand.size frontier))
+               end
+          | GCState => 
+               Vector.new1 (x86.Operand.immediate_label x86MLton.gcState_label,
+                            x86MLton.pointerSize)
+          | Global g => Global.toX86Operand g
+          | Label l => 
+               Vector.new1 (x86.Operand.immediate_label l, x86MLton.pointerSize)
+          | Null => 
+               Vector.new1 (x86.Operand.immediate_zero, x86MLton.wordSize)
+          | Offset {base = GCState, offset, ty} =>
+               let
+                  val offset = Bytes.toInt offset
+                  val ty = Type.toCType ty
+                  val offset = x86MLton.gcState_offset {offset = offset, ty = ty}
+               in
+                  Vector.new1 (offset, valOf (x86.Operand.size offset))
+               end
+          | Offset {base, offset, ty} =>
+               let
+                  val offset = Bytes.toInt offset
+                 val ty = Type.toCType ty
+                 val base = toX86Operand base
+                 val _ = Assert.assert("x86Translate.Operand.toX86Operand: Offset/base",
+                                       fn () => Vector.length base = 1)
+                 val base = getOp0 base
+                 val origin =
+                    case (x86.Operand.deImmediate base,
+                          x86.Operand.deMemloc base) of
+                       (SOME base, _) =>
+                          x86.MemLoc.imm
+                          {base = base,
+                           index = x86.Immediate.int offset,
+                           scale = x86.Scale.One,
+                           size = x86.Size.BYTE,
+                           class = x86MLton.Classes.Heap}
+                     | (_, SOME base) =>
+                          x86.MemLoc.simple
+                          {base = base,
+                           index = x86.Immediate.int offset,
+                           scale = x86.Scale.One,
+                           size = x86.Size.BYTE,
+                           class = x86MLton.Classes.Heap}
+                     | _ => Error.bug (concat ["x86Translate.Operand.toX86Operand: ",
+                                               "strange Offset: base: ",
+                                               x86.Operand.toString base])
+                 val sizes = x86.Size.fromCType ty
+               in
+                  fromSizes (sizes, origin)
+               end
+          | Real _ => Error.bug "x86Translate.Operand.toX86Operand: Real unimplemented"
+          | StackOffset (StackOffset.T {offset, ty}) =>
+               let
+                  val offset = Bytes.toInt offset
+                  val ty = Type.toCType ty
+                  val origin =
+                     x86.MemLoc.simple 
+                     {base = x86MLton.gcState_stackTopContents (), 
+                      index = x86.Immediate.int offset,
+                      scale = x86.Scale.One,
+                      size = x86.Size.BYTE,
+                      class = x86MLton.Classes.Stack}
+                  val sizes = x86.Size.fromCType ty
+               in
+                  fromSizes (sizes, origin)
+               end
+           | Static {index, offset, ...} =>
+               let
+                  val offset = Bytes.toInt offset
+                  val base = x86.Immediate.labelPlusInt
+                        (x86MLton.static_label index, offset)
+               in
+                  Vector.new1 (x86.Operand.immediate base, x86MLton.pointerSize)
+               end
+          | StackTop => 
+               let 
+                  val stackTop = x86MLton.gcState_stackTopContentsOperand ()
+               in
+                  Vector.new1 (stackTop, valOf (x86.Operand.size stackTop))
+               end
+          | Temporary t =>
+               let
+                  val ty = Machine.Type.toCType (Temporary.ty t)
+                  val index = Machine.Temporary.index t
+                  val base = x86.Immediate.label (x86MLton.local_base ty)
+                  val origin =
+                     x86.MemLoc.imm
+                     {base = base,
+                      index = x86.Immediate.int index,
+                      scale = x86.Scale.fromCType ty,
+                      size = x86.Size.BYTE,
+                      class = x86MLton.Classes.Locals}
+                  val sizes = x86.Size.fromCType ty
+               in
+                  fromSizes (sizes, origin)
+               end
+          | Word w =>
+               let
+                  fun single size =
+                     Vector.new1 (x86.Operand.immediate_word w, size)
+               in
+                  case WordSize.prim (WordX.size w) of
+                     W8 => single x86.Size.BYTE
+                   | W16 => single x86.Size.WORD
+                   | W32 => single x86.Size.LONG
+                   | W64 =>
+                        let
+                           val lo = WordX.resize (w, WordSize.word32)
+                           val w = WordX.rshift (w, 
+                                                 WordX.fromIntInf (32, WordSize.word64),
+                                                 {signed = true})
+                           val hi = WordX.resize (w, WordSize.word32)
+                        in
+                           Vector.new2
+                           ((x86.Operand.immediate_word lo, x86.Size.LONG),
+                            (x86.Operand.immediate_word hi, x86.Size.LONG))
+                        end
+               end
       end
-  end
+    end
 
   type transInfo = x86MLton.transInfo
 

--- a/mlton/codegen/x86-codegen/x86-translate.fun
+++ b/mlton/codegen/x86-codegen/x86-translate.fun
@@ -125,14 +125,14 @@ struct
                                index = index,
                                scale = scale,
                                size = x86.Size.BYTE,
-                               class = x86MLton.Classes.Code}
+                               class = x86MLton.Classes.Heap}
                          | (_, SOME base, _, SOME index) =>
                               x86.MemLoc.basic
                               {base = base,
                                index = index,
                                scale = scale,
                                size = x86.Size.BYTE,
-                               class = x86MLton.Classes.Code}
+                               class = x86MLton.Classes.Heap}
 
                          | _ => Error.bug (concat ["x86Translate.Operand.toX86Operand: ",
                                                    "strange SequenceOffset: base: ",
@@ -222,7 +222,7 @@ struct
                              index = x86.Immediate.int offset,
                              scale = x86.Scale.One,
                              size = x86.Size.BYTE,
-                             class = x86MLton.Classes.Code}
+                             class = x86MLton.Classes.Heap}
                         | _ => Error.bug (concat ["x86Translate.Operand.toX86Operand: ",
                                                   "strange Offset: base: ",
                                                   x86.Operand.toString base]))

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -400,9 +400,14 @@ signature CONTROL_FLAGS =
        | Static
        | None
       val staticAllocInternalPtrs: staticAllocInternalPtrs ref
-      val staticAllocWordVectorConsts: bool ref
+
       val staticInitArrays: bool ref
+      val staticAllocArrays: bool ref
+
       val staticInitObjects: bool option ref
+      val staticAllocObjects: bool ref
+
+      val staticAllocWordVectorConsts: bool ref
 
       (* List of pass names to stop at. *)
       val stopPasses: Regexp.Compiled.t list ref

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -387,6 +387,15 @@ signature CONTROL_FLAGS =
        | Always
       val splitTypesBool: splitTypesBool ref
 
+      datatype staticAllocInternalPtrs =
+         All
+       | Static
+       | None
+      val staticAllocInternalPtrs: staticAllocInternalPtrs ref
+      val staticAllocArrays: bool ref
+      val staticAllocObjects: bool ref
+      val staticAllocVectors: bool ref
+
       (* List of pass names to stop at. *)
       val stopPasses: Regexp.Compiled.t list ref
 

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -400,9 +400,9 @@ signature CONTROL_FLAGS =
        | Static
        | None
       val staticAllocInternalPtrs: staticAllocInternalPtrs ref
-      val staticAllocArrays: bool ref
-      val staticAllocObjects: bool ref
-      val staticAllocVectors: bool ref
+      val staticAllocWordVectorConsts: bool ref
+      val staticInitArrays: bool ref
+      val staticInitObjects: bool option ref
 
       (* List of pass names to stop at. *)
       val stopPasses: Regexp.Compiled.t list ref

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1217,18 +1217,18 @@ val staticAllocInternalPtrs =
             default = Static,
             toString = StaticAlloc.Objptrs.toString}
 
-val staticAllocArrays =
-   control {name = "staticAllocArrays",
+val staticAllocWordVectorConsts =
+   control {name = "staticAllocWordVectorConsts",
             default = true,
             toString = Bool.toString}
-val staticAllocObjects =
-   control {name = "staticAllocObjects",
+val staticInitArrays =
+   control {name = "staticInitArrays",
             default = true,
             toString = Bool.toString}
-val staticAllocVectors =
-   control {name = "staticAllocVectors",
-            default = true,
-            toString = Bool.toString}
+val staticInitObjects =
+   control {name = "staticInitObjects",
+            default = SOME false,
+            toString = Option.toString Bool.toString}
 
 structure SplitTypesBool =
    struct

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1176,6 +1176,41 @@ val showTypes = control {name = "show types",
                          default = true,
                          toString = Bool.toString}
 
+structure StaticAlloc =
+   struct
+      structure Objptrs =
+      struct
+         datatype t =
+            All
+          | Static
+          | None
+
+         val toString = fn
+            All => "All"
+          | Static => "Static"
+          | None => "None"
+      end
+
+   end
+datatype staticAllocInternalPtrs = datatype StaticAlloc.Objptrs.t
+val staticAllocInternalPtrs =
+   control {name = "staticAllocInternalPtrs",
+            default = Static,
+            toString = StaticAlloc.Objptrs.toString}
+
+val staticAllocArrays =
+   control {name = "staticAllocArrays",
+            default = true,
+            toString = Bool.toString}
+val staticAllocObjects =
+   control {name = "staticAllocObjects",
+            default = true,
+            toString = Bool.toString}
+val staticAllocVectors =
+   control {name = "staticAllocVectors",
+            default = true,
+            toString = Bool.toString}
+
 structure SplitTypesBool =
    struct
       datatype t =

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1217,18 +1217,28 @@ val staticAllocInternalPtrs =
             default = Static,
             toString = StaticAlloc.Objptrs.toString}
 
-val staticAllocWordVectorConsts =
-   control {name = "staticAllocWordVectorConsts",
-            default = true,
-            toString = Bool.toString}
 val staticInitArrays =
    control {name = "staticInitArrays",
             default = true,
             toString = Bool.toString}
+val staticAllocArrays =
+   control {name = "staticAllocArrays",
+            default = true,
+            toString = Bool.toString}
+
 val staticInitObjects =
    control {name = "staticInitObjects",
             default = SOME false,
             toString = Option.toString Bool.toString}
+val staticAllocObjects =
+   control {name = "staticAllocObjects",
+            default = true,
+            toString = Bool.toString}
+
+val staticAllocWordVectorConsts =
+   control {name = "staticAllocWordVectorConsts",
+            default = true,
+            toString = Bool.toString}
 
 structure SplitTypesBool =
    struct

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -843,6 +843,9 @@ fun makeOptions {usage} =
                    Result.Yes () => ()
                  | Result.No s' => usage (concat ["invalid -ssa2-passes arg: ", s']))
           | NONE => Error.bug "ssa2 optimization passes missing")),
+       (Expert, "static-alloc-arrays", " {true|false}",
+        "Allow arrays to be statically allocated",
+        boolRef staticAllocArrays),
        (Expert, "static-alloc-internal-ptrs", " {all|static|none}",
         "which pointers to allow in statically allocated values",
         SpaceString (fn s =>
@@ -853,6 +856,9 @@ fun makeOptions {usage} =
                        | "static" => Control.Static
                        | _ => usage (concat ["invalid ",
                        "-static-alloc-internal-ptrs flag: ", s])))),
+       (Expert, "static-alloc-objects", " {true|false}",
+        "Allow objects to be statically allocated",
+        boolRef staticAllocObjects),
        (Expert, "static-alloc-wordvector-consts", " {true|false}",
         "Allow word-vector constants (strings) to be statically allocated",
         boolRef staticAllocWordVectorConsts),

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -814,25 +814,6 @@ fun makeOptions {usage} =
         SpaceString (fn s => showDefUse := SOME s)),
        (Expert, "show-types", " {true|false}", "show types in ILs",
         boolRef showTypes),
-       (Expert, "static-alloc-internal-ptrs", " {all|static|none}",
-        "which pointers to allow in statically allocated values",
-        SpaceString (fn s =>
-                     staticAllocInternalPtrs :=
-                     (case s of
-                         "all" => Control.All
-                       | "none" => Control.None
-                       | "static" => Control.Static
-                       | _ => usage (concat ["invalid ",
-                       "-static-alloc-internal-ptrs flag: ", s])))),
-       (Expert, "static-alloc-arrays", " {true|false}",
-        "Allow arrays to be statically allocated",
-        boolRef staticAllocArrays),
-       (Expert, "static-alloc-objects", " {true|false}",
-        "Allow objects to be statically allocated",
-        boolRef staticAllocObjects),
-       (Expert, "static-alloc-vectors", " {true|false}",
-        "Allow vectors to be statically allocated",
-        boolRef staticAllocVectors),
        (Expert, "split-types-bool", " {smart|always|never}",
         "bool type splitting method",
         SpaceString (fn s =>
@@ -862,6 +843,31 @@ fun makeOptions {usage} =
                    Result.Yes () => ()
                  | Result.No s' => usage (concat ["invalid -ssa2-passes arg: ", s']))
           | NONE => Error.bug "ssa2 optimization passes missing")),
+       (Expert, "static-alloc-internal-ptrs", " {all|static|none}",
+        "which pointers to allow in statically allocated values",
+        SpaceString (fn s =>
+                     staticAllocInternalPtrs :=
+                     (case s of
+                         "all" => Control.All
+                       | "none" => Control.None
+                       | "static" => Control.Static
+                       | _ => usage (concat ["invalid ",
+                       "-static-alloc-internal-ptrs flag: ", s])))),
+       (Expert, "static-alloc-wordvector-consts", " {true|false}",
+        "Allow word-vector constants (strings) to be statically allocated",
+        boolRef staticAllocWordVectorConsts),
+       (Expert, "static-init-arrays", " {true|false}",
+        "Allow arrays to be statically initialized",
+        boolRef staticInitArrays),
+       (Expert, "static-init-objects", " {none|staticAllocOnly|all}",
+        "Allow objects to be statically initialized",
+        SpaceString
+        (fn s =>
+         staticInitObjects := (case s of
+                                  "none" => NONE
+                                | "staticAllocOnly" => SOME false
+                                | "all" => SOME true
+                                | _ => usage (concat ["invalid -static-init-objects arg: ", s])))),
        (Normal, "stop", " {f|g|o|tc}", "when to stop",
         SpaceString
         (fn s =>

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -807,6 +807,25 @@ fun makeOptions {usage} =
         SpaceString (fn s => showDefUse := SOME s)),
        (Expert, "show-types", " {true|false}", "show types in ILs",
         boolRef showTypes),
+       (Expert, "static-alloc-internal-ptrs", " {all|static|none}",
+        "which pointers to allow in statically allocated values",
+        SpaceString (fn s =>
+                     staticAllocInternalPtrs :=
+                     (case s of
+                         "all" => Control.All
+                       | "none" => Control.None
+                       | "static" => Control.Static
+                       | _ => usage (concat ["invalid ",
+                       "-static-alloc-internal-ptrs flag: ", s])))),
+       (Expert, "static-alloc-arrays", " {true|false}",
+        "Allow arrays to be statically allocated",
+        boolRef staticAllocArrays),
+       (Expert, "static-alloc-objects", " {true|false}",
+        "Allow objects to be statically allocated",
+        boolRef staticAllocObjects),
+       (Expert, "static-alloc-vectors", " {true|false}",
+        "Allow vectors to be statically allocated",
+        boolRef staticAllocVectors),
        (Expert, "split-types-bool", " {smart|always|never}",
         "bool type splitting method",
         SpaceString (fn s =>

--- a/regression/mlton.share.sml
+++ b/regression/mlton.share.sml
@@ -21,9 +21,11 @@ val () = MLton.share a
 val () = msg ()
 
 (* tuple option array with pre-existing sharing *)
+val one = 1 + length (CommandLine.arguments ())
+val v = SOME (one, one)
 val a = Array.tabulate (100, fn i =>
                         if i mod 2 = 0
-                           then SOME (1, 1)
+                           then v
                         else SOME (i mod 3, i mod 3))
 val () = Array.update (a, 0, NONE)
 fun msg () =
@@ -97,10 +99,11 @@ val () =
    else ()
 
 (* sharing of vectors *)
+val s = concat ["ab", "cd", "ef"]
 val a =
    Array.tabulate (10, fn i =>
                    if i mod 2 = 0
-                     then "abcdef"
+                     then s
                    else concat ["abc", "def"])
 
 fun p () = print (concat ["size is ", Int.toString (MLton.size a), "\n"])
@@ -118,8 +121,8 @@ val s1 = Array.sub (a, 1)
 val () = print (concat [s0, " ", s1, "\n"])
 
 (* sharing of vectors in a tuple *)
-   
-val t = ("abcdef", concat ["abc", "def"])
+
+val t = (concat ["ab", "cd", "ef"], concat ["abc", "def"])
 
 fun p () = print (concat ["size is ", Int.toString (MLton.size t), "\n"])
 

--- a/regression/size.sml
+++ b/regression/size.sml
@@ -36,7 +36,7 @@ val _ =
                  List.tabulate (4, fn i => i + 1), fn l =>
                  chk (foldl (op +) 0 l, 10))
     ; printSize ("a string of length 10", NONE,
-                 "0123456789", fn s =>
+                 CharVector.tabulate (10, fn i => chr (ord #"0" + i)), fn s =>
                  chk (CharVector.foldl (fn (c,s) => ord c + s) 0 s,  525))
     ; printSize ("an int array of length 10", NONE,
                  Array.tabulate (10, fn i => i), fn a =>

--- a/runtime/gc/dfs-mark.c
+++ b/runtime/gc/dfs-mark.c
@@ -114,6 +114,7 @@ mark:
   assert (not isPointerMarkedByMode (cur, mode));
   assert (header == getHeader (cur));
   assert (headerp == getHeaderp (cur));
+  assert (isPointerInHeap (s, cur));
   header ^= MARK_MASK;
   /* Store the mark.  In the case of an object that contains a pointer to
    * itself, it is essential that we store the marked header before marking
@@ -140,9 +141,9 @@ markInNormal:
     if (DEBUG_DFS_MARK)
       fprintf (stderr, "markInNormal  objptrIndex = %"PRIu32"\n", objptrIndex);
     assert (objptrIndex < numObjptrs);
-    // next = *(pointer*)todo;
     next = fetchObjptrToPointer (todo, s->heap.start);
-    if (not isPointerInHeap (s, next)) {
+    if (not isPointer (next) or
+        not isPointerInHeap (s, next)) {
 markNextInNormal:
       assert (objptrIndex < numObjptrs);
       objptrIndex++;
@@ -216,9 +217,9 @@ markInSequence:
     assert (sequenceIndex < getSequenceLength (cur));
     assert (objptrIndex < numObjptrs);
     assert (todo == indexSequenceAtObjptrIndex (s, cur, sequenceIndex, objptrIndex));
-    // next = *(pointer*)todo;
     next = fetchObjptrToPointer (todo, s->heap.start);
-    if (not (isPointerInHeap(s, next))) {
+    if (not isPointer (next) or
+        not isPointerInHeap (s, next)) {
 markNextInSequence:
       assert (sequenceIndex < getSequenceLength (cur));
       assert (objptrIndex < numObjptrs);
@@ -274,14 +275,14 @@ markInFrame:
       goto markInStack;
     }
     todo = top - frameInfo->size + frameOffsets [objptrIndex + 1];
-    // next = *(pointer*)todo;
     next = fetchObjptrToPointer (todo, s->heap.start);
     if (DEBUG_DFS_MARK)
       fprintf (stderr,
                "    offset %u  todo "FMTPTR"  next = "FMTPTR"\n",
                frameOffsets [objptrIndex + 1],
                (uintptr_t)todo, (uintptr_t)next);
-    if (not isPointerInHeap (s, next)) {
+    if (not isPointer (next) or
+        not isPointerInHeap (s, next)) {
       objptrIndex++;
       goto markInFrame;
     }

--- a/runtime/gc/forward.c
+++ b/runtime/gc/forward.c
@@ -155,7 +155,7 @@ void forwardObjptrIfInNursery (GC_state s, objptr *opp) {
 
   op = *opp;
   p = objptrToPointer (op, s->heap.start);
-  if (p < s->heap.nursery)
+  if ((p < s->heap.nursery) or (p > s->frontier))
     return;
   if (DEBUG_GENERATIONAL)
     fprintf (stderr,

--- a/runtime/gc/forward.h
+++ b/runtime/gc/forward.h
@@ -29,8 +29,8 @@ static inline objptr* getFwdPtrp (pointer p);
 static inline objptr getFwdPtr (pointer p);
 static inline bool hasFwdPtr (pointer p);
 static inline void forwardObjptr (GC_state s, objptr *opp);
-static inline void forwardObjptrIfInNursery (GC_state s, objptr *opp);
 static inline void forwardObjptrIfInHeap (GC_state s, objptr *opp);
+static inline void forwardObjptrIfInNursery (GC_state s, objptr *opp);
 static inline void forwardInterGenerationalObjptrs (GC_state s);
 
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -48,6 +48,8 @@ struct GC_state {
   uint32_t maxFrameSize;
   bool mutatorMarksCards;
   GC_objectHashTable objectHashTable;
+  struct GC_objectInit *objectInits;
+  uint32_t objectInitsLength;
   GC_objectType objectTypes; /* Array of object types. */
   uint32_t objectTypesLength; /* Cardinality of objectTypes array. */
   struct GC_profiling profiling;
@@ -64,8 +66,6 @@ struct GC_state {
   pointer stackBottom; /* Bottom of stack in current thread. */
   struct GC_sysvals sysvals;
   struct GC_translateState translateState;
-  struct GC_vectorInit *vectorInits;
-  uint32_t vectorInitsLength;
   GC_weak weaks; /* Linked list of (live) weak pointers */
 };
 

--- a/runtime/gc/heap.h
+++ b/runtime/gc/heap.h
@@ -37,13 +37,15 @@ typedef struct GC_heap {
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-static inline bool isPointerInOldGen (GC_state s, pointer p);
-static inline bool isPointerInNursery (GC_state s, pointer p);
-static inline bool isPointerInHeap (GC_state s, pointer p);
-static inline bool isObjptrInOldGen (GC_state s, objptr op);
-static inline bool isObjptrInNursery (GC_state s, objptr op);
 static inline bool isObjptrInFromSpace (GC_state s, objptr op);
 static inline bool isObjptrInHeap (GC_state s, objptr op);
+static inline bool isObjptrInNursery (GC_state s, objptr op);
+static inline bool isObjptrInOldGen (GC_state s, objptr op);
+static inline bool isPointerInFromSpace (GC_state s, pointer p);
+static inline bool isPointerInHeap (GC_state s, pointer p);
+static inline bool isPointerInNursery (GC_state s, pointer p);
+static inline bool isPointerInOldGen (GC_state s, pointer p);
+
 static inline bool hasHeapBytesFree (GC_state s, size_t oldGen, size_t nursery);
 static inline bool isHeapInit (GC_heap h);
 

--- a/runtime/gc/heap_predicates.c
+++ b/runtime/gc/heap_predicates.c
@@ -34,18 +34,22 @@ bool isObjptrInNursery (GC_state s, objptr op) {
   return isPointerInNursery (s, p);
 }
 
+bool isPointerInFromSpace (GC_state s, pointer p) {
+  return (isPointerInOldGen (s, p)
+          or isPointerInNursery (s, p));
+}
+
 bool isObjptrInFromSpace (GC_state s, objptr op) {
   return (isObjptrInOldGen (s, op) 
           or isObjptrInNursery (s, op));
 }
 
-bool isObjptrInHeap (GC_state s, objptr op) {
-  return isObjptrInFromSpace(s, op);
+bool isPointerInHeap (GC_state s, pointer p) {
+  return isPointerInFromSpace(s, p);
 }
 
-bool isPointerInHeap (GC_state s, pointer p) {
-  return (isPointerInOldGen (s, p)
-          or isPointerInNursery (s, p));
+bool isObjptrInHeap (GC_state s, objptr op) {
+  return isObjptrInFromSpace(s, op);
 }
 
 bool hasHeapBytesFree (GC_state s, size_t oldGen, size_t nursery) {

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -20,7 +20,7 @@ size_t sizeofInitialBytesLive (GC_state s) {
   for (i = 0; i < s->objectInitsLength; ++i) {
     dataBytes =
       s->objectInits[i].size;
-    total += align (GC_SEQUENCE_METADATA_SIZE + dataBytes, s->alignment);
+    total += align (dataBytes, s->alignment);
   }
   return total;
 }

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -35,11 +35,9 @@ void initObjects (GC_state s) {
   inits = s->objectInits;
   frontier = s->frontier;
   for (i = 0; i < s->objectInitsLength; i++) {
-
     objectSize = align (inits[i].size, s->alignment);
     assert (objectSize <= (size_t)(s->heap.start + s->heap.size - frontier));
     memcpy (frontier, inits[i].words, inits[i].size);
-
     s->globals[inits[i].globalIndex] =
       pointerToObjptr(frontier + inits[i].headerOffset, s->heap.start);
     frontier = frontier + objectSize;

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -13,15 +13,13 @@
 
 size_t sizeofInitialBytesLive (GC_state s) {
   uint32_t i;
-  size_t dataBytes;
   size_t total;
 
   total = 0;
   for (i = 0; i < s->objectInitsLength; ++i) {
-    dataBytes =
-      s->objectInits[i].size;
-    total += align (dataBytes, s->alignment);
+    total += align (s->objectInits[i].size, s->alignment);
   }
+  total += sizeofStackWithMetaData (s, sizeofStackInitialReserved (s)) + sizeofThread (s);
   return total;
 }
 

--- a/runtime/gc/init-world.c
+++ b/runtime/gc/init-world.c
@@ -29,18 +29,20 @@ void initObjects (GC_state s) {
   struct GC_objectInit *inits;
   pointer frontier;
   uint32_t i;
+  size_t objectSize;
 
   assert (isFrontierAligned (s, s->frontier));
   inits = s->objectInits;
   frontier = s->frontier;
   for (i = 0; i < s->objectInitsLength; i++) {
 
-    assert (align (inits[i].size, s->alignment) <=
-      (size_t)(s->heap.start + s->heap.size - frontier));
+    objectSize = align (inits[i].size, s->alignment);
+    assert (objectSize <= (size_t)(s->heap.start + s->heap.size - frontier));
     memcpy (frontier, inits[i].words, inits[i].size);
+
     s->globals[inits[i].globalIndex] =
       pointerToObjptr(frontier + inits[i].headerOffset, s->heap.start);
-    frontier = frontier + inits[i].size;
+    frontier = frontier + objectSize;
     if (DEBUG_DETAILED)
       fprintf (stderr, "allocated object at "FMTPTR"\n",
                (uintptr_t)(s->globals[inits[i].globalIndex]));

--- a/runtime/gc/init-world.h
+++ b/runtime/gc/init-world.h
@@ -26,10 +26,10 @@ struct GC_intInfInit {
 };
 
 /* GC_init allocates a collection of sequences in the heap. */
-struct GC_vectorInit {
-  size_t elementSize;
+struct GC_objectInit {
   uint32_t globalIndex;
-  GC_sequenceLength length;
+  size_t headerOffset;
+  size_t size;
   pointer words;
 };
 
@@ -38,7 +38,7 @@ struct GC_vectorInit {
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
 static inline size_t sizeofInitialBytesLive (GC_state s);
-static void initVectors (GC_state s);
+static void initObjects (GC_state s);
 static void initWorld (GC_state s);
 
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */

--- a/runtime/gc/invariant.c
+++ b/runtime/gc/invariant.c
@@ -74,6 +74,24 @@ bool invariantForGC (GC_state s) {
   }
   assert (s->secondaryHeap.start == NULL 
           or s->heap.size == s->secondaryHeap.size);
+  /* The following checks are disabled,
+   * because objptrs to static objects * fail `isObjptrInFromSpace`.
+   * if an efficient `isObjptrStatic` predicate were available,
+   * then these checks could be re-enabled.
+   */
+  if (FALSE) {
+  /* Check that all pointers are into from space. */
+  foreachGlobalObjptr (s, assertIsObjptrInFromSpace);
+  pointer back = s->heap.start + s->heap.oldGenSize;
+  if (DEBUG_DETAILED)
+    fprintf (stderr, "Checking old generation.\n");
+  foreachObjptrInRange (s, alignFrontier (s, s->heap.start), &back, 
+                        assertIsObjptrInFromSpace, FALSE);
+  if (DEBUG_DETAILED)
+    fprintf (stderr, "Checking nursery.\n");
+  foreachObjptrInRange (s, s->heap.nursery, &s->frontier, 
+                        assertIsObjptrInFromSpace, FALSE);
+  }
   /* Current thread. */
   GC_stack stack = getStackCurrent(s);
   assert (isStackReservedAligned (s, stack->reserved));

--- a/runtime/gc/mark-compact.c
+++ b/runtime/gc/mark-compact.c
@@ -52,6 +52,9 @@ void threadInternalObjptr (GC_state s, objptr *opp) {
 
   opop = pointerToObjptr ((pointer)opp, s->heap.start);
   p = objptrToPointer (*opp, s->heap.start);
+  if (not isPointerInHeap (s, p))
+      return;
+
   if (FALSE)
     fprintf (stderr,
              "threadInternal opp = "FMTPTR"  p = "FMTPTR"  header = "FMTHDR"\n",
@@ -196,6 +199,7 @@ thread:
     objptr newObjptr;
 
     assert (not (GC_VALID_HEADER_MASK & header));
+    assert (isPointerInHeap (s, (pointer)headerp));
     /* It's a pointer.  This object must be live.  Fix all the forward
      * pointers to it, store its header, then thread its internal
      * pointers.
@@ -327,6 +331,7 @@ unmark:
     objptr newObjptr;
 
     assert (not (GC_VALID_HEADER_MASK & header));
+    assert (isPointerInHeap (s, (pointer)headerp));
     /* It's a pointer.  This object must be live.  Fix all the
      * backward pointers to it.  Then unmark it.
      */


### PR DESCRIPTION
The later IRs now support static data of various sorts. Some features are merged into statics: `isMutable` in Rssa has been weakened to `pinned` which is only needed to maintain the changes from BounceVars without excessive liveness analysis. The vectors field of Machine.Program.T has been changed to include general statics. In Rssa, a new expression defines a unique static for each usage in the program. In the backend, statics are moved into the program (no uniqueifying is performed, as it seems to be an artifact of propagation of constants), and references are done through an operand. The operand Static is a constant value which has type CPointer or ObjPtr, and its data can be accessed with Offset/Contents as normal. Thus, it has no address, and it cannot be written to (which indicated some conflations of meaning for isLocation).

Under the default behavior, globals are not statically allocated if they have one or more mutable fields which can hold an object pointer (after packing) or if their data is not statically allocated. In practice, there are no such globals for just about all programs.

This version has support in all codegens. As expected, code size and compile time are improved across the board, particularly for larger programs. Runtime improves sometimes, but should only affect programs which had hot code accessing globals, as it removes one level of indirection. We should also expect marginally faster garbage collections, as globals are now mostly skipped.

A couple pieces are still outstanding for discussion and review:

- Command line options. There's a lot of dimensions to this, and in general they should all be enabled unless a bug or performance regression arises in user code, or a GC choice makes them impossible. Right now disabling it for particular sorts of data still leaves them statically initialized (and heap allocated), but ...
- Objects which are not statically allocated are currently created in code. It seems not to be worth it to make a statically initialized heap allocated object, as the code to initialize them is quite small. The statically allocated objects should have better compile time though.
- There's still a good bit of complexity that I'd like to reduce as much as possible of. Some options are partially coupled: generally the heap allocated statics are precisely the statics with destination globals. As an awkwardness with this, which de-facto cannot occur (due to propagation), is a non-heap static with global, which would be copied to the heap under the current code (but doing something else would be an additional edge case). Empty (array) data has to have different initialization rules from others to avoid executable bloat (so it goes in bss, instead of text). I have at least managed to center all decision-making to ssa2-to-rssa and all initialization to c codegen's outputDecls.
- Rssa still has WordXVector support for constants. Only one particular pass in Rssa created them, so it may be easiest to just disable it, which would simplify the backend and reduce redundancy. The complexity here is that disabling this requires duplicating or factoring the logic for deciding where to place statics (WordXVectors are only placed on the heap at the moment).
- Statics are somewhat inconsistent with globals: they are stored with the program, and information about them is local, whereas globals are created and stored globally, but I couldn't convince myself to create a module just for a single integer counter.

This resolves https://github.com/MLton/mlton/issues/300

This affects the previous globalization changes in https://github.com/MLton/mlton/pull/288, so they should be re-examined as well. In particular effects due to extra indirections should disappear, so remaining effects will only be due to low-level perturbations and interactions with other passes (local-ref for instance).