### PR TITLE
Don't `#define MREMAP_MAYMOVE` in `runtime/platform/linux.c`

### DIFF
--- a/runtime/platform/linux.c
+++ b/runtime/platform/linux.c
@@ -1,3 +1,4 @@
+// For `mremap` and `MREMAP_MAYMOVE`
 #define _GNU_SOURCE
 
 #include "platform.h"
@@ -71,15 +72,6 @@ void GC_setSigProfHandler (struct sigaction *sa) {
         sa->sa_flags = SA_ONSTACK | SA_RESTART | SA_SIGINFO;
         sa->sa_sigaction = (void (*)(int, siginfo_t*, void*))catcher;
 }
-
-/* We need the value of MREMAP_MAYMOVE, which should come from sys/mman.h, but
- * isn't there.  It is in linux/mman.h, but we can't #include that here, because
- * kernel headers don't mix with system headers.  We could create a separate
- * file, include the kernel headers there, and define a global.  But there
- * sometimes seem to be problems including kernel headers, so the easiest thing
- * to do is just define MREMAP_MAYMOVE.
- */
-#define MREMAP_MAYMOVE 1
 
 void *GC_mremap (void *start, size_t oldLength, size_t newLength) {
         return mremap (start, oldLength, newLength, MREMAP_MAYMOVE);


### PR DESCRIPTION
Due to the `#define _GNU_SOURCE`, the constant is defined by
`sys/mman.h`.