### PR TITLE
Refactor RSSA/Machine object types

### DIFF
--- a/mlton/atoms/atoms.fun
+++ b/mlton/atoms/atoms.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019-2020 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -80,6 +80,7 @@ structure Atoms =
                              structure RealSize = RealSize
                              structure WordSize = WordSize)
 
+      structure Prod = Prod ()
       structure Handler = Handler (structure Label = Label)
       structure Return = Return (structure Label = Label
                                  structure Handler = Handler)

--- a/mlton/atoms/atoms.sig
+++ b/mlton/atoms/atoms.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019-2020 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -31,6 +31,7 @@ signature ATOMS' =
       structure IntSize: INT_SIZE
       structure Label: LABEL
       structure Prim: PRIM
+      structure Prod: PROD
       structure ProfileExp: PROFILE_EXP
       structure ProfileLabel: PROFILE_LABEL
       structure RealSize: REAL_SIZE
@@ -103,6 +104,7 @@ signature ATOMS =
       sharing IntSize = Atoms.IntSize
       sharing Label = Atoms.Label
       sharing Prim = Atoms.Prim
+      sharing Prod = Atoms.Prod
       sharing ProfileExp = Atoms.ProfileExp
       sharing ProfileLabel = Atoms.ProfileLabel
       sharing RealSize = Atoms.RealSize

--- a/mlton/atoms/prod.fun
+++ b/mlton/atoms/prod.fun
@@ -39,6 +39,7 @@ fun allAreMutable (T v) = Vector.forall (v, #isMutable)
 fun someIsImmutable (T v) = Vector.exists (v, not o #isMutable)
 fun someIsMutable (T v) = Vector.exists (v, #isMutable)
 
+fun first (T p) = Vector.first p
 fun sub (T p, i) = Vector.sub (p, i)
 
 fun elt (p, i) = #elt (sub (p, i))
@@ -51,6 +52,11 @@ val equals: 'a t * 'a t * ('a * 'a -> bool) -> bool =
                   fn ({elt = e1, isMutable = m1},
                       {elt = e2, isMutable = m2}) =>
                   m1 = m2 andalso equals (e1, e2))
+
+val hash: 'a t * ('a -> word) -> word =
+   fn (p, hash) =>
+   Hash.vectorMap (dest p, fn {elt = e, isMutable = m} =>
+                   Hash.combine (Bool.hash m, hash e))
 
 fun layout (p, layoutElt) =
    let

--- a/mlton/atoms/prod.fun
+++ b/mlton/atoms/prod.fun
@@ -1,0 +1,95 @@
+(* Copyright (C) 2009,2014,2017-2020 Matthew Fluet.
+ * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
+ *    Jagannathan, and Stephen Weeks.
+ * Copyright (C) 1997-2000 NEC Research Institute.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+functor Prod (S: PROD_STRUCTS): PROD =
+struct
+
+open S
+
+datatype 'a t = T of {elt: 'a, isMutable: bool} vector
+
+fun dest (T p) = p
+
+val make = T
+
+fun empty () = T (Vector.new0 ())
+
+local
+   fun new1 {elt, isMutable} = T (Vector.new1 {elt = elt, isMutable = isMutable})
+in
+   fun new1Immutable elt = new1 {elt = elt, isMutable = false}
+   fun new1Mutable elt = new1 {elt = elt, isMutable = true}
+end
+
+fun fold (p, b, f) =
+   Vector.fold (dest p, b, fn ({elt, ...}, b) => f (elt, b))
+
+fun foreach (p, f) = Vector.foreach (dest p, f o #elt)
+
+fun isEmpty p = Vector.isEmpty (dest p)
+
+fun allAreImmutable (T v) = Vector.forall (v, not o #isMutable)
+fun allAreMutable (T v) = Vector.forall (v, #isMutable)
+fun someIsImmutable (T v) = Vector.exists (v, not o #isMutable)
+fun someIsMutable (T v) = Vector.exists (v, #isMutable)
+
+fun sub (T p, i) = Vector.sub (p, i)
+
+fun elt (p, i) = #elt (sub (p, i))
+
+fun length p = Vector.length (dest p)
+
+val equals: 'a t * 'a t * ('a * 'a -> bool) -> bool =
+   fn (p1, p2, equals) =>
+   Vector.equals (dest p1, dest p2,
+                  fn ({elt = e1, isMutable = m1},
+                      {elt = e2, isMutable = m2}) =>
+                  m1 = m2 andalso equals (e1, e2))
+
+fun layout (p, layoutElt) =
+   let
+      open Layout
+   in
+      seq [str "(",
+           (mayAlign o separateRight)
+           (Vector.toListMap (dest p, fn {elt, isMutable} =>
+                              if isMutable
+                                 then seq [layoutElt elt, str " mut"]
+                                 else layoutElt elt),
+            ","),
+           str ")"]
+   end
+
+fun parse (parseElt: 'a Parse.t): 'a t Parse.t =
+   let
+      open Parse
+      (* infix declarations for Parse.Ops *)
+      infix  1 <|> >>=
+      infix  3 <*> <* *>
+      infixr 4 <$> <$$> <$$$> <$$$$> <$ <$?>
+   in
+      make <$>
+      vector (parseElt >>= (fn elt =>
+              optional (kw "mut") >>= (fn isMutable =>
+              pure {elt = elt, isMutable = Option.isSome isMutable})))
+   end
+
+val map: 'a t * ('a -> 'b) -> 'b t =
+   fn (p, f) =>
+   make (Vector.map (dest p, fn {elt, isMutable} =>
+                     {elt = f elt,
+                      isMutable = isMutable}))
+
+val keepAllMap: 'a t * ('a -> 'b option) -> 'b t =
+   fn (p, f) =>
+   make (Vector.keepAllMap (dest p, fn {elt, isMutable} =>
+                            Option.map (f elt, fn elt =>
+                                        {elt = elt,
+                                         isMutable = isMutable})))
+end

--- a/mlton/atoms/prod.sig
+++ b/mlton/atoms/prod.sig
@@ -21,8 +21,10 @@ signature PROD =
       val elt: 'a t * int -> 'a
       val equals: 'a t * 'a t * ('a * 'a -> bool) -> bool
       val empty: unit -> 'a t
+      val first: 'a t -> {elt: 'a, isMutable: bool}
       val fold: 'a t * 'b * ('a * 'b -> 'b) -> 'b
       val foreach: 'a t * ('a -> unit) -> unit
+      val hash: 'a t * ('a -> word) -> word
       val isEmpty: 'a t -> bool
       val keepAllMap: 'a t * ('a -> 'b option) -> 'b t
       val layout: 'a t * ('a -> Layout.t) -> Layout.t

--- a/mlton/atoms/prod.sig
+++ b/mlton/atoms/prod.sig
@@ -1,0 +1,38 @@
+(* Copyright (C) 2009,2017,2019-2020 Matthew Fluet.
+ * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
+ *    Jagannathan, and Stephen Weeks.
+ * Copyright (C) 1997-2000 NEC Research Institute.
+ *
+ * MLton is released under a HPND-style license.
+ * See the file MLton-LICENSE for details.
+ *)
+
+signature PROD_STRUCTS =
+   sig
+   end
+
+signature PROD =
+   sig
+      type 'a t
+
+      val allAreImmutable: 'a t -> bool
+      val allAreMutable: 'a t -> bool
+      val dest: 'a t -> {elt: 'a, isMutable: bool} vector
+      val elt: 'a t * int -> 'a
+      val equals: 'a t * 'a t * ('a * 'a -> bool) -> bool
+      val empty: unit -> 'a t
+      val fold: 'a t * 'b * ('a * 'b -> 'b) -> 'b
+      val foreach: 'a t * ('a -> unit) -> unit
+      val isEmpty: 'a t -> bool
+      val keepAllMap: 'a t * ('a -> 'b option) -> 'b t
+      val layout: 'a t * ('a -> Layout.t) -> Layout.t
+      val length: 'a t -> int
+      val make: {elt: 'a, isMutable: bool} vector -> 'a t
+      val map: 'a t * ('a -> 'b) -> 'b t
+      val new1Immutable: 'a -> 'a t
+      val new1Mutable: 'a -> 'a t
+      val parse: 'a Parse.t -> 'a t Parse.t
+      val someIsImmutable: 'a t -> bool
+      val someIsMutable: 'a t -> bool
+      val sub: 'a t * int -> {elt: 'a, isMutable: bool}
+   end

--- a/mlton/atoms/sources.cm
+++ b/mlton/atoms/sources.cm
@@ -108,6 +108,8 @@ cases.sig
 cases.fun
 prim.sig
 prim.fun
+prod.sig
+prod.fun
 handler.sig
 handler.fun
 return.sig

--- a/mlton/atoms/sources.cm
+++ b/mlton/atoms/sources.cm
@@ -22,6 +22,7 @@ signature LABEL
 signature PRIM
 signature PRIM_CONS
 signature PRIM_TYCONS
+signature PROD
 signature PROFILE_LABEL
 signature REAL_SIZE
 signature REAL_X

--- a/mlton/atoms/sources.mlb
+++ b/mlton/atoms/sources.mlb
@@ -70,6 +70,8 @@ local
    cases.fun
    prim.sig
    prim.fun
+   prod.sig
+   prod.fun
    handler.sig
    handler.fun
    return.sig

--- a/mlton/atoms/sources.mlb
+++ b/mlton/atoms/sources.mlb
@@ -106,6 +106,7 @@ in
    signature PRIM
    signature PRIM_CONS
    signature PRIM_TYCONS
+   signature PROD
    signature PROFILE_LABEL
    signature REAL_SIZE
    signature REAL_X

--- a/mlton/backend/backend-atoms.fun
+++ b/mlton/backend/backend-atoms.fun
@@ -22,6 +22,7 @@ structure BackendAtoms =
                                    structure Label = Label
                                    structure ObjptrTycon = ObjptrTycon
                                    structure Prim = Prim
+                                   structure Prod = Prod
                                    structure RealSize = RealSize
                                    structure RealX = RealX
                                    structure Runtime = Runtime

--- a/mlton/backend/backend-atoms.sig
+++ b/mlton/backend/backend-atoms.sig
@@ -37,6 +37,7 @@ signature BACKEND_ATOMS' =
       sharing Const = Type.Const
       sharing Label = Type.Label
       sharing Prim = Type.Prim
+      sharing Prod = Type.Prod
       sharing RealSize = ObjptrTycon.RealSize = RealX.RealSize = Type.RealSize
       sharing RealX = Type.RealX
       sharing WordSize = ObjptrTycon.WordSize = Type.WordSize = WordX.WordSize

--- a/mlton/backend/collect-statics.fun
+++ b/mlton/backend/collect-statics.fun
@@ -141,8 +141,7 @@ structure RealConsts =
                                         src = Operand.Const (Const.Real r)})
                                    val obj =
                                       Object.Sequence
-                                      {elt = elt,
-                                       init = init,
+                                      {init = init,
                                        tycon = vecTycon}
                                 in
                                    SOME {dst = (vecVar, vecTy), obj = obj}

--- a/mlton/backend/implement-profiling.fun
+++ b/mlton/backend/implement-profiling.fun
@@ -144,6 +144,8 @@ fun transform program =
    else
    let
       val Program.T {functions, handlesSignals, main, objectTypes, statics, ...} = program
+      fun tyconTy tycon =
+         Vector.sub (objectTypes, ObjptrTycon.index tycon)
       val debug = false
       datatype z = datatype Control.profile
       val profile = !Control.profile
@@ -748,7 +750,9 @@ fun transform program =
                                Object {obj, ...} =>
                                   {args = args,
                                    bytesAllocated = Bytes.+ (bytesAllocated,
-                                                             Object.size obj),
+                                                             Object.size
+                                                             (obj,
+                                                              {tyconTy = tyconTy})),
                                    kind = kind,
                                    label = label,
                                    leaves = leaves,

--- a/mlton/backend/limit-check.fun
+++ b/mlton/backend/limit-check.fun
@@ -863,7 +863,9 @@ fun transform (Program.T {functions, handlesSignals, main, objectTypes, profileI
                 then (ObjptrTycon.setIndex (flagsTycon, Vector.length objectTypes)
                       ; (Vector.concat
                          [objectTypes,
-                          Vector.new1 (ObjectType.Sequence {elt = flagTy, hasIdentity = true})],
+                          Vector.new1 (ObjectType.Sequence
+                                       {components = Vector.new1 flagTy,
+                                        hasIdentity = true})],
                          Vector.concat
                          [statics,
                           Vector.new1 {dst = (flagsVar, flagsTy),

--- a/mlton/backend/limit-check.fun
+++ b/mlton/backend/limit-check.fun
@@ -864,7 +864,7 @@ fun transform (Program.T {functions, handlesSignals, main, objectTypes, profileI
                       ; (Vector.concat
                          [objectTypes,
                           Vector.new1 (ObjectType.Sequence
-                                       {components = Vector.new1 flagTy,
+                                       {components = Prod.new1Mutable flagTy,
                                         hasIdentity = true})],
                          Vector.concat
                          [statics,

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -1157,7 +1157,7 @@ structure Program =
                    (#1 o Vector.mapAndFold)
                    (staticHeaps k, Bytes.zero, fn (obj, next) =>
                     ((Bytes.+ (next, Object.metaDataSize obj), obj),
-                     Bytes.+ (next, Object.size obj))))
+                     Bytes.+ (next, Object.size (obj, {tyconTy = tyconTy})))))
                end
 
             fun checkGlobal (name, global, isOk, layoutVal) =

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -1246,10 +1246,18 @@ structure Program =
                             end handle _ => false)
                       | Offset {base, offset, ty} =>
                            (checkOperand (base, alloc)
-                            ; Type.offsetIsOk {base = Operand.ty base,
-                                               offset = offset,
-                                               tyconTy = tyconTy,
-                                               result = ty})
+                            ; (Type.offsetIsOk
+                               {base = Operand.ty base,
+                                (* MachineIR doesn't distinguish
+                                 * initialization of object field
+                                 * from update of object field;
+                                 * only the latter requires
+                                 * the field to be mutable.
+                                 *)
+                                mustBeMutable = false,
+                                offset = offset,
+                                tyconTy = tyconTy,
+                                result = ty}))
                       | StackOffset (so as StackOffset.T {offset, ty, ...}) =>
                            Bytes.<= (Bytes.+ (offset, Type.bytes ty), maxFrameSize)
                            andalso Alloc.doesDefine (alloc, Live.StackOffset so)
@@ -1285,12 +1293,20 @@ structure Program =
                       | SequenceOffset {base, index, offset, scale, ty} =>
                            (checkOperand (base, alloc)
                             ; checkOperand (index, alloc)
-                            ; Type.sequenceOffsetIsOk {base = Operand.ty base,
-                                                       index = Operand.ty index,
-                                                       offset = offset,
-                                                       tyconTy = tyconTy,
-                                                       result = ty,
-                                                       scale = scale})
+                            ; (Type.sequenceOffsetIsOk
+                               {base = Operand.ty base,
+                                index = Operand.ty index,
+                                (* MachineIR doesn't distinguish
+                                 * initialization of object field
+                                 * from update of object field;
+                                 * only the latter requires
+                                 * the field to be mutable.
+                                 *)
+                                mustBeMutable = false,
+                                offset = offset,
+                                tyconTy = tyconTy,
+                                result = ty,
+                                scale = scale}))
                       | StaticHeapRef r => checkStaticHeapRef r
                       | StackTop => true
                       | Temporary t => Alloc.doesDefine (alloc, Live.Temporary t)

--- a/mlton/backend/object-type.sig
+++ b/mlton/backend/object-type.sig
@@ -8,23 +8,24 @@
 
 signature OBJECT_TYPE =
    sig
+      structure Prod: PROD
       structure ObjptrTycon: OBJPTR_TYCON
       structure Runtime: RUNTIME
 
       type ty
       datatype t =
-         Normal of {components: ty vector,
+         Normal of {components: ty Prod.t,
                     hasIdentity: bool}
-       | Sequence of {components: ty vector,
+       | Sequence of {components: ty Prod.t,
                       hasIdentity: bool}
        | Stack
        | Weak of ty option (* in Weak (SOME t), must have Type.isObjptr t *)
 
       val basic: unit -> (ObjptrTycon.t * t) vector
-      val components: t -> ty vector
+      val components: t -> ty Prod.t
       val componentsSize: t -> Bytes.t
-      val deNormal: t -> {components: ty vector, hasIdentity: bool}
-      val deSequence: t -> {components: ty vector, hasIdentity: bool}
+      val deNormal: t -> {components: ty Prod.t, hasIdentity: bool}
+      val deSequence: t -> {components: ty Prod.t, hasIdentity: bool}
       val isOk: t -> bool
       val layout: t -> Layout.t
       val toRuntime: t -> Runtime.RObjectType.t

--- a/mlton/backend/object-type.sig
+++ b/mlton/backend/object-type.sig
@@ -13,16 +13,18 @@ signature OBJECT_TYPE =
 
       type ty
       datatype t =
-         Normal of {hasIdentity: bool,
-                    ty: ty}
-       | Sequence of {elt: ty,
+         Normal of {components: ty vector,
+                    hasIdentity: bool}
+       | Sequence of {components: ty vector,
                       hasIdentity: bool}
        | Stack
        | Weak of ty option (* in Weak (SOME t), must have Type.isObjptr t *)
 
       val basic: unit -> (ObjptrTycon.t * t) vector
-      val deNormal: t -> {hasIdentity: bool, ty: ty}
-      val deSequence: t -> {elt: ty, hasIdentity: bool}
+      val components: t -> ty vector
+      val componentsSize: t -> Bytes.t
+      val deNormal: t -> {components: ty vector, hasIdentity: bool}
+      val deSequence: t -> {components: ty vector, hasIdentity: bool}
       val isOk: t -> bool
       val layout: t -> Layout.t
       val toRuntime: t -> Runtime.RObjectType.t

--- a/mlton/backend/object-type.sig
+++ b/mlton/backend/object-type.sig
@@ -21,6 +21,8 @@ signature OBJECT_TYPE =
        | Weak of ty option (* in Weak (SOME t), must have Type.isObjptr t *)
 
       val basic: unit -> (ObjptrTycon.t * t) vector
+      val deNormal: t -> {hasIdentity: bool, ty: ty}
+      val deSequence: t -> {elt: ty, hasIdentity: bool}
       val isOk: t -> bool
       val layout: t -> Layout.t
       val toRuntime: t -> Runtime.RObjectType.t

--- a/mlton/backend/object-type.sig
+++ b/mlton/backend/object-type.sig
@@ -1,4 +1,5 @@
-(* Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2020 Matthew Fluet
+ * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a HPND-style license.
@@ -17,7 +18,7 @@ signature OBJECT_TYPE =
        | Sequence of {elt: ty,
                       hasIdentity: bool}
        | Stack
-       | Weak of ty option (* in Weak (SOME t), must have Type.isPointer t *)
+       | Weak of ty option (* in Weak (SOME t), must have Type.isObjptr t *)
 
       val basic: unit -> (ObjptrTycon.t * t) vector
       val isOk: t -> bool

--- a/mlton/backend/object.fun
+++ b/mlton/backend/object.fun
@@ -159,6 +159,10 @@ fun isOk (obj: t,
                fun offsetIsOk {offset, result} =
                   Type.offsetIsOk
                   {base = base,
+                   (* initialization of object field
+                    * does not require the field to be mutable.
+                    *)
+                   mustBeMutable = false,
                    offset = offset,
                    tyconTy = tyconTy,
                    result = result}
@@ -181,6 +185,10 @@ fun isOk (obj: t,
                       Type.sequenceOffsetIsOk
                       {base = base,
                        index = index,
+                       (* initialization of object field
+                        * does not require the field to be mutable.
+                        *)
+                       mustBeMutable = false,
                        offset = offset,
                        result = result,
                        scale = scale,

--- a/mlton/backend/object.sig
+++ b/mlton/backend/object.sig
@@ -37,15 +37,12 @@ signature OBJECT =
       datatype t =
          Normal of {init: {offset: Bytes.t,
                            src: Use.t} vector,
-                    ty: Type.t,
                     tycon: ObjptrTycon.t}
-       | Sequence of {elt: Type.t,
-                      init: {offset: Bytes.t,
+       | Sequence of {init: {offset: Bytes.t,
                              src: Use.t} vector vector,
                       tycon: ObjptrTycon.t}
 
-      val deString: {elt: Type.t,
-                     init: {offset: Bytes.t,
+      val deString: {init: {offset: Bytes.t,
                             src: Use.t} vector vector,
                      tycon: ObjptrTycon.t} -> string option
       val foldUse: t * 'a * (Use.t * 'a -> 'a) -> 'a
@@ -56,7 +53,7 @@ signature OBJECT =
       val layout: t -> Layout.t
       val metaDataSize: t -> Bytes.t
       val replace: t * {use: Use.t -> Use.t} -> t
-      val size: t -> Bytes.t
+      val size: t * {tyconTy: ObjptrTycon.t -> ObjectType.t} -> Bytes.t
       val toString: t -> string
       val ty: t -> Type.t
    end

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -943,7 +943,7 @@ structure ObjptrRep =
                   tycon = opt}
          end
 
-      fun tuple (T {components, componentsTy, ty, tycon, ...},
+      fun tuple (T {components, ty, tycon, ...},
                  {dst = dst: Var.t,
                   src: {index: int} -> Operand.t}) =
          let
@@ -968,7 +968,6 @@ structure ObjptrRep =
             ([Object {dst = (dst, ty),
                       obj = Object.Normal
                             {init = Vector.fromListRev init,
-                             ty = componentsTy,
                              tycon = tycon}}]
              :: pre)
          end
@@ -979,7 +978,7 @@ structure ObjptrRep =
           layout, Var.layout o #dst, List.layout Statement.layout)
          tuple
 
-      fun sequence (T {components, componentsTy, ty, tycon, ...},
+      fun sequence (T {components, ty, tycon, ...},
                     {dst = dst: Var.t,
                      src: ({index: int} -> Operand.t) vector}) =
          let
@@ -1010,8 +1009,7 @@ structure ObjptrRep =
             List.concatRev
             ([Object {dst = (dst, ty),
                       obj = Object.Sequence
-                            {elt = componentsTy,
-                             init = Vector.fromListRev init,
+                            {init = Vector.fromListRev init,
                              tycon = tycon}}]
              :: pre)
          end

--- a/mlton/backend/packed-representation.fun
+++ b/mlton/backend/packed-representation.fun
@@ -1376,6 +1376,26 @@ structure TupleRep =
                          Bytes.+ (offset, Bytes.inWord32),
                          ac)
                      end
+            val makeSubWord32sAllPrims0 = makeSubWord32sAllPrims
+            fun makeSubWord32sAllPrims1 (_, offset: Bytes.t, components) =
+               let
+                  fun doit (b, offset, components) =
+                     simple (List.map (Array.sub (subWord32s, b), fn {index, isMutable, rep} =>
+                                       {component = Component.Direct {index = index,
+                                                                      isMutable = isMutable,
+                                                                      rep = rep},
+                                        index = index}),
+                             Bits.toBytes (Bits.fromInt b), offset, components)
+                  val (offset, components) = doit (16, offset, components)
+                  val (offset, components) = doit (8, offset, components)
+               in
+                  (offset, components)
+               end
+            val makeSubWord32sAllPrims =
+               case !Control.packedRepresentationMakeSubWord32sAllPrimsStyle of
+                  0 => makeSubWord32sAllPrims0
+                | 1 => makeSubWord32sAllPrims1
+                | _ => Error.bug "PackedRepresentation.TupleRep.make: Control.packedRepresentationMakeSubWord32sStyle"
             val (offset, components) =
                if (not hasNonPrim) andalso needsBox
                   then makeSubWord32sAllPrims (Array.length subWord32s - 1, offset, components)

--- a/mlton/backend/rep-type.fun
+++ b/mlton/backend/rep-type.fun
@@ -412,6 +412,18 @@ structure ObjectType =
        | Stack
        | Weak of Type.t option
 
+      fun deNormal t =
+         case t of
+            Normal {hasIdentity, ty} =>
+               {hasIdentity = hasIdentity, ty = ty}
+          | _ => Error.bug "ObjectType.deNormal"
+
+      fun deSequence t =
+         case t of
+            Sequence {elt, hasIdentity} =>
+               {elt = elt, hasIdentity = hasIdentity}
+          | _ => Error.bug "ObjectType.deSequence"
+
       fun layout (t: t) =
          let
             open Layout

--- a/mlton/backend/rep-type.sig
+++ b/mlton/backend/rep-type.sig
@@ -14,6 +14,7 @@ signature REP_TYPE_STRUCTS =
       structure Label: LABEL
       structure ObjptrTycon: OBJPTR_TYCON
       structure Prim: PRIM
+      structure Prod: PROD
       structure RealSize: REAL_SIZE
       structure RealX: REAL_X
       structure Runtime: RUNTIME
@@ -37,6 +38,7 @@ signature REP_TYPE =
 
       structure ObjectType: OBJECT_TYPE
       sharing type ObjectType.ty = t
+      sharing ObjectType.Prod = Prod
       (* sharing ObjectType.ObjptrTycon = ObjptrTycon *)
       (* sharing ObjectType.Runtime = Runtime *)
 

--- a/mlton/backend/rep-type.sig
+++ b/mlton/backend/rep-type.sig
@@ -82,6 +82,7 @@ signature REP_TYPE =
       val ofWordXVector: WordXVector.t -> t
       val ofWordX: WordX.t -> t
       val offsetIsOk: {base: t,
+                       mustBeMutable: bool,
                        offset: Bytes.t,
                        tyconTy: ObjptrTycon.t -> ObjectType.t,
                        result: t} -> bool
@@ -93,6 +94,7 @@ signature REP_TYPE =
       val seqIndex: unit -> t
       val sequenceOffsetIsOk: {base: t,
                                index: t,
+                               mustBeMutable: bool,
                                offset: Bytes.t,
                                tyconTy: ObjptrTycon.t -> ObjectType.t,
                                result: t,

--- a/mlton/backend/representation.sig
+++ b/mlton/backend/representation.sig
@@ -11,6 +11,7 @@ signature REPRESENTATION_STRUCTS =
    sig
       structure Rssa: RSSA
       structure Ssa2: SSA2
+      sharing Rssa.Prod = Ssa2.Prod
       sharing Rssa.RealSize = Ssa2.RealSize
       sharing Rssa.WordSize = Ssa2.WordSize
    end

--- a/mlton/backend/rssa-type-check.fun
+++ b/mlton/backend/rssa-type-check.fun
@@ -21,7 +21,6 @@ structure Operand =
           | Offset _ => true
           | Runtime _ => true
           | SequenceOffset _ => true
-          | Var _ => true
           | _ => false
    end
 

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -681,10 +681,10 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
 
       val newObjectTypes = ref []
       local
-         fun componentsHash ts =
-            Hash.vectorMap (ts, Type.hash)
-         fun componentsEquals (ts1, ts2) =
-            Vector.equals (ts1, ts2, Type.equals)
+         fun componentsHash cs =
+            Prod.hash (cs, Type.hash)
+         fun componentsEquals (cs1, cs2) =
+            Prod.equals (cs1, cs2, Type.equals)
          val h = HashTable.new {hash = componentsHash, equals = componentsEquals}
       in
          fun allocRawOpt components =
@@ -693,10 +693,10 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
              fn () =>
              let
                 val rawComponents =
-                   Vector.map (components, fn ty =>
-                               if Type.isObjptr ty
-                                  then Type.bits (Type.width ty)
-                                  else ty)
+                   Prod.map (components, fn ty =>
+                             if Type.isObjptr ty
+                                then Type.bits (Type.width ty)
+                                else ty)
                 val rawTy = ObjectType.Sequence {components = rawComponents, hasIdentity = true}
                 val rawOpt = ObjptrTycon.new ()
                 val () =

--- a/mlton/backend/ssa2-to-rssa.fun
+++ b/mlton/backend/ssa2-to-rssa.fun
@@ -681,15 +681,23 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
 
       val newObjectTypes = ref []
       local
-         val h = HashTable.new {hash = Bits.toWord, equals = Bits.equals }
+         fun componentsHash ts =
+            Hash.vectorMap (ts, Type.hash)
+         fun componentsEquals (ts1, ts2) =
+            Vector.equals (ts1, ts2, Type.equals)
+         val h = HashTable.new {hash = componentsHash, equals = componentsEquals}
       in
-         fun allocRawOpt width =
+         fun allocRawOpt components =
             HashTable.lookupOrInsert
-            (h, width,
+            (h, components,
              fn () =>
              let
-                val rawElt = Type.bits width
-                val rawTy = ObjectType.Sequence {elt = rawElt, hasIdentity = true}
+                val rawComponents =
+                   Vector.map (components, fn ty =>
+                               if Type.isObjptr ty
+                                  then Type.bits (Type.width ty)
+                                  else ty)
+                val rawTy = ObjectType.Sequence {components = rawComponents, hasIdentity = true}
                 val rawOpt = ObjptrTycon.new ()
                 val () =
                    ObjptrTycon.setIndex
@@ -1168,11 +1176,11 @@ fun convert (program as S.Program.T {functions, globals, main, ...},
                                                  | SOME arrOpt => arrOpt
                                              val arrTy =
                                                 Vector.sub (objectTypes, ObjptrTycon.index arrOpt)
-                                             val arrElt =
+                                             val arrComponents =
                                                 case arrTy of
-                                                   ObjectType.Sequence {elt, ...} => elt
+                                                   ObjectType.Sequence {components, ...} => components
                                                  | _ => Error.bug "SsaToRssa.translateStatementsTransfer: PrimApp,Array_allocRaw"
-                                             val rawOpt = allocRawOpt (Type.width arrElt)
+                                             val rawOpt = allocRawOpt arrComponents
                                           in
                                              rawOpt
                                           end

--- a/mlton/codegen/c-codegen/c-codegen.fun
+++ b/mlton/codegen/c-codegen/c-codegen.fun
@@ -362,10 +362,6 @@ fun outputDeclarations
             fun sym k = Label.toString (Kind.label k)
             fun ty k = concat [sym k, "Ty"]
 
-            fun componentsSize components =
-               Vector.fold (components, Bytes.zero, fn (ty, b) =>
-                            Bytes.+ (b, Type.bytes ty))
-
             fun mkPadTy (next, offset) =
                if Bytes.equals (next, offset)
                   then NONE
@@ -456,8 +452,7 @@ fun outputDeclarations
                       ; (case obj of
                             Object.Normal {init, tycon} =>
                                let
-                                  val {components, ...} = ObjectType.deNormal (tyconTy tycon)
-                                  val size = componentsSize components
+                                  val size = ObjectType.componentsSize (tyconTy tycon)
                                in
                                   print "struct __attribute__ ((packed)) {"
                                   ; print (CType.toString headerTy)
@@ -475,7 +470,7 @@ fun outputDeclarations
                           | Object.Sequence {init, tycon} =>
                                let
                                   val {components, ...} = ObjectType.deSequence (tyconTy tycon)
-                                  val size = componentsSize components
+                                  val size = ObjectType.componentsSize (tyconTy tycon)
                                   val length = Vector.length init
                                in
                                   print "struct __attribute__ ((packed)) {"
@@ -489,8 +484,8 @@ fun outputDeclarations
                                   ; print " header;"
                                   ; print "} metadata;"
                                   ; print " "
-                                  ; if Vector.length components = 1
-                                       andalso Type.equals (Vector.first components,
+                                  ; if Prod.length components = 1
+                                       andalso Type.equals (#elt (Prod.first components),
                                                             Type.word WordSize.word8)
                                        then print (CType.toString CType.Word8)
                                        else (print "struct __attribute__ ((packed)) {"
@@ -574,8 +569,7 @@ fun outputDeclarations
                       ; (case obj of
                             Object.Normal {init, tycon} =>
                                let
-                                  val {components, ...} = ObjectType.deNormal (tyconTy tycon)
-                                  val size = componentsSize components
+                                  val size = ObjectType.componentsSize (tyconTy tycon)
                                in
                                   print "{"
                                   ; print (mkHeader tycon)
@@ -589,8 +583,7 @@ fun outputDeclarations
                                end
                           | Object.Sequence (arg as {init, tycon}) =>
                                let
-                                  val {components, ...} = ObjectType.deSequence (tyconTy tycon)
-                                  val size = componentsSize components
+                                  val size = ObjectType.componentsSize (tyconTy tycon)
                                   val length = Vector.length init
                                in
                                   print "{"

--- a/mlton/control/bits.sml
+++ b/mlton/control/bits.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2019 Matthew Fluet.
+(* Copyright (C) 2009,2019-2020 Matthew Fluet.
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -39,6 +39,7 @@ local
                val inWord64: t
                val isAligned: t * {alignment: t} -> bool
                val isByteAligned: t -> bool
+               val isPrim: t -> bool
                val isWord8Aligned: t -> bool
                val isWord16Aligned: t -> bool
                val isWord32Aligned: t -> bool
@@ -48,6 +49,7 @@ local
                val max: t * t -> t
                val min: t * t -> t
                val one: t
+               val prims: t list
                val toBytes: t -> bytes
                val toInt: t -> int
                val toIntInf: t -> IntInf.t
@@ -129,6 +131,9 @@ local
                val inWord32: bits = 32
                val inWord64: bits = 64
 
+               val prims = [inWord8, inWord16, inWord32, inWord64]
+               fun isPrim b = List.contains (prims, b, equals)
+
                fun isAligned (b, {alignment = a}) = 0 = rem (b, a)
                fun isByteAligned b = isAligned (b, {alignment = inByte})
                fun isWord8Aligned b = isAligned (b, {alignment = inWord8})
@@ -153,8 +158,6 @@ local
             struct
                open IntInf
 
-               (* val inWord8: bytes = 1 *)
-               (* val inWord16: bytes = 2 *)
                val inWord32: bytes = 4
                val inWord64: bytes = 8
 

--- a/mlton/control/bits.sml
+++ b/mlton/control/bits.sml
@@ -81,8 +81,8 @@ local
                val fromInt: int -> t
                val fromIntInf: IntInf.t -> t
                val hash: t -> word
-               (* val inWord8: t *)
-               (* val inWord16: t *)
+               val inWord8: t
+               val inWord16: t
                val inWord32: t
                val inWord64: t
                val isAligned: t * {alignment: t} -> bool
@@ -93,6 +93,7 @@ local
                val max: t * t -> t
                val min: t * t -> t
                val one: t
+               val prims: t list
                val toBits: t -> Bits.t
                val toInt: t -> int
                val toIntInf: t -> IntInf.t
@@ -158,8 +159,12 @@ local
             struct
                open IntInf
 
+               val inWord8: bytes = 1
+               val inWord16: bytes = 2
                val inWord32: bytes = 4
                val inWord64: bytes = 8
+
+               val prims = [inWord8, inWord16, inWord32, inWord64]
 
                fun isAligned (b, {alignment = a}) = 0 = rem (b, a)
                (* fun isWord8Aligned b = isAligned (b, {alignment = inWord8}) *)

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -382,6 +382,8 @@ signature CONTROL_FLAGS =
             val setAll: string -> unit Result.t
          end
 
+      val packedRepresentationMakeSubWord32sAllPrimsStyle: int ref
+
       (* Only duplicate big functions when
        * (size - small) * (number of occurrences - 1) <= product
        *)

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -382,8 +382,6 @@ signature CONTROL_FLAGS =
             val setAll: string -> unit Result.t
          end
 
-      val packedRepresentationMakeSubWord32sAllPrimsStyle: int ref
-
       (* Only duplicate big functions when
        * (size - small) * (number of occurrences - 1) <= product
        *)

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -444,8 +444,6 @@ signature CONTROL_FLAGS =
 
       val profileVal: bool ref
 
-      val repTypeCheckOffsetStyle: int ref
-
       (* Show the basis library. *)
       val showBasis: File.t option ref
 

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -444,6 +444,8 @@ signature CONTROL_FLAGS =
 
       val profileVal: bool ref
 
+      val repTypeCheckOffsetStyle: int ref
+
       (* Show the basis library. *)
       val showBasis: File.t option ref
 

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1331,6 +1331,11 @@ structure OptimizationPasses =
                                            | Result.Yes () => Result.Yes ()))
    end
 
+val packedRepresentationMakeSubWord32sAllPrimsStyle =
+   control {name = "packedRepresentationMakeSubWord32sAllPrimsStyle",
+            default = 0,
+            toString = Int.toString}
+
 val polyvariance =
    control {name = "polyvariance",
             default = SOME {hofo = true,

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1331,11 +1331,6 @@ structure OptimizationPasses =
                                            | Result.Yes () => Result.Yes ()))
    end
 
-val packedRepresentationMakeSubWord32sAllPrimsStyle =
-   control {name = "packedRepresentationMakeSubWord32sAllPrimsStyle",
-            default = 0,
-            toString = Int.toString}
-
 val polyvariance =
    control {name = "polyvariance",
             default = SOME {hofo = true,

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1494,6 +1494,11 @@ val profileVal = control {name = "profile val",
                           default = false,
                           toString = Bool.toString}
 
+val repTypeCheckOffsetStyle =
+   control {name = "repTypeCheckOffsetStyle",
+            default = 0,
+            toString = Int.toString}
+
 val showBasis = control {name = "show basis",
                          default = NONE,
                          toString = Option.toString File.toString}

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1494,11 +1494,6 @@ val profileVal = control {name = "profile val",
                           default = false,
                           toString = Bool.toString}
 
-val repTypeCheckOffsetStyle =
-   control {name = "repTypeCheckOffsetStyle",
-            default = 0,
-            toString = Int.toString}
-
 val showBasis = control {name = "show basis",
                          default = NONE,
                          toString = Option.toString File.toString}

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -801,6 +801,8 @@ fun makeOptions {usage} =
        (Normal, "profile-val", " {false|true}",
         "profile val bindings in addition to functions",
         boolRef profileVal),
+       (Normal, "RepType.checkOffset-style", " <n>", "style for RepType.checkOffset",
+        intRef repTypeCheckOffsetStyle),
        (Normal, "runtime", " <arg>", "pass arg to runtime via @MLton",
         SpaceString (fn s => List.push (runtimeArgs, s))),
        (Expert, "seed-rand", " <w>", "seed the pseudo-random number generator",

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -667,6 +667,8 @@ fun makeOptions {usage} =
                       | Result.Yes () => ())),
        (Normal, "output", " <file>", "name of output file",
         SpaceString (fn s => output := SOME s)),
+       (Normal, "PackedRepresentation.makeSubWord32sAllPrims-style", " <n>", "representation style for PackedRepresentation.makeSubWord32sAllPrims",
+        intRef packedRepresentationMakeSubWord32sAllPrimsStyle),
        (Expert, "polyvariance", " {true|false}", "use polyvariance",
         Bool (fn b => if b then () else polyvariance := NONE)),
        (Expert, "polyvariance-hofo", " {true|false}", "duplicate higher-order fns only",

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -667,8 +667,6 @@ fun makeOptions {usage} =
                       | Result.Yes () => ())),
        (Normal, "output", " <file>", "name of output file",
         SpaceString (fn s => output := SOME s)),
-       (Normal, "PackedRepresentation.makeSubWord32sAllPrims-style", " <n>", "representation style for PackedRepresentation.makeSubWord32sAllPrims",
-        intRef packedRepresentationMakeSubWord32sAllPrimsStyle),
        (Expert, "polyvariance", " {true|false}", "use polyvariance",
         Bool (fn b => if b then () else polyvariance := NONE)),
        (Expert, "polyvariance-hofo", " {true|false}", "duplicate higher-order fns only",

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -801,8 +801,6 @@ fun makeOptions {usage} =
        (Normal, "profile-val", " {false|true}",
         "profile val bindings in addition to functions",
         boolRef profileVal),
-       (Normal, "RepType.checkOffset-style", " <n>", "style for RepType.checkOffset",
-        intRef repTypeCheckOffsetStyle),
        (Normal, "runtime", " <arg>", "pass arg to runtime via @MLton",
         SpaceString (fn s => List.push (runtimeArgs, s))),
        (Expert, "seed-rand", " <w>", "seed the pseudo-random number generator",

--- a/mlton/ssa/ssa-tree2.fun
+++ b/mlton/ssa/ssa-tree2.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2014,2017-2019 Matthew Fluet.
+(* Copyright (C) 2009,2014,2017-2020 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -16,87 +16,6 @@ open S
 infix  1 <|> >>=
 infix  3 <*> <* *>
 infixr 4 <$> <$$> <$$$> <$$$$> <$ <$?>
-
-structure Prod =
-   struct
-      datatype 'a t = T of {elt: 'a, isMutable: bool} vector
-
-      fun dest (T p) = p
-
-      val make = T
-
-      fun empty () = T (Vector.new0 ())
-
-      local
-         fun new1 {elt, isMutable} = T (Vector.new1 {elt = elt, isMutable = isMutable})
-      in
-         fun new1Immutable elt = new1 {elt = elt, isMutable = false}
-         fun new1Mutable elt = new1 {elt = elt, isMutable = true}
-      end
-
-      fun fold (p, b, f) =
-         Vector.fold (dest p, b, fn ({elt, ...}, b) => f (elt, b))
-
-      fun foreach (p, f) = Vector.foreach (dest p, f o #elt)
-
-      fun isEmpty p = Vector.isEmpty (dest p)
-
-      fun allAreImmutable (T v) = Vector.forall (v, not o #isMutable)
-      fun allAreMutable (T v) = Vector.forall (v, #isMutable)
-      fun someIsImmutable (T v) = Vector.exists (v, not o #isMutable)
-      fun someIsMutable (T v) = Vector.exists (v, #isMutable)
-
-      fun sub (T p, i) = Vector.sub (p, i)
-
-      fun elt (p, i) = #elt (sub (p, i))
-
-      fun length p = Vector.length (dest p)
-
-      val equals: 'a t * 'a t * ('a * 'a -> bool) -> bool =
-         fn (p1, p2, equals) =>
-         Vector.equals (dest p1, dest p2,
-                        fn ({elt = e1, isMutable = m1},
-                            {elt = e2, isMutable = m2}) =>
-                        m1 = m2 andalso equals (e1, e2))
-
-      fun layout (p, layoutElt) =
-         let
-            open Layout
-         in
-            seq [str "(",
-                 (mayAlign o separateRight)
-                 (Vector.toListMap (dest p, fn {elt, isMutable} =>
-                                    if isMutable
-                                       then seq [layoutElt elt, str " mut"]
-                                       else layoutElt elt),
-                  ","),
-                 str ")"]
-         end
-
-      fun parse (parseElt: 'a Parse.t): 'a t Parse.t =
-         let
-            open Parse
-         in
-            make <$>
-            vector (parseElt >>= (fn elt =>
-                    optional (kw "mut") >>= (fn isMutable =>
-                    pure {elt = elt, isMutable = Option.isSome isMutable})))
-
-         end
-
-      val map: 'a t * ('a -> 'b) -> 'b t =
-         fn (p, f) =>
-         make (Vector.map (dest p, fn {elt, isMutable} =>
-                           {elt = f elt,
-                            isMutable = isMutable}))
-
-      val keepAllMap: 'a t * ('a -> 'b option) -> 'b t =
-         fn (p, f) =>
-         make (Vector.keepAllMap (dest p, fn {elt, isMutable} =>
-                                  Option.map (f elt, fn elt => 
-                                              {elt = elt, 
-                                               isMutable = isMutable})))
-   end
 
 structure ObjectCon =
    struct

--- a/mlton/ssa/ssa-tree2.sig
+++ b/mlton/ssa/ssa-tree2.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2017,2019 Matthew Fluet.
+(* Copyright (C) 2009,2017,2019-2020 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -15,28 +15,6 @@ signature SSA_TREE2_STRUCTS =
 signature SSA_TREE2 = 
    sig
       include SSA_TREE2_STRUCTS
-
-      structure Prod:
-         sig
-            type 'a t
-
-            val allAreImmutable: 'a t -> bool
-            val allAreMutable: 'a t -> bool
-            val dest: 'a t -> {elt: 'a, isMutable: bool} vector
-            val elt: 'a t * int -> 'a
-            val empty: unit -> 'a t
-            val fold: 'a t * 'b * ('a * 'b -> 'b) -> 'b
-            val foreach: 'a t * ('a -> unit) -> unit
-            val isEmpty: 'a t -> bool
-            val keepAllMap: 'a t * ('a -> 'b option) -> 'b t
-            val layout: 'a t * ('a -> Layout.t) -> Layout.t
-            val length: 'a t -> int
-            val make: {elt: 'a, isMutable: bool} vector -> 'a t
-            val map: 'a t * ('a -> 'b) -> 'b t
-            val someIsImmutable: 'a t -> bool
-            val someIsMutable: 'a t -> bool
-            val sub: 'a t * int -> {elt: 'a, isMutable: bool}
-         end
 
       structure ObjectCon:
          sig

--- a/regression/flat-array.4.sml
+++ b/regression/flat-array.4.sml
@@ -1,0 +1,28 @@
+structure Main =
+   struct
+      fun doit n =
+         let
+            val v = Vector.tabulate (1000000, fn i =>
+                                     (Word14.fromInt i,
+                                      Word10.fromInt (i + 1),
+                                      Word8.fromInt (i + 2)))
+            fun loop n =
+               if 0 = n
+                  then ()
+               else
+                  let
+                     val sum = Vector.foldl (fn ((a, b, c), d) =>
+                                             Word14.toLarge a +
+                                             Word10.toLarge b +
+                                             Word8.toLarge c + d) 0wx0 v
+                     val _ = if 0wx20E0F3760 <> sum
+                                then raise Fail (LargeWord.toString sum)
+                                else ()
+                  in
+                     loop (n - 1)
+                  end
+         in
+            loop n
+         end
+   end
+val _ = Main.doit 10


### PR DESCRIPTION
Change:

    datatype OBJECT_TYPE.t =
       Normal of {hasIdentity: bool,
                  ty: ty}
     | Sequence of {elt: ty,
                    hasIdentity: bool}
     | Stack
     | Weak of ty option (* in Weak (SOME t), must have Type.isObjptr t *)

to

    datatype OBJECT_TYPE.t =
       Normal of {components: ty Prod.t,
                  hasIdentity: bool}
     | Sequence of {components: ty Prod.t,
                    hasIdentity: bool}
     | Stack
     | Weak of ty option (* in Weak (SOME t), must have Type.isObjptr t *)

With this change, the backend is able to be less conservative about
placing static objects in the `Dynamic` heap (b39a8f84c) and the RSSA
type checker can verify that updates via object offsets are of mutable
components (f72b174be).