### PR TITLE
Fix SimplifyTypes SSA optimization pass

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,9 @@ Here are the changes from version 20180206 to version YYYYMMDD.
 
 === Details
 
+* 2020-02-14
+  ** Fixed bug in `SimplifyTypes` SSA optimization pass.
+
 * 2020-01-22
   ** Added expert `-pi-style {default|npi|pic|pie}` and
   `-native-pic {false|true}` options, which can be used to override a
@@ -16,7 +19,7 @@ Here are the changes from version 20180206 to version YYYYMMDD.
 
 * 2020-01-21
   ** Support parallel build (i.e., `make -j`).  This mainly supports
-  platforms/packagers tht use a parallel `make` by default; it does
+  platforms/packagers that use a parallel `make` by default; it does
   not obtain significant build speedups.
 
 * 2020-01-11

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -552,10 +552,16 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                       PrimApp {prim = prim,
                                targs = simplifyTypes targs,
                                args = args}
+                   fun length () =
+                      case simplifyTypeOpt (Vector.first targs) of
+                         NONE => Exp.Const (Const.word (WordX.zero (WordSize.seqIndex ())))
+                       | SOME _ => normal ()
                    datatype z = datatype Prim.Name.t
                 in
                    case Prim.name prim of
-                      _ => normal ()
+                      Array_length => length ()
+                    | Vector_length => length ()
+                    | _ => normal ()
                 end)
           | Select {tuple, offset} =>
                let

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -153,7 +153,7 @@ structure ConRep =
 structure Result =
    struct
       datatype 'a t =
-         Bugg
+         Dead
        | Delete
        | Keep of 'a
 
@@ -161,7 +161,7 @@ structure Result =
          let
             open Layout
          in
-            fn Bugg => str "Bug"
+            fn Dead => str "Dead"
              | Delete => str "Delete"
              | Keep x => seq [str "Keep ", layoutX x]
          end
@@ -550,7 +550,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                  | ConRep.Useful =>
                       Keep (ConApp {con = con,
                                     args = removeUselessVars args})
-                 | ConRep.Useless => Bugg)
+                 | ConRep.Useless => Dead)
           | PrimApp {prim, targs, args} =>
                Keep
                (let
@@ -690,13 +690,13 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                 * the vector of length 0; this `Vector_sub` is unreachable due
                 * to a dominating bounds check that must necessarily fail.
                 *)
-               Bugg
+               Dead
           | SOME ty =>
                (* It is wrong to omit calling simplifyExp when var = NONE because
                 * targs in a PrimApp may still need to be simplified.
                 *)
                (case simplifyExp exp of
-                   Bugg => Bugg
+                   Dead => Dead
                  | Delete => Delete
                  | Keep exp => Keep (Statement.T {var = var, ty = ty, exp = exp}))
       val simplifyStatement =
@@ -718,7 +718,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                      Vector.fold'
                      (statements, 0, [], fn (_, statement, statements) =>
                       case simplifyStatement statement of
-                         Bugg => Vector.Done NONE
+                         Dead => Vector.Done NONE
                        | Delete => Vector.Continue statements
                        | Keep s => Vector.Continue (s :: statements),
                       SOME o Vector.fromListRev)
@@ -779,7 +779,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                                     exp = Exp.unit}),
           Vector.keepAllMap (globals, fn s =>
                              case simplifyStatement s of
-                                Bugg => Error.bug "SimplifyTypes.globals: bind can't fail"
+                                Dead => Error.bug "SimplifyTypes.globals: Dead"
                               | Delete => NONE
                               | Keep b => SOME b)]
       val shrink = shrinkFunction {globals = globals}

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -320,9 +320,8 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                   conCardinality con))
           in
              if Vector.isEmpty cons
-                then (setTyconReplacement (tycon, SOME Type.unit)
-                      ; NONE)
-             else SOME (Datatype.T {tycon = tycon, cons = cons})
+                then NONE
+                else SOME (Datatype.T {tycon = tycon, cons = cons})
           end)
       (* diagnostic *)
       val _ =
@@ -380,9 +379,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                     else SOME c)
           in
              case Vector.length cons of
-                0 => (setTyconNumCons (tycon, 0)
-                      ; setTyconReplacement (tycon, SOME Type.unit)
-                      ; (datatypes, unary))
+                0 => (datatypes, unary)
               | 1 =>
                    let
                       val {con, args} = Vector.first cons

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -503,7 +503,6 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
          Vector.concat
          [Vector.new1 (Datatype.T {tycon = void, cons = Vector.new0 ()}),
           datatypes]
-      val unitVar = Var.newNoname ()
       val {get = varInfo: Var.t -> Type.t, set = setVarInfo, ...} =
          Property.getSetOnce
          (Var.plist, Property.initRaise ("varInfo", Var.layout))
@@ -772,15 +771,11 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                   end
          end
       val globals =
-         Vector.concat
-         [Vector.new1 (Statement.T {var = SOME unitVar,
-                                    ty = Type.unit,
-                                    exp = Exp.unit}),
-          Vector.keepAllMap (globals, fn s =>
-                             case simplifyStatement s of
-                                Dead => Error.bug "SimplifyTypes.globals: Dead"
-                              | Delete => NONE
-                              | Keep b => SOME b)]
+         Vector.keepAllMap (globals, fn s =>
+                            case simplifyStatement s of
+                               Dead => Error.bug "SimplifyTypes.globals: Dead"
+                             | Delete => NONE
+                             | Keep b => SOME b)
       val shrink = shrinkFunction {globals = globals}
       val simplifyFunction = fn f => Option.map (simplifyFunction f, shrink)
       val functions = List.revKeepAllMap (functions, simplifyFunction)

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -543,7 +543,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                (case conRep con of
                    ConRep.Transparent => Keep (tuple args)
                  | ConRep.Useful => Keep (ConApp {con = con, args = args})
-                 | ConRep.Useless => Dead)
+                 | ConRep.Useless => Error.bug "SimplifyTypes.simplfyExp: ConApp, ConRep.Useless")
           | PrimApp {prim, targs, args} =>
                Keep
                (let


### PR DESCRIPTION
`SimplifyTypes` could fail with a `no varInfo property` internal compiler error.  `SimplifyTypes` transforms each function by visiting the blocks via `Function.dfs`.  When visiting a statement, `setVarInfo` is called for the defined variable.  However, after identifying an unreachable statement (e.g., the `ConApp` of a `Useless` constructor), `SimplifyTypes` does not visit the remaining statements of the block.  When continuing with the DFS, `SimplifyTypes` may subsequently visit a block that use variables that were defined (but not visited and, therefore, not `setVarInfo`-ed) by a previously visited block.

This potential error was previously noted (see the comment at the end of MLton/mlton@19b07c0) and has now been observed in the wild (see MPLLang/mpl#107).

To fix the error, switch from a DFS (on the control-flow graph) to a dominator tree (depth-first) traversal, where the dominator tree traversal does not visit any children blocks of an unreachable block.  This addresses the `no varInfo property` internal compiler error, because any block that uses a variable must be dominated by the block that defines the variable.

Also refactor the handling of uninhabited types.  Previously, the `simplifyType` property had the type
`Type.t -> Type.t`, where `Type.unit` was used to signal an uninhabited type.  However, this is ambiguous, because `Type.unit` *is* an inhabited type.  The refactored `simplifyTypeOpt` property has the type
`Type.t -> Type.t option`, where `NONE` is used to signal an uninhabited type.  Many subsequent simplifications of `SimplifyTypes` follow from this refactoring:

 * A `Statement.t` that purports to produce a value of an uninhabited type must be unreachable.  This optimization isn't expressible when an uninhabited type is signaled by `Type.unit`, because many statements may produce a value of `Type.unit`.
 * A block with an argument of an uninhabited type must be unreachable.
 * A function with an argument of an unihabited type must be unreachable.
 * It is impossible to `ConApp`, `PrimApp`, `Call`, `Raise`, or `Return` with a value of an uninhabited type.
 * An array or vector of an uninhabited type must have length 0.
 * `MLton_eq` and `MLton_equal` at a type of cardinality 1 must return `true`.

But, the above does not actually improve effectiveness of the optimization, because it simply eliminates dead code slight more aggressively than before.  This dead code was likely to have been eliminated by `Shrink` and/or `RemoveUnused`.