### PR TITLE
Reset position-independent style defaults with `update` target of `Makefile.binary`

### DIFF
--- a/Makefile.binary
+++ b/Makefile.binary
@@ -68,8 +68,8 @@ update:
 	$(CP) "$(SBIN)/mlton" "$(SBIN)/mlton.bak"
 	$(SED) \
 		-e "s;^CC=.*;CC=\"$(CC)\";" \
-		-e "s;^GMP_INC_DIR=.*;GMP_INC_DIR=\"$(WITH_GMP_INC_DIR)\";" \
-		-e "s;^GMP_LIB_DIR=.*;GMP_LIB_DIR=\"$(WITH_GMP_LIB_DIR)\";" \
+		-e "s;^GMP_INC_DIR=.*;GMP_INC_DIR=$(if $(WITH_GMP_INC_DIR),\"$(WITH_GMP_INC_DIR)\");" \
+		-e "s;^GMP_LIB_DIR=.*;GMP_LIB_DIR=$(if $(WITH_GMP_LIB_DIR),\"$(WITH_GMP_LIB_DIR)\");" \
 		< "$(SBIN)/mlton.bak" > "$(SBIN)/mlton"
 	chmod a+x "$(SBIN)/mlton"
 	$(RM) "$(SBIN)/mlton.bak"

--- a/Makefile.binary
+++ b/Makefile.binary
@@ -72,4 +72,10 @@ update:
 		-e "s;^GMP_LIB_DIR=.*;GMP_LIB_DIR=\"$(WITH_GMP_LIB_DIR)\";" \
 		< "$(SBIN)/mlton.bak" > "$(SBIN)/mlton"
 	chmod a+x "$(SBIN)/mlton"
-	rm "$(SBIN)/mlton.bak"
+	$(RM) "$(SBIN)/mlton.bak"
+	$(CP) "$(SLIB)/targets/self/constants" "$(SLIB)/targets/self/constants.bak"
+	$(SED) \
+		-e "s;^default::pie=.*;default::pie=$(subst __pie__,0,$(shell echo "__pie__" | $(CC) -P -E -));" \
+		-e "s;^default::pic=.*;default::pic=$(subst __pic__,0,$(shell echo "__pic__" | $(CC) -P -E -));" \
+		< "$(SLIB)/targets/self/constants.bak" > "$(SLIB)/targets/self/constants"
+	$(RM) "$(SLIB)/targets/self/constants.bak"

--- a/Makefile.binary
+++ b/Makefile.binary
@@ -79,3 +79,15 @@ update:
 		-e "s;^default::pic=.*;default::pic=$(subst __pic__,0,$(shell echo "__pic__" | $(CC) -P -E -));" \
 		< "$(SLIB)/targets/self/constants.bak" > "$(SLIB)/targets/self/constants"
 	$(RM) "$(SLIB)/targets/self/constants.bak"
+	if [ $$(echo "__pie__" | $(CC) -P -E -) -gt 0 ]; then \
+		pi="-pie";
+	elif if [ $$(echo "__pic__" | $(CC) -P -E -) -gt 0 ]; then \
+		pi="-pic";
+	else \
+		pi="-npi";
+	fi ; \
+	for lib in mlton gdtoa; do \
+		for md in "" -dbg; do \
+			$(CP) "$(SLIB)/targets/self/lib$${lib}$${md}$${pi}.a" "$(SLIB)/targets/self/lib$${lib}$${md}.a"; \
+		done; \
+	done

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1394,8 +1394,8 @@ structure PositionIndependentStyle =
       fun linkOpts pis =
          case pis of
             NONE => []
-          | SOME NPI => ["-no-pie"]
-          | SOME PIC => ["-no-pie"]
+          | SOME NPI => ["-fno-pic", "-fno-pie", "-no-pie"]
+          | SOME PIC => ["-fno-pie", "-no-pie"]
           | SOME PIE => ["-fPIE -pie"]
    end
 

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1112,10 +1112,14 @@ fun commandLine (args: string list): unit =
           | Self => !cc
       val arScript = !arScript
 
-      fun addMD s =
-         if !debugRuntime then s ^ "-dbg" else s
-      fun addPI s =
-         s ^ (Control.PositionIndependentStyle.toSuffix positionIndependentStyle)
+      local
+         fun addMD s =
+            if !debugRuntime then s ^ "-dbg" else s
+         fun addPI s =
+            s ^ (Control.PositionIndependentStyle.toSuffix positionIndependentStyle)
+      in
+         val mkLibName = addPI o addMD
+      end
       fun addTargetOpts opts =
          List.fold
          (!opts, [], fn ({opt, pred}, ac) =>
@@ -1135,13 +1139,13 @@ fun commandLine (args: string list): unit =
       val ccOpts = addTargetOpts ccOpts
       val linkOpts = addTargetOpts linkOpts
       val linkOpts =
-         List.map (["mlton", "gdtoa"], fn lib => "-l" ^ addPI (addMD lib)) @ linkOpts
+         List.map (["mlton", "gdtoa"], fn lib => "-l" ^ mkLibName lib) @ linkOpts
       val linkOpts = ("-L" ^ targetLibDir) :: linkOpts
 
       val linkArchives =
          List.map (["mlton", "gdtoa"], fn lib =>
                    OS.Path.joinDirFile {dir = targetLibDir,
-                                        file = "lib" ^ addPI (addMD lib) ^ ".a"})
+                                        file = "lib" ^ mkLibName lib ^ ".a"})
 
       val llvm_as = !llvm_as
       val llvm_llc = !llvm_llc

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -705,7 +705,7 @@ fun makeOptions {usage} =
                                          rounds = rounds,
                                          small = small}
               | _ => ())),
-       (Expert, "pi-style", " {default|static|pic|pie}", "position-independent style",
+       (Expert, "pi-style", " {default|npi|pic|pie}", "position-independent style",
         SpaceString (fn s =>
                      (case (s, PositionIndependentStyle.fromString s) of
                          ("default", NONE) => positionIndependentStyle := NONE


### PR DESCRIPTION
If the C compiler's default behavior with respect to position-independent code/executables is different between the machine that built a binary release and a machine that uses a binary release, then there could be link-time errors when using the compiler.  In particular, if the machine that built the binary release defaults to `-fno-pie` (i.e., non-position independent), but the machine that uses the binary release defaults to `-pie` (i.e., position independent executable), then the link will fail (with a `relocation` error and a suggestion from the linker to recompile with `-fPIC`).

The `update` target of the `Makefile.binary` now detects the default behavior of the C compiler on the machine using the binary release and appropriately resets the `default::{pie,pic}` values in the target-specific `constants` file and copies the appropriate of `%-npi.a`, `%-pic.a`, or `%-pie.a` to `%.a`.

An apparently simpler solution (than copying `%.a` from `%-npi.a`, `%-pic.a`, or `%-pie.a`) would be to only use the `%-npi.a`, `%-pic.a`, or `%-pie.a` libraries and, after parsing command-line options and determining the target, pretend that `-pi-style` was set to the target default (unless explicitly set).  However, this leads to awkward behavior on MacOS.  Although MacOS generates PIE by default, `echo "__pie__ __pic__" | clang -E -P -` returns `__pie__ 2` (and returns that same result regardless of `-fno-pie`, `-fPIE`, `-fno-pic`, `-fPIC` arguments).  Thus, the MacOS is considered to have a default of `pic`; however, compiling with `-pi-style pic` would cause the link command to have `-fno-pie -no-pie`, which would generate a non-pi executable.  Retaining a "default" that invokes the compiler and linker with no extra flags avoids this awkwardness.  (Cygwin and MinGW would probably have similar awkwardnesses.)