### PR TITLE
Fix bug in `RssaShrink`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,17 @@
 = CHANGELOG
 
+== Version YYYYMMDD
+
+Here are the changes from version 20200722 to version YYYYMMDD.
+
+=== Summary
+
+=== Details
+
+* 2020-07-30
+  ** Fix bug in jump-chaining optimization of `RssaShrink` that would
+  result in an unbound variable and an internal compiler error.
+
 == Version 20200722
 
 Here are the changes from version 20180206 to version 20200722.

--- a/doc/guide/src/Bugs20200722.adoc
+++ b/doc/guide/src/Bugs20200722.adoc
@@ -3,3 +3,11 @@ Bugs20200722
 
 Here are the known bugs in <:Release20200722:MLton 20200722>, listed
 in reverse chronological order of date reported.
+
+* <!Anchor(bug01)>
+Bug in `RssaShrink` that could fail with a `no RssaShrink.replaceVar property`
+internal compiler error.
++
+Thanks to Steve Sims and bitmappergit for the bug reports.
++
+Fixed by commit <!ViewGitCommit(mlton,d4dbe316f)>.

--- a/mlton/backend/rssa-tree.fun
+++ b/mlton/backend/rssa-tree.fun
@@ -486,6 +486,11 @@ structure Kind =
        | Handler
        | Jump
 
+      fun isJump k =
+         case k of
+            Jump => true
+          | _ => false
+
       fun layout k =
          let
             open Layout

--- a/mlton/backend/rssa-tree.sig
+++ b/mlton/backend/rssa-tree.sig
@@ -143,6 +143,7 @@ signature RSSA_TREE =
 
             datatype frameStyle = None | OffsetsAndSize | SizeOnly
             val frameStyle: t -> frameStyle
+            val isJump: t -> bool
             val layout: t -> Layout.t
          end
 


### PR DESCRIPTION
Previously, `RssaShrink` could fail with a `no RssaShrink.replaceVar property` internal compiler error.  Consider the following:

```
  L_K (x) Cont =
    L_1 (x)
  L_1 (y) Jump =
    loop (y)
  loop (z) Jump =
    ...
  L_2 (...) Jump =
    ...
    a = y
    ...
```

L_1 was identified as a candidate for jump chaining and the `goto L_1 (x)` in L_K was replaced by `goto loop (x)`:

```
  L_K (x) Cont =
    loop (x)
  loop (z) Jump =
    ...
  L_2 (...) Jump =
    ...
    a = y
    ...
```

This results in an unbound variable `y`.  (In practice, it led to a `Fail: y has no RssaShrink.replaceVar property`, because no binding occurrence of `y` was encountered before the use during the transformation.)

Now, an occurrence count is calculated for each variable and a block is a candidate for jump chaining only if all of its arguments have an occurrence count of 1 (corresponding to their uses in the block's goto transfer).