### PR TITLE
Fix for x86-darwin

### DIFF
--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1357,7 +1357,7 @@ structure PositionIndependentStyle =
 
       fun fromString s =
          case s of
-            "static" => SOME NPI
+            "npi" => SOME NPI
           | "pic" => SOME PIC
           | "pie" => SOME PIE
           | _ => NONE


### PR DESCRIPTION
Avoid defaulting to native codegen on x86-darwin

The C compiler on x86-darwin defaults to producing position independent code, but the x86 codegen does not properly support x86-darwin PIC.

x86-darwin barely exists as a platform anymore.  It may be possible to get the old behavior by compiling with `-codegen 86 -pi-style npi`, but this is untested.