### PR TITLE
Updates to ConstantPropagation

### DIFF
--- a/lib/mlton/basic/list.sig
+++ b/lib/mlton/basic/list.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2017 Matthew Fluet.
+(* Copyright (C) 2009,2017,2021 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -39,6 +39,7 @@ signature LIST =
        * and after it in the same order as in the list.
        *)
 (*      val each: 'a t -> ('a t * 'a * 'a t) t *)
+      val empty: 'a t
       val equals: 'a t * 'b t * ('a * 'b -> bool) -> bool
       val equalsAsSet: 'a t * 'a t * ('a * 'a -> bool) -> bool
       (* Group according to equivalence relation. *)
@@ -150,6 +151,7 @@ signature LIST =
              replace: 'a t * ('a -> 'a option) -> 'a t,
              map: 'a t * ('a -> 'a) -> 'a t,
              layout: 'a t -> Layout.t}
+      val single: 'a -> 'a t
       val snoc: 'a t * 'a -> 'a t
 (*      val splitAtMost: 'a t * int -> ('a t * 'a t) option *)
       val splitAt: 'a t * int -> 'a t * 'a t

--- a/lib/mlton/basic/list.sml
+++ b/lib/mlton/basic/list.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2017 Matthew Fluet.
+(* Copyright (C) 2009,2017,2021 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -120,6 +120,8 @@ fun index (l, f) =
       loop (l, 0)
    end
 
+val empty = []
+
 fun isEmpty l =
    case l of
       [] => true
@@ -193,6 +195,8 @@ in
 end
 
 val cons = op ::
+
+fun single x = cons (x, empty)
 
 val snoc = fn (l, x) => l @ [x]
 

--- a/lib/mlton/basic/parse.sml
+++ b/lib/mlton/basic/parse.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017,2019 Jason Carr, Matthew Fluet.
+(* Copyright (C) 2017,2019,2021 Jason Carr, Matthew Fluet.
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
@@ -445,7 +445,7 @@ fun char c =
                     expected ([name], location)}
    end
 
-fun each ps = List.fold
+fun each ps = List.foldr
    (ps, pure [],
     fn (p, x) => (op ::) <$$> (p, x))
 

--- a/lib/mlton/basic/ref.sig
+++ b/lib/mlton/basic/ref.sig
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2021 Matthew Fluet.
+ * Copyright (C) 1999-2005 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a HPND-style license.
@@ -23,5 +24,6 @@ signature REF =
                                         print: unit -> unit}
       val layout: ('a -> Layout.t) -> 'a t -> Layout.t
       val memoize: 'a option t * (unit -> 'a) -> 'a
+      val new: 'a -> 'a t
       val swap: 'a t * 'a t -> unit
    end

--- a/lib/mlton/basic/ref.sml
+++ b/lib/mlton/basic/ref.sml
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2021 Matthew Fluet.
+ * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
  * MLton is released under a HPND-style license.
@@ -9,6 +10,8 @@ structure Ref: REF =
 struct
 
 type 'a t = 'a ref
+
+val new = ref
 
 val (op !) = (op !)
 

--- a/lib/mlton/lattice/flat-lattice.fun
+++ b/lib/mlton/lattice/flat-lattice.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2021 Matthew Fluet.
+ * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -126,4 +127,358 @@ fun point p =
 
 val point = Trace.trace ("FlatLattice.point", Point.layout, layout) point
 
+end
+
+
+
+functor FlatLatticeRec (S: FLAT_LATTICE_REC_STRUCTS): FLAT_LATTICE_REC =
+struct
+
+open S
+
+structure Handlers =
+   struct
+      datatype t = T of unit -> unit
+      fun run (T hs) = hs ()
+      val empty = T (fn () => ())
+      fun cons (h: unit -> unit, hs) = T (fn () => (h () ; run hs))
+   end
+
+structure Value =
+   struct
+      datatype 'a t =
+         Bottom
+       | Point of 'a Point.t
+       | Top
+
+      local
+         open Layout
+      in
+         fun layout layoutA v =
+            case v of
+               Bottom => str bottom
+             | Point p => Point.layout layoutA p
+             | Top => str top
+      end
+
+      fun coerce {clone = cloneA, coerce = coerceA, equals = equalsA}
+                 {from, to}: 'a t option =
+         let
+            val pointClone = Point.clone {clone = cloneA, equals = equalsA}
+            val pointCoerce = Point.coerce {clone = cloneA, coerce = coerceA, equals = equalsA}
+         in
+            case (from, to) of
+               (_, Top) => NONE
+             | (Top, _) => SOME Top
+             | (Point from, Bottom) =>
+                  let
+                     val to = pointClone from
+                  in
+                     if pointCoerce {from = from, to = to}
+                        then SOME (Point to)
+                        else SOME Top
+                  end
+             | (Point from, Point to) =>
+                  if pointCoerce {from = from, to = to}
+                     then NONE
+                     else SOME Top
+             | (Bottom, _) => NONE
+         end
+
+      fun unify {equals = equalsA, unify = unifyA}
+                (v1, v2): (bool * bool * 'a t) =
+         let
+            val pointUnify = Point.unify {equals = equalsA, unify = unifyA}
+         in
+            case (v1, v2) of
+               (Bottom, Bottom) => (false, false, Bottom)
+             | (Bottom, _) => (true, false, v2)
+             | (_, Bottom) => (false, true, v1)
+             | (Point p1, Point p2) =>
+                  if pointUnify (p1, p2)
+                     then (false, false, Point p1)
+                     else (true, true, Top)
+             | (Top, Top) => (false, false, Top)
+             | (Top, _) => (false, true, Top)
+             | (_, Top) => (true, false, Top)
+         end
+   end
+
+datatype 'a t = T of {handlers: Handlers.t Ref.t,
+                      lessThan: 'a t List.t Ref.t,
+                      value: 'a Value.t Ref.t}
+
+local
+   fun mk' sel (T s) = sel s
+   fun mk sel e = ! (mk' sel e)
+in
+   fun handlersRef e = mk' #handlers e
+   fun handlers e = mk #handlers e
+   (* fun lessThanRef e = mk' #lessThan e *)
+   (* fun lessThan e = mk #lessThan e *)
+   fun valueRef e = mk' #value e
+   fun value e = mk #value e
+end
+
+(*
+fun setValue (e, value) =
+   valueRef e := value
+*)
+
+fun equals (e1, e2) = Ref.equals (valueRef e1, valueRef e2)
+
+fun getPoint e =
+   case value e of
+      Value.Point p => SOME p
+    | _ => NONE
+fun isBottom e =
+   case value e of
+      Value.Bottom => true
+    | _ => false
+fun isPoint e =
+   case value e of
+      Value.Point _ => true
+    | _ => false
+fun isPointEq equalsA (e, p') =
+   case value e of
+      Value.Point p => Point.equals equalsA (p, p')
+    | _ => false
+fun isTop e =
+   case value e of
+      Value.Top  => true
+    | _ => false
+
+fun layout layoutA e =
+   Value.layout layoutA (value e)
+
+fun new value = T {handlers = Ref.new Handlers.empty,
+                   lessThan = Ref.new List.empty,
+                   value = Ref.new value}
+
+fun newBottom () = new Value.Bottom
+fun newPoint p = new (Value.Point p)
+fun newTop () = new Value.Top
+
+(*
+fun setLessThan (e, lessThan) =
+   lessThanRef e := lessThan
+*)
+
+fun setHandlers (e, handlers) =
+   handlersRef e := handlers
+fun addHandler (e, h) =
+   (setHandlers (e, Handlers.cons (h, handlers e))
+    ; h ())
+fun addHandler' (e, h) = addHandler (e, fn () => h (value e))
+
+fun makeTop (T {handlers, lessThan, value}): unit =
+   case !value of
+      Value.Top => ()
+    | _ => (value := Value.Top
+            ; List.foreach (!lessThan, makeTop)
+            ; lessThan := []
+            ; Handlers.run (!handlers)
+            ; handlers := Handlers.empty)
+
+fun 'a lowerBoundPoint {clone = cloneA, coerce = coerceA, equals = equalsA} =
+   (fn {from: 'a Point.t, to = to as T {lessThan, handlers, value}: 'a t} =>
+    let
+       val pointClone = Point.clone {clone = cloneA, equals = equalsA}
+       val pointCoerce = Point.coerce {clone = cloneA, coerce = coerceA, equals = equalsA}
+       val lowerBoundPoint = lowerBoundPoint {clone = cloneA, coerce = coerceA, equals = equalsA}
+    in
+       case !value of
+          Value.Bottom =>
+             let
+                val p = pointClone from
+             in
+                if pointCoerce {from = from, to = p}
+                   then (value := Value.Point p
+                         ; List.foreach (!lessThan, fn e => lowerBoundPoint {from = p, to = e})
+                         ; Handlers.run (!handlers))
+                   else makeTop to
+             end
+        | Value.Point p =>
+             if pointCoerce {from = from, to = p}
+                then ()
+                else makeTop to
+        | Value.Top => ()
+    end)
+
+fun 'a setPoint {clone = cloneA, coerce = coerceA, equals = equalsA} =
+   (fn (T {lessThan, handlers, value}: 'a t, p: 'a Point.t) =>
+    let
+       val lowerBoundPoint = lowerBoundPoint {clone = cloneA, coerce = coerceA, equals = equalsA}
+    in
+       case !value of
+          Value.Bottom =>
+             (value := Value.Point p
+              ; List.foreach (!lessThan, fn e => lowerBoundPoint {from = p, to = e})
+              ; Handlers.run (!handlers))
+        | _ => Error.bug "FlatLatticeRec.setPoint"
+    end)
+
+fun 'a coerce {clone = cloneA, coerce = coerceA, equals = equalsA} =
+   (fn {from = from as T {lessThan, value, ...}: 'a t, to: 'a t} =>
+    if equals (from, to)
+       then ()
+       else let
+               val lowerBoundPoint = lowerBoundPoint {clone = cloneA, coerce = coerceA, equals = equalsA}
+               fun pushLessThan () = List.push (lessThan, to)
+            in
+               case !value of
+                  Value.Bottom => pushLessThan ()
+                | Value.Point from => (pushLessThan (); lowerBoundPoint {from = from, to = to})
+                | Value.Top => makeTop to
+            end)
+
+fun lowerBound {clone = cloneA, coerce = coerceA, equals = equalsA} =
+   (fn (e', v) =>
+    let
+       val lowerBoundPoint = lowerBoundPoint {clone = cloneA, coerce = coerceA, equals = equalsA}
+    in
+       case v of
+          Value.Bottom => ()
+        | Value.Point p => lowerBoundPoint {from = p, to = e'}
+        | Value.Top => makeTop e'
+    end)
+
+fun unify {clone = cloneA, coerce = coerceA, equals = equalsA, unify = unifyA} =
+   (fn (e1 as T {lessThan = lessThan1, ...},
+        e2 as T {lessThan = lessThan2, ...}) =>
+    if equals (e1, e2)
+       then ()
+    else if true
+       then let
+               val pointUnify = Point.unify {equals = equalsA, unify = unifyA}
+               val setPoint = setPoint {clone = cloneA, coerce = coerceA, equals = equalsA}
+               fun pushLessThan () =
+                  (List.push (lessThan1, e2); List.push (lessThan2, e1))
+            in
+               case (value e1, value e2) of
+                  (Value.Top, Value.Top) => ()
+                | (Value.Top, _) => makeTop e2
+                | (_, Value.Top) => makeTop e1
+                | (Value.Point p1, Value.Point p2) =>
+                     if pointUnify (p1, p2)
+                        then pushLessThan ()
+                        else (makeTop e1; makeTop e2)
+                | (Value.Point p1, Value.Bottom) =>
+                     (pushLessThan ()
+                      ; setPoint (e2, p1))
+                | (Value.Bottom, Value.Point p2) =>
+                     (pushLessThan ()
+                      ; setPoint (e1, p2))
+                 | (Value.Bottom, Value.Bottom) =>
+                     pushLessThan ()
+            end
+       else let
+               val coerce = coerce {clone = cloneA, coerce = coerceA, equals = equalsA}
+            in
+               coerce {from = e1, to = e2}
+               ; coerce {from = e2, to = e1}
+            end)
+end
+
+functor FlatLatticePoly (S: FLAT_LATTICE_POLY_STRUCTS) =
+struct
+   local
+      structure L =
+         FlatLatticeRec
+         (struct
+             open S
+             structure Point =
+                struct
+                   open Point
+                   fun coerce {clone = _, coerce = _, equals = equalsA} =
+                      fn {from, to} =>
+                      equals equalsA (from, to)
+                   fun unify {equals = equalsA, unify = _} =
+                      fn (p1, p2) =>
+                      equals equalsA (p1, p2)
+                end
+          end)
+      fun err (f, g) _ =
+         Error.bug (concat ["FlatLatticePoly.", f, ": ", g])
+   in
+      open L
+      structure Point = S.Point
+      val coerce = fn {equals = equalsA} =>
+         coerce {clone = err ("coerce", "clone"),
+                 coerce = err ("coerce", "coerce"),
+                 equals = equalsA}
+      val lowerBound = fn {equals = equalsA} =>
+         lowerBound {clone = err ("lowerBound", "clone"),
+                     coerce = err ("lowerBound", "coerce"),
+                     equals = equalsA}
+      val unify = fn {equals = equalsA} =>
+         unify {clone = err ("unify", "clone"),
+                coerce = err ("unify", "coerce"),
+                equals = equalsA,
+                unify = err ("unify", "unify")}
+   end
+end
+
+functor FlatLatticeParam (S: FLAT_LATTICE_PARAM_STRUCTS) =
+struct
+   local
+      structure L =
+         FlatLatticePoly
+         (struct
+             open S
+             structure Point =
+                struct
+                   open Point
+                   val clone = fn _ => fn p => p
+                   val equals = fn _ => equals
+                end
+          end)
+      fun err (f, g) _ =
+         Error.bug (concat ["FlatLatticeParam.", f, ": ", g])
+   in
+      open L
+      structure Point = S.Point
+      val coerce = fn args =>
+         coerce {equals = err ("coerce", "equals")} args
+      val isPointEq = fn args => isPointEq (err ("isPointEq", "equals")) args
+      val lowerBound = fn args =>
+         lowerBound {equals = err ("lowerBound", "equals")} args
+      val unify = fn args =>
+         unify {equals = err ("unify", "equals")} args
+      val op<= = fn (from, to) => coerce {from = from, to = to}
+      val op== = unify
+   end
+end
+
+functor FlatLatticeMono (S: FLAT_LATTICE_MONO_STRUCTS) =
+struct
+   local
+      structure L =
+         FlatLatticeParam
+         (struct
+             open S
+             structure Point =
+                struct
+                   open Point
+                   type 'a t = t
+                   val layout = fn _ => layout
+                end
+          end)
+      structure Void =
+         struct
+            datatype t = Void of t
+            val layout: string -> t -> Layout.t = fn f => fn _ =>
+               Error.bug (concat ["FlatLatticeMono.", f, ": Void.layout"])
+         end
+   in
+      open L
+      type t = Void.t t
+      structure Point = S.Point
+      structure Value =
+         struct
+            open Value
+            val layout = layout (Void.layout "Value.layout")
+         end
+      val layout = layout (Void.layout "layout")
+   end
 end

--- a/lib/mlton/lattice/flat-lattice.sig
+++ b/lib/mlton/lattice/flat-lattice.sig
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2021 Matthew Fluet.
+ * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -36,4 +37,115 @@ signature FLAT_LATTICE =
       val new: unit -> t
       val point: Point.t -> t
       val upperBound: t * Point.t -> bool
+   end
+
+
+
+signature FLAT_LATTICE_REC_STRUCTS =
+   sig
+      structure Point:
+         sig
+            type 'a t
+
+            val clone: {clone: 'a -> 'a,
+                        equals: 'a * 'a -> bool} -> 'a t -> 'a t
+            val coerce: {clone: 'a -> 'a,
+                         coerce: {from: 'a, to: 'a} -> unit,
+                         equals: 'a * 'a -> bool} -> {from: 'a t, to: 'a t} -> bool
+            val equals: ('a * 'a -> bool) -> 'a t * 'a t -> bool
+            val layout: ('a -> Layout.t) -> 'a t -> Layout.t
+            val unify: {equals: 'a * 'a -> bool,
+                        unify: 'a * 'a -> unit} -> 'a t * 'a t -> bool
+         end
+      (* pretty print names *)
+      val bottom: string
+      val top: string
+   end
+
+signature FLAT_LATTICE_REC =
+   sig
+      include FLAT_LATTICE_REC_STRUCTS
+
+      structure Value:
+         sig
+            datatype 'a t =
+               Bottom
+             | Point of 'a Point.t
+             | Top
+
+            val layout: ('a -> Layout.t) -> 'a t -> Layout.t
+         end
+
+      type 'a t
+
+      (* handler will be run once for each value *)
+      val addHandler': 'a t * ('a Value.t -> unit) -> unit
+      val addHandler: 'a t * (unit -> unit) -> unit
+      val coerce: {clone: 'a -> 'a,
+                   coerce: {from: 'a, to: 'a} -> unit,
+                   equals: 'a * 'a -> bool} -> {from: 'a t, to: 'a t} -> unit
+      val equals: 'a t * 'a t -> bool
+      val getPoint: 'a t -> 'a Point.t option
+      val isBottom: 'a t -> bool
+      val isPoint: 'a t -> bool
+      val isPointEq: ('a * 'a -> bool) -> 'a t * 'a Point.t -> bool
+      val isTop: 'a t -> bool
+      val layout: ('a -> Layout.t) -> 'a t -> Layout.t
+      val lowerBound: {clone: 'a -> 'a,
+                       coerce: {from: 'a, to: 'a} -> unit,
+                       equals: 'a * 'a -> bool} -> 'a t * 'a Value.t -> unit
+      val makeTop: 'a t -> unit
+      val new: 'a Value.t -> 'a t
+      val newBottom: unit -> 'a t
+      val newPoint: 'a Point.t -> 'a t
+      val newTop: unit -> 'a t
+      val unify: {clone: 'a -> 'a,
+                  coerce: {from: 'a, to: 'a} -> unit,
+                  equals: 'a * 'a -> bool,
+                  unify: 'a * 'a -> unit} -> 'a t * 'a t -> unit
+      val value: 'a t -> 'a Value.t
+   end
+
+signature FLAT_LATTICE_POLY_STRUCTS =
+   sig
+      structure Point:
+         sig
+            type 'a t
+
+            val clone: {clone: 'a -> 'a,
+                        equals: 'a * 'a -> bool} -> 'a t -> 'a t
+            val equals: ('a * 'a -> bool) -> 'a t * 'a t -> bool
+            val layout: ('a -> Layout.t) -> 'a t -> Layout.t
+         end
+      (* pretty print names *)
+      val bottom: string
+      val top: string
+   end
+
+signature FLAT_LATTICE_PARAM_STRUCTS =
+   sig
+      structure Point:
+         sig
+            type 'a t
+
+            val equals: 'a t * 'a t -> bool
+            val layout: ('a -> Layout.t) -> 'a t -> Layout.t
+         end
+      (* pretty print names *)
+      val bottom: string
+      val top: string
+   end
+
+signature FLAT_LATTICE_MONO_STRUCTS =
+   sig
+      structure Point:
+         sig
+            type t
+
+            val equals: t * t -> bool
+            val layout: t -> Layout.t
+         end
+      (* pretty print names *)
+      val bottom: string
+      val top: string
    end

--- a/lib/mlton/lattice/sources.cm
+++ b/lib/mlton/lattice/sources.cm
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019,2021 Matthew Fluet.
  *
  * MLton is released under a BSD-style license.
  * See the file MLton-LICENSE for details.
@@ -7,12 +7,17 @@
 Library
 
 signature FLAT_LATTICE
+signature FLAT_LATTICE_REC
 signature N_POINT_LATTICE
 signature POWERSET_LATTICE
 signature THREE_POINT_LATTICE
 signature TWO_POINT_LATTICE
 
 functor FlatLattice
+functor FlatLatticeMono
+functor FlatLatticeParam
+functor FlatLatticePoly
+functor FlatLatticeRec
 functor NPointLattice
 functor PowerSetLattice_ListSet
 functor PowerSetLattice_UniqueSet

--- a/lib/mlton/lattice/sources.mlb
+++ b/lib/mlton/lattice/sources.mlb
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019,2021 Matthew Fluet.
  *
  * MLton is released under a BSD-style license.
  * See the file MLton-LICENSE for details.
@@ -26,12 +26,17 @@ in
       three-point-lattice.fun
    in
       signature FLAT_LATTICE
+      signature FLAT_LATTICE_REC
       signature N_POINT_LATTICE
       signature POWERSET_LATTICE
       signature THREE_POINT_LATTICE
       signature TWO_POINT_LATTICE
 
       functor FlatLattice
+      functor FlatLatticeMono
+      functor FlatLatticeParam
+      functor FlatLatticePoly
+      functor FlatLatticeRec
       functor NPointLattice
       functor PowerSetLattice_ListSet
       functor PowerSetLattice_UniqueSet

--- a/lib/mlton/sources.cm
+++ b/lib/mlton/sources.cm
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2013,2019 Matthew Fluet.
+(* Copyright (C) 2009,2013,2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -162,6 +162,10 @@ functor Control
 functor Env
 functor EuclideanRing
 functor FlatLattice
+functor FlatLatticeMono
+functor FlatLatticeParam
+functor FlatLatticePoly
+functor FlatLatticeRec
 functor HashedUniqueSet
 functor IntUniqueId
 functor MakeMonoEnv

--- a/lib/mlton/sources.mlb
+++ b/lib/mlton/sources.mlb
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2019 Matthew Fluet.
+(* Copyright (C) 2009,2019,2021 Matthew Fluet.
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -134,6 +134,10 @@ ann "forceUsed" in
       functor Env
       functor EuclideanRing
       functor FlatLattice
+      functor FlatLatticeMono
+      functor FlatLatticeParam
+      functor FlatLatticePoly
+      functor FlatLatticeRec
       functor IntUniqueId
       functor MakeMonoEnv
       functor MonoArray

--- a/mlton/atoms/c-symbol.fun
+++ b/mlton/atoms/c-symbol.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019,2021 Matthew Fluet.
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
@@ -22,8 +22,8 @@ fun equals (T {cty = cty1, name = name1, symbolScope = symbolScope1},
 fun hash (T {name, ...}) = String.hash name
 
 fun layout (T {cty, name, symbolScope}) =
-  Layout.record [("name", Layout.str name),
-                 ("cty", Option.layout CType.layout cty),
+  Layout.record [("cty", Option.layout CType.layout cty),
+                 ("name", Layout.str name),
                  ("symbolScope", CSymbolScope.layout symbolScope)]
 
 val toString = Layout.toString o layout

--- a/mlton/atoms/id.fun
+++ b/mlton/atoms/id.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017,2019 Matthew Fluet.
+(* Copyright (C) 2017,2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -136,7 +136,10 @@ local
    val symId =
       (fn (c,cs,suf) => (c::(cs@suf))) <$$$>
       (sym, many sym,
-       (op ::) <$$> (char #"_", many (nextSat Char.isDigit))
+       List.concat <$>
+       each [many (nextSat Char.isAlpha),
+             List.single <$> char #"_",
+             many (nextSat Char.isDigit)]
        <|> pure [])
    val tyvarId =
       (op ::) <$$> (nextSat (fn c => c = #"'"), many alphanum)

--- a/mlton/atoms/word-x-vector.fun
+++ b/mlton/atoms/word-x-vector.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2014,2017,2019-2020 Matthew Fluet.
+(* Copyright (C) 2014,2017,2019-2021 Matthew Fluet.
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -103,6 +103,8 @@ fun le (v, v') =
 fun foldFrom (v, start, b, f) = Vector.foldFrom (elements v, start, b, f)
 
 fun forall (v, f) = Vector.forall (elements v, f)
+
+fun foreach (v, f) = Vector.foreach (elements v, f)
 
 fun fromVector ({elementSize}, v) =
    T {elementSize = elementSize,

--- a/mlton/atoms/word-x-vector.sig
+++ b/mlton/atoms/word-x-vector.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2014,2017,2019-2020 Matthew Fluet.
+(* Copyright (C) 2014,2017,2019-2021 Matthew Fluet.
  * Copyright (C) 2004-2006 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -24,6 +24,7 @@ signature WORD_X_VECTOR =
       val equals: t * t -> bool
       val foldFrom: t * int * 'b * (WordX.t * 'b -> 'b) -> 'b
       val forall: t * (WordX.t -> bool) -> bool
+      val foreach: t * (WordX.t -> unit) -> unit
       val fromList: {elementSize: WordSize.t} * WordX.t list -> t
       val fromListRev: {elementSize: WordSize.t} * WordX.t list -> t
       val fromString: string -> t

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2014,2016-2017,2019-2020 Matthew Fluet.
+(* Copyright (C) 2009,2014,2016-2017,2019-2021 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -1768,8 +1768,6 @@ fun simplify p =
       val machinePasses =
          {name = "machineShuffle", doit = Program.shuffle, execute = false} ::
          nil
-      (* Machine type check is too slow to run by default. *)
-      (* val () = Control.trace (Control.Pass, "machineTypeCheck") Program.typeCheck p *)
       val p =
          Control.simplifyPasses
          {arg = p,
@@ -1777,7 +1775,6 @@ fun simplify p =
           stats = Program.layoutStats,
           toFile = Program.toFile,
           typeCheck = Program.typeCheck}
-      (* val () = Control.trace (Control.Pass, "machineTypeCheck") Program.typeCheck p *)
    in
       p
    end

--- a/mlton/backend/rssa-simplify.fun
+++ b/mlton/backend/rssa-simplify.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019-2020 Matthew Fluet.
+(* Copyright (C) 2019-2021 Matthew Fluet.
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
@@ -41,8 +41,6 @@ val rssaPasses =
 fun simplify p =
    let
       val rssaPasses = rssaPasses
-      (* RSSA type check is too slow to run by default. *)
-      (* val () = Control.trace (Control.Pass, "rssaTypeCheck") typeCheck p *)
       val p =
          Control.simplifyPasses
          {arg = p,
@@ -50,7 +48,6 @@ fun simplify p =
           stats = Program.layoutStats,
           toFile = Program.toFile,
           typeCheck = typeCheck}
-      (* val () = Control.trace (Control.Pass, "rssaTypeCheck") typeCheck p *)
    in
       p
    end

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -94,6 +94,8 @@ signature CONTROL_FLAGS =
       val commandLineConsts: StrMap.t
       val setCommandLineConst: {name: string, value: string} -> unit
 
+      val constPropAbsValLayoutDepth: int ref
+
       val contifyIntoMain: bool ref
 
       (* Generate an executable with debugging info. *)

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012,2014-2017,2019-2020 Matthew Fluet.
+(* Copyright (C) 2009-2012,2014-2017,2019-2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -497,9 +497,6 @@ signature CONTROL_FLAGS =
                   val sequenceMetaData: unit -> Bits.t
                end
          end
-
-      (* Type check ILs. *)
-      val typeCheck: bool ref
 
       structure Verbosity:
          sig

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1638,10 +1638,6 @@ fun mlbPathMap () =
              path = !defaultWord}],
            !mlbPathVars])
 
-val typeCheck = control {name = "type check",
-                         default = false,
-                         toString = Bool.toString}
-
 structure Verbosity =
    struct
       datatype t =

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -261,6 +261,10 @@ val codegenFuseOpAndChk = control {name = "fuse `op` and `opCheckP` primitives i
                                    default = false,
                                    toString = Bool.toString}
 
+val constPropAbsValLayoutDepth = control {name = "cut-off depth for printing of abstract values in`ConstantPropagation`",
+                                          default = 2,
+                                          toString = Int.toString}
+
 val contifyIntoMain = control {name = "contifyIntoMain",
                                default = false,
                                toString = Bool.toString}

--- a/mlton/control/control.sig
+++ b/mlton/control/control.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2019 Matthew Fluet.
+(* Copyright (C) 2009,2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -65,6 +65,7 @@ signature CONTROL =
       val simplifyPass: {arg: 'a,
                          doit: 'a -> 'a,
                          execute: bool,
+                         forceTypeCheck: bool option,
                          keepIL: bool,
                          name: string,
                          stats: 'a -> Layout.t,
@@ -82,5 +83,5 @@ signature CONTROL =
                           srcToFile: {display: 'a display, style: style, suffix: string} option,
                           tgtStats: ('b -> Layout.t) option,
                           tgtToFile: {display: 'b display, style: style, suffix: string} option,
-                          tgtTypeCheck: ('b -> unit) option} -> 'b
+                          tgtTypeCheck: (('b -> unit) * bool option) option} -> 'b
    end

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -340,6 +340,9 @@ fun makeOptions {usage} =
                            Control.setCommandLineConst {name = name,
                                                         value = value}
                       | _ => usage (concat ["invalid -const flag: ", s]))),
+       (Expert, "const-prop-absval-layout-depth", " <n>",
+        "cut-off depth for printing of abstract values in`ConstantPropagation`",
+        intRef constPropAbsValLayoutDepth),
        (Expert, "contify-into-main", " {false|true}",
         "contify functions into main",
         boolRef contifyIntoMain),

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010-2011,2013-2020 Matthew Fluet.
+(* Copyright (C) 2010-2011,2013-2021 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -931,7 +931,14 @@ fun makeOptions {usage} =
         (fn (target, opt) => List.push (llvm_optOpts, {opt = opt, pred = OptPred.Target target}))),
        (Expert, #1 trace, " name1,...", "trace compiler internals", #2 trace),
        (Expert, "type-check", " {false|true}", "type check ILs",
-        boolRef typeCheck),
+        Bool
+        (fn b =>
+         let
+            val re = Regexp.seq [Regexp.anys, Regexp.string ":typeCheck"]
+            val re = Regexp.compileDFA re
+         in
+            List.push (executePasses, (re, b))
+         end)),
        (Normal, "verbose", " {0|1|2|3}", "how verbose to be",
         SpaceString
         (fn s =>

--- a/mlton/ssa/constant-propagation.fun
+++ b/mlton/ssa/constant-propagation.fun
@@ -425,6 +425,8 @@ structure Value =
          fun layout (seen, v) =
             if List.contains (seen, v, equals)
                then str "$$$"
+            else if List.length seen > !Control.constPropAbsValLayoutDepth
+               then str "..."
                else let
                        val seen' = v::seen
                        val layout = fn v' => layout (seen', v')

--- a/mlton/ssa/constant-propagation.fun
+++ b/mlton/ssa/constant-propagation.fun
@@ -985,7 +985,7 @@ fun transform (program: Program.t): Program.t =
              | Const _ => ()
              | Datatype _ => ()
              | Ref {arg, ...} => makeUnknown arg
-             | Vector {elt, ...} => makeUnknown elt
+             | Vector _ => ()
              | Tuple vs => Vector.foreach (vs, sideEffect)
              | Weak v => makeUnknown v
          fun primApp {prim,

--- a/mlton/ssa/constant-propagation.fun
+++ b/mlton/ssa/constant-propagation.fun
@@ -848,7 +848,7 @@ fun transform (program: Program.t): Program.t =
                 val v = ConApp ca
                 fun loop arg: unit =
                    traceSendConAppLoop
-                   (fn Data {value, coercedTo, filters, ...} =>
+                   (fn d' as Data {value, coercedTo, filters, ...} =>
                     case !value of
                        Unknown => ()
                      | Undefined =>
@@ -864,7 +864,7 @@ fun transform (program: Program.t): Program.t =
                              orelse (Con.equals (con, con')
                                      andalso Vector.isEmpty args)
                              then ()
-                          else makeDataUnknown d) arg
+                          else makeDataUnknown d') arg
              in loop d
              end) arg
          and coerces {froms: Value.t vector, tos: Value.t vector} =

--- a/mlton/ssa/constant-propagation.fun
+++ b/mlton/ssa/constant-propagation.fun
@@ -503,7 +503,7 @@ structure Value =
                     | _ => Error.bug err)
              | _ => Error.bug err
       in
-         val devector = make ("ConstantPropagation.Value.devector", #elt)
+         val vectorElt = make ("ConstantPropagation.Value.vectorElt", #elt)
          val vectorLength = make ("ConstantPropagation.Value.vectorLength", #length)
       end
 
@@ -512,7 +512,8 @@ structure Value =
             case value v of
                Array fs => sel fs
              | _ => Error.bug err
-      in val dearray = make ("ConstantPropagation.Value.dearray", #elt)
+      in
+         val arrayElt = make ("ConstantPropagation.Value.arrayElt", #elt)
          val arrayLength = make ("ConstantPropagation.Value.arrayLength", #length)
          val arrayBirth = make ("ConstantPropagation.Value.arrayBirth", #birth)
       end
@@ -847,7 +848,7 @@ fun transform (program: Program.t): Program.t =
                                        else Birth.unknown ()
                    | _ => Error.bug "ConstantPropagation.Value.primApp.bear"
                fun update (a, v) =
-                  (coerce {from = v, to = dearray a}
+                  (coerce {from = v, to = arrayElt a}
                    ; unit ())
                fun arg i = Vector.sub (args, i)
                fun array (birth, length) =
@@ -856,14 +857,14 @@ fun transform (program: Program.t): Program.t =
                      val _ = ArrayBirth.coerce {from = birth, to = arrayBirth a}
                      val _ = coerce {from = length, to = arrayLength a}
                   in
-                     (a, dearray a)
+                     (a, arrayElt a)
                   end
                fun vector length =
                   let
                      val v = fromType resultType
                      val _ = coerce {from = length, to = vectorLength v}
                   in
-                     (v, devector v)
+                     (v, vectorElt v)
                   end
                fun sequence mk =
                   let
@@ -893,11 +894,11 @@ fun transform (program: Program.t): Program.t =
                         sequence (fn l => array (birth, l))
                      end
                 | Prim.Array_copyArray =>
-                     update (arg 0, dearray (arg 2))
+                     update (arg 0, arrayElt (arg 2))
                 | Prim.Array_copyVector =>
-                     update (arg 0, devector (arg 2))
+                     update (arg 0, vectorElt (arg 2))
                 | Prim.Array_length => arrayLength (arg 0)
-                | Prim.Array_sub => dearray (arg 0)
+                | Prim.Array_sub => arrayElt (arg 0)
                 | Prim.Array_toArray => arrayFromArray (arg 0)
                 | Prim.Array_toVector => vectorFromArray (arg 0)
                 | Prim.Array_update => update (arg 0, arg 2)
@@ -915,7 +916,7 @@ fun transform (program: Program.t): Program.t =
                         r
                      end
                 | Prim.Vector_length => vectorLength (arg 0)
-                | Prim.Vector_sub => devector (arg 0)
+                | Prim.Vector_sub => vectorElt (arg 0)
                 | Prim.Vector_vector => sequence vector
                 | Prim.Weak_get => deweak (arg 0)
                 | Prim.Weak_new =>

--- a/mlton/ssa/simplify.fun
+++ b/mlton/ssa/simplify.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2017,2019 Matthew Fluet.
+(* Copyright (C) 2009,2017,2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -293,10 +293,6 @@ fun simplify p =
                                       doit = S.orderFunctions,
                                       execute = true})
       val ssaPasses = AppendList.toList ssaPasses
-      (* Always want to type check the initial and final SSA programs,
-       * even if type checking is turned off, just to catch bugs.
-       *)
-      val () = Control.trace (Control.Pass, "ssaTypeCheck") typeCheck p
       val p =
          Control.simplifyPasses
          {arg = p,
@@ -304,7 +300,6 @@ fun simplify p =
           stats = Program.layoutStats,
           toFile = Program.toFile,
           typeCheck = typeCheck}
-      val () = Control.trace (Control.Pass, "ssaTypeCheck") typeCheck p
    in
       p
    end

--- a/mlton/ssa/simplify2.fun
+++ b/mlton/ssa/simplify2.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017,2019 Matthew Fluet.
+(* Copyright (C) 2017,2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -100,10 +100,6 @@ fun simplify p =
                                        doit = S.orderFunctions,
                                        execute = true})
       val ssa2Passes = AppendList.toList ssa2Passes
-      (* Always want to type check the initial and final SSA2 programs,
-       * even if type checking is turned off, just to catch bugs.
-       *)
-      val () = Control.trace (Control.Pass, "ssa2TypeCheck") typeCheck p
       val p =
          Control.simplifyPasses
          {arg = p,
@@ -111,7 +107,6 @@ fun simplify p =
           stats = Program.layoutStats,
           toFile = Program.toFile,
           typeCheck = typeCheck}
-      val () = Control.trace (Control.Pass, "ssa2TypeCheck") typeCheck p
    in
       p
    end

--- a/mlton/ssa/useless.fun
+++ b/mlton/ssa/useless.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2017-2020 Matthew Fluet.
+(* Copyright (C) 2009,2017-2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -945,6 +945,12 @@ fun transform (program: Program.t): Program.t =
                                       targs = Vector.new1 Type.unit,
                                       args = Vector.new1 unitVar}
                         else doit ()
+                  fun makeSeq deSeq =
+                     if Type.isUnit (deSeq resultType)
+                        then PrimApp {prim = prim,
+                                      targs = Vector.new1 Type.unit,
+                                      args = Vector.map (args, fn _ => unitVar)}
+                        else doit ()
                in
                   case prim of
                      Prim.Array_uninitIsNop =>
@@ -952,6 +958,7 @@ fun transform (program: Program.t): Program.t =
                            then doit ()
                            else ConApp {args = Vector.new0 (),
                                         con = Con.truee}
+                   | Prim.Array_array => makeSeq Type.deArray
                    | Prim.MLton_equal =>
                         let
                            val (t0, _) = Value.getNew (value (arg 0))
@@ -971,6 +978,7 @@ fun transform (program: Program.t): Program.t =
                                            con = Con.falsee}
                         end
                    | Prim.Ref_ref => makePtr Type.deRef
+                   | Prim.Vector_vector => makeSeq Type.deVector
                    | Prim.Weak_new => makePtr Type.deWeak
                    | _ => doit ()
                end

--- a/mlton/xml/polyvariance.fun
+++ b/mlton/xml/polyvariance.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -454,6 +454,7 @@ val transform =
                                                     end))
                                            ; shrink (transform (p, hofo, small, product))),
                            execute = true,
+                           forceTypeCheck = NONE,
                            keepIL = false,
                            name = concat ["duplicate", Int.toString (n + 1)],
                            stats = Program.layoutStats,

--- a/mlton/xml/sxml-simplify.fun
+++ b/mlton/xml/sxml-simplify.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -147,10 +147,6 @@ val _ = Control.OptimizationPasses.register {il = "sxml", set = sxmlPassesSet}
 fun simplify p =
    let
       val sxmlPasses = !sxmlPasses
-      (* Always want to type check the initial and final SXML programs,
-       * even if type checking is turned off, just to catch bugs.
-       *)
-      val () = Control.trace (Control.Pass, "sxmlTypeCheck") typeCheck p
       val p =
          Control.simplifyPasses
          {arg = p,
@@ -158,7 +154,6 @@ fun simplify p =
           stats = Program.layoutStats,
           toFile = Program.toFile,
           typeCheck = typeCheck}
-      val () = Control.trace (Control.Pass, "sxmlTypeCheck") typeCheck p
    in
       p
    end

--- a/mlton/xml/xml-simplify.fun
+++ b/mlton/xml/xml-simplify.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 Matthew Fluet.
+(* Copyright (C) 2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2006, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -73,10 +73,6 @@ val _ = Control.OptimizationPasses.register {il = "xml", set = xmlPassesSet}
 fun simplify p =
    let
       val xmlPasses = !xmlPasses
-      (* Always want to type check the initial and final XML programs,
-       * even if type checking is turned off, just to catch bugs.
-       *)
-      val () = Control.trace (Control.Pass, "xmlTypeCheck") typeCheck p
       val p =
          Control.simplifyPasses
          {arg = p,
@@ -84,7 +80,6 @@ fun simplify p =
           stats = Program.layoutStats,
           toFile = Program.toFile,
           typeCheck = typeCheck}
-      val () = Control.trace (Control.Pass, "xmlTypeCheck") typeCheck p
    in
       p
    end


### PR DESCRIPTION
Various improvements to `ConstantPropagation`:
- Introduce `functor FlatLattice{Rec,Poly,Param,Mono}` and use to implement abstract values for constants, "birth", and con apps, replacing bespoke implementations.
- Use `FlatLattice{Rec,Poly,Param,Mono}.addHandler` to perform constant folding in `ConstantPropagation`.
- Use a bespoke `Sequence` lattice (which itself uses `FlatLatticeRec`) to allow fine-grained tracking of sequences with a known number of elements (up to 0w1000); in particular, this allows `WordXVector` constants to be propagated to join points of `Vector` abstract values.