### PR TITLE
Fix bug in SimplifyTypes SSA optimization pass

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,11 @@
 = CHANGELOG
 
+== Version YYYYMMDD
+
+* 2020-10-22
+  ** Fix bug in `SimplifyTypes` SSA optimization pass.  Thanks
+  to Martin Elsman for the bug report.
+
 == Version 20201002
 
 Here are the changes from version 20200817 to version 20201002.
@@ -12,7 +18,8 @@ Here are the changes from version 20200817 to version 20201002.
 === Details
 
 * 2020-09-20
-  ** Fix bug in handling of weak objects during mark-compact GC.
+  ** Fix bug in handling of weak objects during mark-compact GC.  Thanks to
+  Bernard Berthomieu for the bug report.
 
 == Version 20200817
 
@@ -123,10 +130,10 @@ Here are the changes from version 20180206 to version 20200722.
   non-printable.
 
 * 2020-02-14
-  ** Fixed bug in `SimplifyTypes` SSA optimization pass.
+  ** Fix bug in `SimplifyTypes` SSA optimization pass.
 
 * 2020-01-22
-  ** Added expert `-pi-style {default|npi|pic|pie}` and
+  ** Add expert `-pi-style {default|npi|pic|pie}` and
   `-native-pic {false|true}` options, which can be used to override a
   target-determined default.  See
   https://github.com/MLton/mlton/pull/365 for details.

--- a/mlton/Makefile
+++ b/mlton/Makefile
@@ -75,7 +75,7 @@ $(MLTON_OUTPUT): $(SOURCES)
 		-target $(TARGET) -output $(MLTON_OUTPUT)			\
 		$(MLTON_MLB)
 
-ifeq ($(shell (cat control/version_sml.src; echo $(MLTON_NAME) $(MLTON_VERSION); if [ -e control/version.sml ]; then cat control/version.sml; fi) | $(SHA1DGST)),$(shell if [ -e control/version_sml.chk ]; then cat control/version_sml.chk; fi))
+ifeq ($(shell (cat control/version_sml.src; echo '$(MLTON_NAME)' '$(MLTON_VERSION)'; if [ -e control/version.sml ]; then cat control/version.sml; fi) | $(SHA1DGST)),$(shell if [ -e control/version_sml.chk ]; then cat control/version_sml.chk; fi))
 control/version.sml: control/version_sml.src
 	touch control/version.sml
 else
@@ -86,7 +86,7 @@ control/version.sml: control/version_sml.src
 		-e "s/MLTON_VERSION/$(MLTON_VERSION)/" \
 		< control/version_sml.src \
 		> control/version.sml
-	(cat control/version_sml.src; echo $(MLTON_NAME) $(MLTON_VERSION); cat control/version.sml) | $(SHA1DGST) > control/version_sml.chk
+	(cat control/version_sml.src; echo '$(MLTON_NAME)' '$(MLTON_VERSION)'; cat control/version.sml) | $(SHA1DGST) > control/version_sml.chk
 endif
 
 front-end/%.lex.sml: front-end/%.lex

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -346,7 +346,11 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                              Cardinality.layout (tyconCardinality tycon)]);
                Vector.foreach
                (cons, fn {con, ...} =>
-                (display (seq [str "cardinality of ",
+                (display (seq [str "rep of ",
+                               Con.layout con,
+                               str " = ",
+                               ConRep.layout (conRep con)]);
+                 display (seq [str "cardinality of ",
                                Con.layout con,
                                str " = ",
                                Cardinality.layout (conCardinality con)])))))
@@ -355,10 +359,10 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
          (setTyconNumCons (tycon, 1)
           ; setTyconReplacement (tycon, SOME (Type.tuple args))
           ; setConRep (con, ConRep.Transparent))
-      (* "unary" is datatypes with one constructor whose rhs contains an
-       * array (or vector) type.
-       * For datatypes with one variant not containing an array type, eliminate
-       * the datatype.
+      (* "unary" are datatypes with one constructor
+       * whose rhs contains an array (or vector) type.
+       * For datatypes with one variant not containing an array type,
+       * eliminate the datatype.
        *)
       fun containsArrayOrVector (ty: Type.t): bool =
          let
@@ -436,6 +440,30 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                   :: accum
           else (transparent (tycon, con, args)
                 ; accum))
+      (* diagnostic *)
+      val _ =
+         Control.diagnostics
+         (fn display =>
+          let
+             open Layout
+          in
+             Vector.foreach
+             (origDatatypes, fn Datatype.T {tycon, cons} =>
+              (display (seq [str "num cons of ",
+                             Tycon.layout tycon,
+                             str " = ",
+                             Int.layout (tyconNumCons tycon)]);
+               display (seq [str "replacement of ",
+                             Tycon.layout tycon,
+                             str " = ",
+                             Option.layout Type.layout (tyconReplacement tycon)]);
+               Vector.foreach
+               (cons, fn {con, ...} =>
+                display (seq [str "rep of ",
+                              Con.layout con,
+                              str " = ",
+                              ConRep.layout (conRep con)]))))
+          end)
 
       fun makeSimplifyTypeFns simplifyType =
          let

--- a/mlton/ssa/simplify-types.fun
+++ b/mlton/ssa/simplify-types.fun
@@ -439,7 +439,15 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
 
       fun makeSimplifyTypeFns simplifyType =
          let
+            val simplifyType =
+               Trace.trace
+               ("SimplifyTypes.simplifyType", Type.layout, Type.layout)
+               simplifyType
             fun simplifyTypes ts = Vector.map (ts, simplifyType)
+            val simplifyTypes =
+               Trace.trace ("SimplifyTypes.simplifyTypes",
+                            Vector.layout Type.layout, Vector.layout Type.layout)
+               simplifyTypes
             fun simplifyUsefulTypesOpt ts =
                Exn.withEscape
                (fn escape =>
@@ -454,9 +462,20 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                              then NONE
                           else SOME t
                        end)))
+            val simplifyUsefulTypesOpt =
+               Trace.trace ("SimplifyTypes.simplifyUsefulTypesOpt",
+                            Vector.layout Type.layout,
+                            Option.layout (Vector.layout Type.layout))
+               simplifyUsefulTypesOpt
             val simplifyUsefulTypes = valOf o simplifyUsefulTypesOpt
+            val simplifyUsefulTypes =
+               Trace.trace ("SimplifyTypes.simplifyUsefulTypes",
+                            Vector.layout Type.layout,
+                            Vector.layout Type.layout)
+               simplifyUsefulTypes
          in
-            {simplifyTypes = simplifyTypes,
+            {simplifyType = simplifyType,
+             simplifyTypes = simplifyTypes,
              simplifyUsefulTypes = simplifyUsefulTypes,
              simplifyUsefulTypesOpt = simplifyUsefulTypesOpt}
          end
@@ -466,7 +485,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
           Property.initRec
           (fn (t, simplifyType) =>
            let
-              val {simplifyUsefulTypesOpt, ...} =
+              val {simplifyType, simplifyUsefulTypesOpt, ...} =
                  makeSimplifyTypeFns simplifyType
               fun doitPtr (mk, t) =
                  let
@@ -499,10 +518,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                | Weak t => doitPtr (weak, t)
                | _ => t
            end))
-      val simplifyType =
-         Trace.trace ("SimplifyTypes.simplifyType", Type.layout, Type.layout)
-         simplifyType
-      val {simplifyTypes, simplifyUsefulTypesOpt, simplifyUsefulTypes, ...} =
+      val {simplifyType, simplifyTypes, simplifyUsefulTypesOpt, simplifyUsefulTypes, ...} =
          makeSimplifyTypeFns simplifyType
       val typeIsUseful = not o Type.isUnit o simplifyType
       (* Simplify constructor argument types. *)


### PR DESCRIPTION
19b07c03f attempted to fix a bug in `SimplifyTypes` related to `MLton_bogus` primitives added by `Useless`.  The essence of the bug is that is not appropriate to conclude that a tycon has cardinality `Zero` (e.g., if it is simplified to the point where it has no constructors) when a "value" of the tycon is created by `MLton_bogus`.

19b07c03f simply forced any tycon used with `MLton_bogus` to have cardinality `Many`.  However, such a tycon might have all constructors eliminated and will be marked to be replaced by the `void` type.  In turn, other types that use the tycon will be retained (with cardinality `Many`), but an `Option` exception would be raised by `simplifyUsefulTypes`, which assumes that all components are really useful (and non-`void`).

This PR adjusts things to force any tycon used with `MLton_bogus` to have cardinality at least `One`; if such a tycon has all constructors eliminated, then it will be marked to be replaced by the `unit` type.

Thanks to Martin Elsman for the bug report.

Closes #419.
