### PR TITLE
fix option '-pi-style pie'

### DIFF
--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1396,7 +1396,7 @@ structure PositionIndependentStyle =
             NONE => []
           | SOME NPI => ["-fno-pic", "-fno-pie", "-no-pie"]
           | SOME PIC => ["-fno-pie", "-no-pie"]
-          | SOME PIE => ["-fPIE -pie"]
+          | SOME PIE => ["-fPIE", "-pie"]
    end
 
 val positionIndependentStyle = control {name = "position independent style",


### PR DESCRIPTION
feed the flags to gcc separately, to fix this error:

`gcc: error: unrecognized command-line option '-fPIE -pie'`