### PR TITLE
Fix bug in running `blockFn`s for `CML.sync`

### DIFF
--- a/doc/guide/src/ConcurrentMLImplementation.adoc
+++ b/doc/guide/src/ConcurrentMLImplementation.adoc
@@ -119,26 +119,30 @@ datatype 'a status =
 type 'a base = unit -> 'a status
 
 fun ext ([], blockFns): 'a =
-     S.atomicSwitch
-     (fn (t: 'a S.thread) =>
-      let
-         val (transId, cleanUp) = TransID.mkFlg ()
-         fun log blockFns: S.rdy_thread =
-            case blockFns of
-               [] => S.next ()
-             | blockFn::blockFns =>
-                  (S.prep o S.new)
-                  (fn _ => fn () =>
-                   let
-                      val () = S.atomicBegin ()
-                      val x = blockFn {transId = transId,
-                                       cleanUp = cleanUp,
-                                       next = fn () => log blockFns}
-                   in S.switch(fn _ => S.prepVal (t, x))
-                   end)
-      in
-         log blockFns
-      end)
+   S.atomicSwitch
+   (fn (t: 'a S.thread) =>
+    let
+       val (transId, cleanUp) = TransID.mkFlg ()
+       fun log blockFns: S.rdy_thread =
+          let
+             val () = S.atomicBegin ()
+          in
+             case blockFns of
+                [] => (S.atomicEnd (); S.next ())
+              | blockFn::blockFns =>
+                   (S.prep o S.new)
+                   (fn _ => fn () =>
+                    let
+                       val () = S.atomicBegin ()
+                       val x = blockFn {transId = transId,
+                                        cleanUp = cleanUp,
+                                        next = fn () => log blockFns}
+                    in S.switch(fn _ => S.prepVal (t, x))
+                    end)
+          end
+    in
+       log blockFns
+    end)
 ----
 
 To avoid the nested `switch`-es, I run the `blockFn` in it's own

--- a/lib/cml/core-cml/channel.sml
+++ b/lib/cml/core-cml/channel.sml
@@ -74,7 +74,7 @@ structure Channel : CHANNEL_EXTRA =
       fun send (CHAN {prio, inQ, outQ}, msg) = 
          let
             val () = Assert.assertNonAtomic' "Channel.send"
-            val () = debug' "Chennel.send(1)" (* NonAtomic *)
+            val () = debug' "Channel.send(1)" (* NonAtomic *)
             val () = Assert.assertNonAtomic' "Channel.send(1)"
             val () = S.atomicBegin ()
             val () = debug' "Channel.send(2)" (* Atomic 1 *)
@@ -106,7 +106,7 @@ structure Channel : CHANNEL_EXTRA =
                         val () = debug' "Channel.send(3.2.2)" (* Atomic 1 *)
                         val () = Assert.assertAtomic' ("Channel.send(3.2.2)", SOME 1)
                         val () = S.atomicReadyAndSwitch (fn () => S.prepVal (rt, msg))
-                        val () = debug' "Chanell.send(3.2.3)" (* NonAtomic *)
+                        val () = debug' "Channel.send(3.2.3)" (* NonAtomic *)
                         val () = Assert.assertNonAtomic' "Channel.send(3.2.2)"
                      in
                         ()

--- a/lib/cml/core-cml/event.sml
+++ b/lib/cml/core-cml/event.sml
@@ -368,16 +368,16 @@ structure Event : EVENT_EXTRA =
                                val (transId, cleanUp) = TransID.mkFlg ()
                                fun log blockFns : S.rdy_thread =
                                   let
-                                     val () = debug' "syncOnBEvts(2).ext([]).log" (* Atomic 1 *)        
+                                     val () = debug' "syncOnBEvts(2).ext([]).log" (* Atomic 1 *)
                                      val () = Assert.assertAtomic' ("Event.syncOnBEvts(2).ext([]).log", SOME 1)
+                                     val () = S.atomicBegin ()
                                   in
                                      case blockFns of
-                                        [] => S.next ()
+                                        [] => (S.atomicEnd (); S.next ())
                                       | blockFn::blockFns =>
                                            (S.prep o S.new)
                                            (fn _ => fn () =>
                                             let 
-                                               val () = S.atomicBegin ()
                                                val x = blockFn {transId = transId,
                                                                 cleanUp = cleanUp,
                                                                 next = fn () => log blockFns}
@@ -547,14 +547,14 @@ structure Event : EVENT_EXTRA =
                                   let
                                      val () = debug' "syncOnGrp(2).ext([]).log" (* Atomic 1 *)  
                                      val () = Assert.assertAtomic' ("Event.syncOnGrp(2).ext([]).log", SOME 1)
+                                     val () = S.atomicBegin ()
                                   in
                                      case blockFns of
-                                        [] => S.next ()
+                                        [] => (S.atomicEnd (); S.next ())
                                       | (blockFn,ackFlg)::blockFns =>
                                            (S.prep o S.new)
                                            (fn _ => fn () =>
                                             let 
-                                               val () = S.atomicBegin ()
                                                val x = blockFn {transId = transId,
                                                                 cleanUp = cleanUp ackFlg,
                                                                 next = fn () => log blockFns}

--- a/lib/cml/core-cml/run-cml.sml
+++ b/lib/cml/core-cml/run-cml.sml
@@ -74,7 +74,7 @@ structure RunCML : RUN_CML =
       (* Note that SH.pauseHook is only invoked by S.next
        * when there are no threads on the ready queue;
        * Furthermore, note that alrmHandler always
-       * enqueues the preepted thread (via S.preempt).
+       * enqueues the preempted thread (via S.preempt).
        * Hence, the ready queue is never empty
        * at the S.next in alrmHandler.  Therefore,
        * pauseHook is never run within alrmHandler.

--- a/lib/cml/core-cml/run-cml.sml
+++ b/lib/cml/core-cml/run-cml.sml
@@ -115,7 +115,7 @@ structure RunCML : RUN_CML =
                 let
                    val () = R.isRunning := true 
                    val () = reset true
-                   val () = SH.shutdownHook := S.prepend (thrd, fn arg => (S.atomicBegin (); arg))
+                   val () = SH.shutdownHook := S.prepend (thrd, fn arg => (S.atomicBegin (); debug' "shutdownHook"; arg))
                    val () = SH.pauseHook := pauseHook
                    val () = installAlrmHandler alrmHandler
                    val () = ignore (Thread.spawn initialProc)

--- a/lib/cml/core-cml/scheduler.sml
+++ b/lib/cml/core-cml/scheduler.sml
@@ -105,6 +105,7 @@ structure Scheduler : SCHEDULER =
       fun next () =
          let
             val () = Assert.assertAtomic' ("Scheduler.next", NONE)
+            val () = debug' "Scheduler.next" (* Atomic 1 *)
             val thrd =
                case deque1 () of
                   NONE => !SH.pauseHook ()
@@ -122,6 +123,7 @@ structure Scheduler : SCHEDULER =
       local
          fun atomicSwitchAux msg f = 
             (Assert.assertAtomic (fn () => "Scheduler." ^ msg, NONE)
+             ; debug (fn () => "Scheduler." ^ msg)
              ; T.atomicSwitch (fn t => 
                                let
                                   val tid = getCurThreadId ()


### PR DESCRIPTION
When no base event in a CML synchronization is enabled, then all base events must be blocked.  It is important that all of the `blockFn`s are executed atomically (along with the prior work of synchronization), but the previous implementation briefly left the critical section as it switched from the thread that executed one `blockFn` to the next.  This would allow the timer interrupt to switch to another CML thread, without executing all of the `blockFn`s; the switched-to thread could initiate a synchronization that doesn't properly see the effect of the switched-from thread's `blockFn`s.

As a concrete example, consider a receiver thread that performs `CML.select (List.map CML.recvEvt chs)`; that is, it synchronizes on the choice of receiving from any channel in a list of channels.  Assuming that there is no pending sender, the receiver thread will execute `blockFn`s that places the receiver thread on each of the channels.  However, if the timer interrupt arrives during the execution of the `blockFn`s, then the program can switch to another thread before the receiver thread is properly placed on each of the channels.  Now, suppose that the switched-to thread performs `CML.send ch` for some `ch` in `chs` beyond the point where the `blockFn`s were successfully executed; that is, it synchronizes on sending to one of the channels on which the receiver thread has not yet been placed.  Finding no pending receiver, the sender thread executes a `blockFn` that places the sender thread on the channel.  Control then switches back to the receiver thread, which continues executing the `blockFn`s, placing it on the remaining channels, including the channel that has the blocked sender.  At this point, the program has violated the invariant that a channel never has both pending senders and pending receivers and, if there are no other ready threads in the system, will terminate with an apparent deadlock.

The fix is to simply perform an extra `S.atomicBegin()` immediately before switching to the temporary thread that will execute the `blockFn`; see the `ConcurrentMLImplementation` page for details about why the `blockFn` is executed by a temporary thread.  This ensures that all of the `blockFn`s are executed in the same critical section as the prior work of synchronization, without the possibility of switching to another thread before all `blockFn`s are executed.

Closes MLton/mlton#381.