### PR TITLE
Fix top-level `Overflow` in SML/NJ Library

### DIFF
--- a/lib/mlrisc-lib/MLRISC.patch
+++ b/lib/mlrisc-lib/MLRISC.patch
@@ -10,7 +10,7 @@ index 24d393f..6e58ea0 100755
  #
 diff --git a/README.mlton b/README.mlton
 new file mode 100644
-index 0000000..8d31e04
+index 0000000..510e25d
 --- /dev/null
 +++ b/README.mlton
 @@ -0,0 +1,8 @@
@@ -20,7 +20,7 @@ index 0000000..8d31e04
 +* eliminate sequential `withtype` expansions: Most could be rewritten as a sequence of type definitions and datatype definitions.
 +* eliminate higher-order functors: Every higher-order functor definition and application could be uncurried in the obvious way.
 +* eliminate `where <str> = <str>`: Quite painful to expand out all the flexible types in the respective structures.  Furthermore, many of the implied type equalities aren't needed, but it's too hard to pick out the right ones.
-+* `library/array-noneq.sml` (added, not exported): Implements `signature ARRAY_NONEQ`, similar to `signature ARRAY` from the Basis Library, but replacing the latter's `eqtype 'a array = 'a array` and `type 'a vector = 'a Vector.vector` with `type 'a array` and `type 'a vector`.  Thus, array-like containers may match `ARRAY_NONEQ`, whereas only the pervasive `'a array` container may math `ARRAY`.  (SML/NJ's implementation of `signature ARRAY` omits the type realizations.)
++* `library/array-noneq.sml` (added, not exported): Implements `signature ARRAY_NONEQ`, similar to `signature ARRAY` from the Basis Library, but replacing the latter's `eqtype 'a array = 'a array` and `type 'a vector = 'a Vector.vector` with `type 'a array` and `type 'a vector`.  Thus, array-like containers may match `ARRAY_NONEQ`, whereas only the pervasive `'a array` container may match `ARRAY`.  (SML/NJ's implementation of `signature ARRAY` omits the type realizations.)
 +* `library/dynamic-array.sml` and `library/hash-array.sml` (modifed): Replace `include ARRAY` with `include ARRAY_NONEQ`; see above.
 diff --git a/Tools/nowhere/build.sh b/Tools/nowhere/build
 similarity index 91%

--- a/lib/smlnj-lib/smlnj-lib.patch
+++ b/lib/smlnj-lib/smlnj-lib.patch
@@ -3096,10 +3096,10 @@ index 0000000..0694ef1
 +end
 diff --git a/README.mlton b/README.mlton
 new file mode 100644
-index 0000000..a2025b8
+index 0000000..4bd5fed
 --- /dev/null
 +++ b/README.mlton
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,16 @@
 +The following changes were made to the SML/NJ Library, in addition to
 +deriving the `.mlb` files from the `.cm` files:
 +
@@ -3110,6 +3110,7 @@ index 0000000..a2025b8
 +* `Util/base64.sml` (modified): Rewrote use of `Unsafe.CharVector.create` and `Unsafe.CharVector.update`; MLton assumes that vectors are immutable.
 +* `Util/engine.mlton.sml` (added, not exported): Implements `structure Engine`, providing time-limited, resumable computations using <:MLtonThread:>, <:MLtonSignal:>, and <:MLtonItimer:>.
 +* `Util/graph-scc-fn.sml` (modified): Rewrote use of `where` structure specification.
++* `Util/hash-table-rep.sml` (modified): The computation of the `maxSize` computes succesive powers of two less than or equal to `Array.maxLen`, which overflows under MLton.  Add a `handle Overflow => i` to properly find the correct maximum size.
 +* `Util/redblack-map-fn.sml` (modified): Rewrote use of `where` structure specification.
 +* `Util/redblack-set-fn.sml` (modified): Rewrote use of `where` structure specification.
 +* `Util/time-limit.mlb` (added): Exports `structure TimeLimit`, which is _not_ exported by `smlnj-lib.mlb`.  Since MLton is very conservative in the presence of threads and signals, program performance may be adversely affected by unnecessarily including `structure TimeLimit`.
@@ -4509,6 +4510,19 @@ index da4c441..0e5e4eb 100644
    struct
      structure Nd = Nd
  
+diff --git a/Util/hash-table-rep.sml b/Util/hash-table-rep.sml
+index 781a7fa..6b5560d 100644
+--- a/Util/hash-table-rep.sml
++++ b/Util/hash-table-rep.sml
+@@ -75,7 +75,7 @@ structure HashTableRep : sig
+ 		  val i' = i+i
+ 		  in
+ 		    if i' < Array.maxLen then f i' else i
+-		  end
++		  end handle Overflow => i
+ 	  in
+ 	    f 0x10000
+ 	  end
 diff --git a/Util/redblack-map-fn.sml b/Util/redblack-map-fn.sml
 index 94ab963..cdedaaa 100644
 --- a/Util/redblack-map-fn.sml


### PR DESCRIPTION
The SML/NJ Library is now used to compile mllex