### PR TITLE
Fix bug in handling of weak objects during mark-compact GC

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,16 @@
 = CHANGELOG
 
+== Version YYYYMMDD
+
+Here are the changes from version 20200817 to version YYYYMMDD.
+
+=== Summary
+
+=== Details
+
+* 2020-09-20
+  ** Fix bug in handling of weak objects during mark-compact GC.
+
 == Version 20200817
 
 Here are the changes from version 20200722 to version 20200817

--- a/runtime/gc/dfs-mark.c
+++ b/runtime/gc/dfs-mark.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012,2016,2019 Matthew Fluet.
+/* Copyright (C) 2012,2016,2019-2020 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -174,7 +174,8 @@ markNextInNormal:
       if (DEBUG_WEAK)
         fprintf (stderr, "marking weak "FMTPTR" ",
                  (uintptr_t)w);
-      if (isObjptrInHeap (s, w->objptr)) {
+      if (isObjptr (w->objptr) and
+          isObjptrInHeap (s, w->objptr)) {
         if (DEBUG_WEAK)
           fprintf (stderr, "linking\n");
         w->link = s->weaks;


### PR DESCRIPTION
During a DFS marking, a weak object should only be linked if its objptr field is a valid object pointer (and not `BOGUS_OBJPTR`).

This bug was introduced by commit ec2a3afa2, which changed `is{Objptr,Pointer}` predicates to `is{Objptr,Pointer}InHeap` predicates.  This was motivated by the introduction of static heaps, because objects in the static heaps are not traced; in particular, objects in the immutable static heap are in read-only memory, and therefore cannot be marked and unmarked.

However, the semantics of these predicates are subtly different.  The `is{Objptr,Pointer}InHeap` return `TRUE` when the argument is a non-pointer (i.e., when `is{Objptr,Pointer}` returns `FALSE`).

Commit 2d46cc122 fixed many of the `isPointerInHeap(p)` predicates to `isPointer(p) and isPointerInHeap(p)`, but missed the `isObjptrInHeap` that guards the linking of a weak object.