### PR TITLE
Mingw fixes

### DIFF
--- a/lib/mlnlffi-lib/Makefile
+++ b/lib/mlnlffi-lib/Makefile
@@ -8,8 +8,16 @@ include $(ROOT)/Makefile.config
 .DELETE_ON_ERROR:
 all: memory/platform/rtld-flags.$(TARGET_OS).sml
 
-CFLAGS := -Wall
+ifeq (mingw, $(TARGET_OS))
+  CFLAGS := -Wall -I.
+else
+  CFLAGS := -Wall
+endif
+
 memory/platform/rtld-flags.$(TARGET_OS).sml: gen-rtld-flags.c
+ifeq (mingw, $(TARGET_OS))
+	$(CP) "$(ROOT)/package/msys2/dlfcn.h" .
+endif
 	$(CC) $(CFLAGS) -o gen-rtld-flags gen-rtld-flags.c
 	./gen-rtld-flags > memory/platform/rtld-flags.$(TARGET_OS).sml
 	$(RM) gen-rtld-flags$(EXE)

--- a/lib/mlnlffi-lib/Makefile
+++ b/lib/mlnlffi-lib/Makefile
@@ -9,15 +9,12 @@ include $(ROOT)/Makefile.config
 all: memory/platform/rtld-flags.$(TARGET_OS).sml
 
 ifeq (mingw, $(TARGET_OS))
-  CFLAGS := -Wall -I.
+  CFLAGS := -Wall -I$(ROOT)/package/msys2
 else
   CFLAGS := -Wall
 endif
 
 memory/platform/rtld-flags.$(TARGET_OS).sml: gen-rtld-flags.c
-ifeq (mingw, $(TARGET_OS))
-	$(CP) "$(ROOT)/package/msys2/dlfcn.h" .
-endif
 	$(CC) $(CFLAGS) -o gen-rtld-flags gen-rtld-flags.c
 	./gen-rtld-flags > memory/platform/rtld-flags.$(TARGET_OS).sml
 	$(RM) gen-rtld-flags$(EXE)

--- a/mlton/codegen/amd64-codegen/amd64-generate-transfers.fun
+++ b/mlton/codegen/amd64-codegen/amd64-generate-transfers.fun
@@ -1516,15 +1516,16 @@ struct
                                  
                                  (* how to access imported functions: *)
                                  (* Windows rewrites the symbol __imp__name *)
-                                 val coff = fn () => Label.fromString ("_imp__" ^ name)
+                                 val coff_cygwin = fn () => Label.fromString ("_imp__" ^ name)
+                                 val coff_mingw = fn () => Label.fromString ("__imp_" ^ name)
                                  val macho = fn () => label () (* @PLT is implicit *)
                                  val elf = fn () => Label.fromString (name ^ "@PLT")
                                  
                                  val importLabel = fn () =>
                                     case !Control.Target.os of
-                                       Cygwin => coff ()
+                                       Cygwin => coff_cygwin ()
                                      | Darwin => macho ()
-                                     | MinGW => coff ()
+                                     | MinGW => coff_mingw ()
                                      |  _ => elf ()
                                  
                                  val direct = fn () =>

--- a/package/msys2/dlfcn.h
+++ b/package/msys2/dlfcn.h
@@ -1,0 +1,45 @@
+/*
+ * dlfcn-win32
+ * Copyright (c) 2007 Ramiro Polla
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef DLFCN_H
+#define DLFCN_H
+
+/* POSIX says these are implementation-defined.
+ * To simplify use with Windows API, we treat them the same way.
+ */
+
+#define RTLD_LAZY   0
+#define RTLD_NOW    0
+
+#define RTLD_GLOBAL (1 << 1)
+#define RTLD_LOCAL  (1 << 2)
+
+/* These two were added in The Open Group Base Specifications Issue 6.
+ * Note: All other RTLD_* flags in any dlfcn.h are not standard compliant.
+ */
+
+#define RTLD_DEFAULT    0
+#define RTLD_NEXT       0
+
+void *dlopen ( const char *file, int mode );
+int   dlclose( void *handle );
+void *dlsym  ( void *handle, const char *name );
+char *dlerror( void );
+
+#endif /* DLFCN_H */


### PR DESCRIPTION
Two minor changes to make mlton compile on mingw.   To clarify, the "mingw" environment we target consists of mingw64 (a fork of the original mingw project) and msys2 (a fork of the original msys project).  mingw64 offers gcc for windows and many other build tools.  msys2 offers a unix-like shell on windows (using mingw64) and a package manager.
. in codegen/amd64-codegen/amd64-generate-transfers.fun, use "__imp_" instead of "_imp__" to access imported functions.  Left cygwin unchanged to use "_imp__".
. when building mlnlffigen, the dlfcn.h header file is missing in the target mingw environment.  We therefore created a package/msys2 directory to contain the header file and modified mlton/lib/mlnlffi-lib/Makefile to add this folder to the include path when compiling on mingw.  