### PR TITLE
Fix String.scan to return NONE

### DIFF
--- a/basis-library/text/char.sig
+++ b/basis-library/text/char.sig
@@ -51,5 +51,7 @@ signature CHAR_EXTRA =
       include CHAR
 
       val formatSequences: (Char.char, 'a) StringCvt.reader -> 'a -> 'a
+      val formatSequencesOpt: (Char.char, 'a) StringCvt.reader
+                              -> (unit, 'a) StringCvt.reader
       val scanC: (Char.char, 'a) StringCvt.reader -> (char, 'a) StringCvt.reader
    end

--- a/basis-library/text/string.sml
+++ b/basis-library/text/string.sml
@@ -71,7 +71,16 @@ functor StringFn(Arg : STRING_ARG)
                                 Char.formatSequences reader state)
                 | SOME (c, state) => loop (state, c :: cs)
          in
-            fn state => loop (state, [])
+            fn state =>
+            case reader state of
+               NONE => SOME (implode [], state)
+             | SOME _ =>
+               case Char.scan reader state of
+                  SOME (c, state) => loop (state, [c])
+                | NONE =>
+                  case Char.formatSequencesOpt reader state of
+                     SOME ((), state) => SOME (implode [], state)
+                   | NONE => NONE
          end
 
       val fromString = StringCvt.scanString scan

--- a/regression/string.fromString.ok
+++ b/regression/string.fromString.ok
@@ -1,8 +1,9 @@
-OK  [abc]
-OK  []
-OK  [a]
-OK  [a]
-OK  []
-OK  []
-OK  []
-OK  []
+OK SOME [abc]
+OK NONE
+OK NONE
+OK SOME [a]
+OK SOME [a]
+OK SOME []
+OK SOME []
+OK SOME []
+OK NONE

--- a/regression/string.fromString.sml
+++ b/regression/string.fromString.sml
@@ -1,18 +1,21 @@
+fun toString NONE = "NONE"
+  | toString (SOME s) = concat ["SOME [", s, "]"]
 fun check (s, s') =
-   case String.fromString s of
-      NONE => print "WRONG  NONE\n"
-    | SOME s'' =>
-         if s' = s''
-            then print (concat ["OK  [", s', "]\n"])
-         else print (concat ["WRONG  [", s', "] [", s'', "]\n"])
+    let val s'' = String.fromString s
+    in if s'' = s'
+          then print (concat ["OK ", toString s'', "\n"])
+       else print (concat ["WRONG ", toString s'', " ", toString s', "\n"])
+    end
 
 val _ =
    List.app check
-   [("abc\"def", "abc"),
-     ("\\q", ""),
-     ("a\^D", "a"),
-     ("a\\ \\\\q", "a"),
-     ("\\ \\", ""),
-     ("", ""),
-     ("\\ \\\^D", ""),
-     ("\\ a", "")]
+   [("abc\"def", SOME "abc"),
+    ("\n", NONE),
+    (* from SML Basis manual example *)
+    ("\\q", NONE),
+    ("a\^D", SOME "a"),
+    ("a\\ \\\\q", SOME "a"),
+    ("\\ \\", SOME ""),
+    ("", SOME ""),
+    ("\\ \\\^D", SOME ""),
+    ("\\ a", NONE)]

--- a/regression/string.sml
+++ b/regression/string.sml
@@ -241,8 +241,8 @@ val test19 =
                        andalso fromString arg = SOME res)
     end;
 
-val test20 = 
-    tst' "test20" (fn _ => List.all (fn arg => isSome (fromString arg))
+val test20 =
+    tst' "test20" (fn _ => List.all (fn arg => not (isSome (fromString arg)))
            ["\\",
             "\\c",
             "\\F",
@@ -260,8 +260,7 @@ val test20 =
             "\\^a",
             "\\^z",
             "\\   a",
-            "\\   a\\B",
-            "\\   \\"]);
+            "\\   a\\B"]);
 
 
 (* Test cases for C string escape functions *)


### PR DESCRIPTION
In [basis](http://sml-family.org/Basis/string.html#SIG:STRING.scan:VAL) description, `String.scan` retuns `NONE` if first character is non-printable.
But, `String.scan` in MLton returns `SOME ([], restStream)` now.

This PR is adding checking whether return value is nil or not.

## Example Code

```sml
val () =
    let
      (* scan starting '\n' that is not printable character *)
      val result = String.scan Substring.getc (Substring.full "\n")
    in
      case result of
          NONE => print "NONE\n"
        | SOME (str, _) => print ("SOME:" ^ str ^ "\n")
    end
```

## Expected

```
NONE
```

Actual

```
SOME:
```
