### PR TITLE
Fix bug in `GC_{share,size}` with non-pointer roots

### DIFF
--- a/regression/size.rep32a4.ok
+++ b/regression/size.rep32a4.ok
@@ -5,6 +5,8 @@ The size of an int array of length 10 is = 52 bytes.
 The size of a double array of length 10 is = 92 bytes.
 The size of an array of length 10 of 2-ples of ints is = 92 bytes.
 The size of a useless function is = 0 bytes.
+The size of an int list option (SOME) is = 56 bytes.
+The size of an int list option (NONE) is = 0 bytes.
 The size of a continuation option ref is >= 4000 bytes and <= 6000 bytes.
 13
 The size of a continuation option ref is = 8 bytes.

--- a/regression/size.rep32a8.ok
+++ b/regression/size.rep32a8.ok
@@ -5,6 +5,8 @@ The size of an int array of length 10 is = 56 bytes.
 The size of a double array of length 10 is = 96 bytes.
 The size of an array of length 10 of 2-ples of ints is = 96 bytes.
 The size of a useless function is = 0 bytes.
+The size of an int list option (SOME) is = 72 bytes.
+The size of an int list option (NONE) is = 0 bytes.
 The size of a continuation option ref is >= 4000 bytes and <= 6000 bytes.
 13
 The size of a continuation option ref is = 8 bytes.

--- a/regression/size.rep64a4.ok
+++ b/regression/size.rep64a4.ok
@@ -5,6 +5,8 @@ The size of an int array of length 10 is = 64 bytes.
 The size of a double array of length 10 is = 104 bytes.
 The size of an array of length 10 of 2-ples of ints is = 104 bytes.
 The size of a useless function is = 0 bytes.
+The size of an int list option (SOME) is = 96 bytes.
+The size of an int list option (NONE) is = 0 bytes.
 The size of a continuation option ref is >= 4000 bytes and <= 6000 bytes.
 13
 The size of a continuation option ref is = 16 bytes.

--- a/regression/size.rep64a8.ok
+++ b/regression/size.rep64a8.ok
@@ -5,6 +5,8 @@ The size of an int array of length 10 is = 64 bytes.
 The size of a double array of length 10 is = 104 bytes.
 The size of an array of length 10 of 2-ples of ints is = 104 bytes.
 The size of a useless function is = 0 bytes.
+The size of an int list option (SOME) is = 112 bytes.
+The size of an int list option (NONE) is = 0 bytes.
 The size of a continuation option ref is >= 4000 bytes and <= 6000 bytes.
 13
 The size of a continuation option ref is = 16 bytes.

--- a/regression/size.sml
+++ b/regression/size.sml
@@ -49,7 +49,20 @@ val _ =
                  chk (Array.foldl (fn ((a,b),s) => a + b + s) 0 a, 100))
     ; printSize ("a useless function", NONE,
                  fn _ => 13, fn f => ())
-    )
+    ; let
+         val l = List.tabulate (8, fn i =>
+                                if i mod 2 = 1
+                                   then NONE
+                                   else SOME (List.tabulate (i, fn i => i + 1)))
+      in
+         ()
+         ; printSize ("an int list option (SOME)", NONE,
+                      List.nth (l, 4), fn lo =>
+                      chk (case lo of NONE => 0 | SOME l => foldl (op +) 0 l, 10))
+         ; printSize ("an int list option (NONE)", NONE,
+                      List.nth (l, 5), fn lo =>
+                      chk (case lo of NONE => 0 | SOME l => foldl (op +) 0 l, 0))
+      end)
    
 local
    open MLton.Cont

--- a/runtime/gc/share.c
+++ b/runtime/gc/share.c
@@ -12,6 +12,9 @@ void GC_share (GC_state s, pointer object) {
   size_t bytesHashConsed;
   struct GC_markState markState;
 
+  if (not isPointer (object))
+    return;
+
   enter (s); /* update stack in heap, in case it is reached */
   if (DEBUG_SHARE)
     fprintf (stderr, "GC_share "FMTPTR"\n", (uintptr_t)object);

--- a/runtime/gc/size.c
+++ b/runtime/gc/size.c
@@ -10,6 +10,9 @@
 size_t GC_size (GC_state s, pointer root) {
   struct GC_markState markState;
   size_t res;
+
+  if (not isPointer (root))
+    return 0;
   
   enter (s); /* update stack in heap, in case it is reached */
   if (DEBUG_SIZE)


### PR DESCRIPTION
`GC_size` and `GC_share` can be called with object-pointer-sized but non-pointer values (e.g., the `NONE` variant of a `int list option`).