### PR TITLE
Properly detect default position-independent style in `Makefile.binary`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,12 +3,14 @@
 == Version YYYYMMDD
 
 * 2021-01-15
+  ** Fix bug in `Makefile.binary` detecting default position-independent style.
+  Thanks to Greg Werbin for the but report.
   ** Preliminary support for `arm64-darwin` ("Apple Silicon").  Thanks to Chris
   Cannam for the patches.
 
 * 2020-10-22
-  ** Fix bug in `SimplifyTypes` SSA optimization pass.  Thanks
-  to Martin Elsman for the bug report.
+  ** Fix bug in `SimplifyTypes` SSA optimization pass.  Thanks to Martin Elsman
+  for the bug report.
 
 == Version 20201002
 

--- a/Makefile.binary
+++ b/Makefile.binary
@@ -79,12 +79,12 @@ update:
 		-e "s;^default::pic=.*;default::pic=$(subst __pic__,0,$(shell echo "__pic__" | $(CC) -P -E -));" \
 		< "$(SLIB)/targets/self/constants.bak" > "$(SLIB)/targets/self/constants"
 	$(RM) "$(SLIB)/targets/self/constants.bak"
-	if [ $$(echo "__pie__" | $(CC) -P -E -) -gt 0 ]; then \
-		pi="-pie";
-	elif if [ $$(echo "__pic__" | $(CC) -P -E -) -gt 0 ]; then \
-		pi="-pic";
+	if [ $$(echo "__pie__" | $(CC) -P -E -) != "__pie__" ]; then \
+		pi="-pie"; \
+	elif if [ $$(echo "__pic__" | $(CC) -P -E -) != "__pic__" ]; then \
+		pi="-pic"; \
 	else \
-		pi="-npi";
+		pi="-npi"; \
 	fi ; \
 	for lib in mlton gdtoa; do \
 		for md in "" -dbg; do \


### PR DESCRIPTION
Closes MLton/mlton#422