### PR TITLE
Updates to `_import`-ed runtime functions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ Here are the changes from version 20210117 to YYYYMMDD.
 
 === Details
 
+* 2021-12-17
+  ** Fix mismatch in C and SML types for some `_import`-ed runtime
+     functions.
+
 * 2021-10-21
   ** Migrate website sources from http://asciidoc.org/[AsciiDoc] to
   http://asciidoctor.org/[AsciiDoctor].

--- a/basis-library/primitive/prim-mlton.sml
+++ b/basis-library/primitive/prim-mlton.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010-2011,2013-2014,2017,2019 Matthew Fluet.
+(* Copyright (C) 2010-2011,2013-2014,2017,2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -55,11 +55,11 @@ structure CallStack =
       val callStack =
          _import "GC_callStack" runtime private: GCState.t * Word32.word array -> unit;
       val frameIndexSourceSeq =
-         _import "GC_frameIndexSourceSeq" runtime private: GCState.t * Word32.word -> Pointer.t;
+         _import "GC_frameIndexSourceSeq" private: GCState.t * Word32.word -> Pointer.t;
       val keep = _command_line_const "CallStack.keep": bool = false;
       val numStackFrames =
          _import "GC_numStackFrames" runtime private: GCState.t -> Word32.word;
-      val sourceName = _import "GC_sourceName" runtime private: GCState.t * Word32.word -> C_String.t;
+      val sourceName = _import "GC_sourceName" private: GCState.t * Word32.word -> C_String.t;
    end
 
 structure Codegen =
@@ -109,7 +109,7 @@ structure Exn =
 
 structure FFI =
    struct
-      val getOpArgsResPtr = _import "GC_getCallFromCOpArgsResPtr" runtime private: GCState.t -> Pointer.t;
+      val getOpArgsResPtr = _import "GC_getCallFromCOpArgsResPtr" private: GCState.t -> Pointer.t;
       val numExports = _build_const "MLton_FFI_numExports": Int32.int;
    end
 
@@ -123,23 +123,23 @@ structure GC =
       val collect = _prim "GC_collect": unit -> unit;
       val pack = _import "GC_pack" runtime private: GCState.t -> unit;
       val getBytesAllocated =
-         _import "GC_getCumulativeStatisticsBytesAllocated" runtime private: GCState.t -> C_UIntmax.t;
+         _import "GC_getCumulativeStatisticsBytesAllocated" private: GCState.t -> C_UIntmax.t;
       val getNumCopyingGCs =
-         _import "GC_getCumulativeStatisticsNumCopyingGCs" runtime private: GCState.t -> C_UIntmax.t;
+         _import "GC_getCumulativeStatisticsNumCopyingGCs" private: GCState.t -> C_UIntmax.t;
       val getNumMarkCompactGCs =
-         _import "GC_getCumulativeStatisticsNumMarkCompactGCs" runtime private: GCState.t -> C_UIntmax.t;
+         _import "GC_getCumulativeStatisticsNumMarkCompactGCs" private: GCState.t -> C_UIntmax.t;
       val getNumMinorGCs =
-         _import "GC_getCumulativeStatisticsNumMinorGCs" runtime private: GCState.t -> C_UIntmax.t;
+         _import "GC_getCumulativeStatisticsNumMinorGCs" private: GCState.t -> C_UIntmax.t;
       val getLastBytesLive =
-         _import "GC_getLastMajorStatisticsBytesLive" runtime private: GCState.t -> C_Size.t;
+         _import "GC_getLastMajorStatisticsBytesLive" private: GCState.t -> C_Size.t;
       val getMaxBytesLive =
-         _import "GC_getCumulativeStatisticsMaxBytesLive" runtime private: GCState.t -> C_Size.t;
+         _import "GC_getCumulativeStatisticsMaxBytesLive" private: GCState.t -> C_Size.t;
       val setHashConsDuringGC =
-         _import "GC_setHashConsDuringGC" runtime private: GCState.t * bool -> unit;
-      val setMessages = _import "GC_setControlsMessages" runtime private: GCState.t * bool -> unit;
+         _import "GC_setHashConsDuringGC" private: GCState.t * bool -> unit;
+      val setMessages = _import "GC_setControlsMessages" private: GCState.t * bool -> unit;
       val setRusageMeasureGC =
-         _import "GC_setControlsRusageMeasureGC" runtime private: GCState.t * bool -> unit;
-      val setSummary = _import "GC_setControlsSummary" runtime private: GCState.t * bool -> unit;
+         _import "GC_setControlsRusageMeasureGC" private: GCState.t * bool -> unit;
+      val setSummary = _import "GC_setControlsSummary" private: GCState.t * bool -> unit;
       val unpack = _import "GC_unpack" runtime private: GCState.t -> unit;
    end
 
@@ -304,14 +304,14 @@ structure Profile =
             type t = Pointer.t
 
             val dummy = Pointer.null
-            val free = _import "GC_profileFree" runtime private: GCState.t * t -> unit;
-            val malloc = _import "GC_profileMalloc" runtime private: GCState.t -> t;
+            val free = _import "GC_profileFree" private: GCState.t * t -> unit;
+            val malloc = _import "GC_profileMalloc" private: GCState.t -> t;
             val write =
-               _import "GC_profileWrite" runtime private: GCState.t * t * NullString8.t -> unit;
+               _import "GC_profileWrite" private: GCState.t * t * NullString8.t -> unit;
          end
-      val done = _import "GC_profileDone" runtime private: GCState.t -> unit;
-      val getCurrent = _import "GC_getProfileCurrent" runtime private: GCState.t -> Data.t;
-      val setCurrent = _import "GC_setProfileCurrent" runtime private : GCState.t * Data.t -> unit;
+      val done = _import "GC_profileDone" private: GCState.t -> unit;
+      val getCurrent = _import "GC_getProfileCurrent" private: GCState.t -> Data.t;
+      val setCurrent = _import "GC_setProfileCurrent" private : GCState.t * Data.t -> unit;
    end
 
 structure Thread =
@@ -340,17 +340,17 @@ structure Thread =
        * switching to a copy.
        *)
       val copyCurrent = _prim "Thread_copyCurrent": unit -> unit;
-      val current = _import "GC_getCurrentThread" runtime private: GCState.t -> thread;
-      val finishSignalHandler = _import "GC_finishSignalHandler" runtime private: GCState.t -> unit;
+      val current = _import "GC_getCurrentThread" private: GCState.t -> thread;
+      val finishSignalHandler = _import "GC_finishSignalHandler" private: GCState.t -> unit;
       val returnToC = _prim "Thread_returnToC": unit -> unit;
-      val saved = _import "GC_getSavedThread" runtime private: GCState.t -> thread;
-      val savedPre = _import "GC_getSavedThread" runtime private: GCState.t -> preThread;
+      val saved = _import "GC_getSavedThread" private: GCState.t -> thread;
+      val savedPre = _import "GC_getSavedThread" private: GCState.t -> preThread;
       val setCallFromCHandler =
-         _import "GC_setCallFromCHandlerThread" runtime private: GCState.t * thread -> unit;
+         _import "GC_setCallFromCHandlerThread" private: GCState.t * thread -> unit;
       val setSignalHandler =
-         _import "GC_setSignalHandlerThread" runtime private: GCState.t * thread -> unit;
-      val setSaved = _import "GC_setSavedThread" runtime private: GCState.t * thread -> unit;
-      val startSignalHandler = _import "GC_startSignalHandler" runtime private: GCState.t -> unit;
+         _import "GC_setSignalHandlerThread" private: GCState.t * thread -> unit;
+      val setSaved = _import "GC_setSavedThread" private: GCState.t * thread -> unit;
+      val startSignalHandler = _import "GC_startSignalHandler" private: GCState.t -> unit;
       val switchTo = _prim "Thread_switchTo": thread -> unit;
    end
 
@@ -365,9 +365,9 @@ structure Weak =
 
 structure World =
    struct
-      val getAmOriginal = _import "GC_getAmOriginal" runtime private: GCState.t -> bool;
-      val setAmOriginal = _import "GC_setAmOriginal" runtime private: GCState.t * bool -> unit;
-      val getSaveStatus = _import "GC_getSaveWorldStatus" runtime private: GCState.t -> bool C_Errno.t;
+      val getAmOriginal = _import "GC_getAmOriginal" private: GCState.t -> bool;
+      val setAmOriginal = _import "GC_setAmOriginal" private: GCState.t * bool -> unit;
+      val getSaveStatus = _import "GC_getSaveWorldStatus" private: GCState.t -> bool C_Errno.t;
       (* save's result status is accesible via getSaveStatus ().
        * It is not possible to have the type of save as
        * NullString8.t -> bool C_Errno.t, because there are two

--- a/runtime/gc/gc_state.c
+++ b/runtime/gc/gc_state.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009,2012,2019 Matthew Fluet.
+/* Copyright (C) 2009,2012,2019,2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -105,23 +105,23 @@ void setGCStateCurrentHeap (GC_state s,
   assert (hasHeapBytesFree (s, oldGenBytesRequested, nurseryBytesRequested));
 }
 
-bool GC_getAmOriginal (GC_state s) {
-  return s->amOriginal;
+Bool_t GC_getAmOriginal (GC_state s) {
+  return (Bool_t)(s->amOriginal);
 }
-void GC_setAmOriginal (GC_state s, bool b) {
-  s->amOriginal = b;
-}
-
-void GC_setControlsMessages (GC_state s, bool b) {
-  s->controls.messages = b;
+void GC_setAmOriginal (GC_state s, Bool_t b) {
+  s->amOriginal = (bool)b;
 }
 
-void GC_setControlsSummary (GC_state s, bool b) {
-  s->controls.summary = b;
+void GC_setControlsMessages (GC_state s, Bool_t b) {
+  s->controls.messages = (bool)b;
 }
 
-void GC_setControlsRusageMeasureGC (GC_state s, bool b) {
-  s->controls.rusageMeasureGC = b;
+void GC_setControlsSummary (GC_state s, Bool_t b) {
+  s->controls.summary = (bool)b;
+}
+
+void GC_setControlsRusageMeasureGC (GC_state s, Bool_t b) {
+  s->controls.rusageMeasureGC = (bool)b;
 }
 
 uintmax_t GC_getCumulativeStatisticsBytesAllocated (GC_state s) {
@@ -144,8 +144,8 @@ size_t GC_getCumulativeStatisticsMaxBytesLive (GC_state s) {
   return s->cumulativeStatistics.maxBytesLive;
 }
 
-void GC_setHashConsDuringGC (GC_state s, bool b) {
-  s->hashConsDuringGC = b;
+void GC_setHashConsDuringGC (GC_state s, Bool_t b) {
+  s->hashConsDuringGC = (bool)b;
 }
 
 size_t GC_getLastMajorStatisticsBytesLive (GC_state s) {
@@ -206,14 +206,14 @@ sigset_t* GC_getSignalsPendingAddr (GC_state s) {
   return &(s->signalsInfo.signalsPending);
 }
 
-void GC_setGCSignalHandled (GC_state s, bool b) {
-  s->signalsInfo.gcSignalHandled = b;
+void GC_setGCSignalHandled (GC_state s, Bool_t b) {
+  s->signalsInfo.gcSignalHandled = (bool)b;
 }
 
-bool GC_getGCSignalPending (GC_state s) {
-  return (s->signalsInfo.gcSignalPending);
+Bool_t GC_getGCSignalPending (GC_state s) {
+  return (bool)(s->signalsInfo.gcSignalPending);
 }
 
-void GC_setGCSignalPending (GC_state s, bool b) {
-  s->signalsInfo.gcSignalPending = b;
+void GC_setGCSignalPending (GC_state s, Bool_t b) {
+  s->signalsInfo.gcSignalPending = (bool)b;
 }

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012,2014,2019-2020 Matthew Fluet.
+/* Copyright (C) 2012,2014,2019-2021 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -81,17 +81,17 @@ static void setGCStateCurrentHeap (GC_state s,
 
 #if (defined (MLTON_GC_INTERNAL_BASIS)) 
 
-PRIVATE bool GC_getAmOriginal (GC_state s);
-PRIVATE void GC_setAmOriginal (GC_state s, bool b);
-PRIVATE void GC_setControlsMessages (GC_state s, bool b);
-PRIVATE void GC_setControlsSummary (GC_state s, bool b);
-PRIVATE void GC_setControlsRusageMeasureGC (GC_state s, bool b);
+PRIVATE Bool_t GC_getAmOriginal (GC_state s);
+PRIVATE void GC_setAmOriginal (GC_state s, Bool_t b);
+PRIVATE void GC_setControlsMessages (GC_state s, Bool_t b);
+PRIVATE void GC_setControlsSummary (GC_state s, Bool_t b);
+PRIVATE void GC_setControlsRusageMeasureGC (GC_state s, Bool_t b);
 PRIVATE uintmax_t GC_getCumulativeStatisticsBytesAllocated (GC_state s);
 PRIVATE uintmax_t GC_getCumulativeStatisticsNumCopyingGCs (GC_state s);
 PRIVATE uintmax_t GC_getCumulativeStatisticsNumMarkCompactGCs (GC_state s);
 PRIVATE uintmax_t GC_getCumulativeStatisticsNumMinorGCs (GC_state s);
 PRIVATE size_t GC_getCumulativeStatisticsMaxBytesLive (GC_state s);
-PRIVATE void GC_setHashConsDuringGC (GC_state s, bool b);
+PRIVATE void GC_setHashConsDuringGC (GC_state s, Bool_t b);
 PRIVATE size_t GC_getLastMajorStatisticsBytesLive (GC_state s);
 
 PRIVATE pointer GC_getCallFromCHandlerThread (GC_state s);
@@ -109,8 +109,8 @@ PRIVATE struct rusage* GC_getRusageGCAddr (GC_state s);
 
 PRIVATE sigset_t* GC_getSignalsHandledAddr (GC_state s);
 PRIVATE sigset_t* GC_getSignalsPendingAddr (GC_state s);
-PRIVATE void GC_setGCSignalHandled (GC_state s, bool b);
-PRIVATE bool GC_getGCSignalPending (GC_state s);
-PRIVATE void GC_setGCSignalPending (GC_state s, bool b);
+PRIVATE void GC_setGCSignalHandled (GC_state s, Bool_t b);
+PRIVATE Bool_t GC_getGCSignalPending (GC_state s);
+PRIVATE void GC_setGCSignalPending (GC_state s, Bool_t b);
 
 PRIVATE GC_state MLton_gcState ();


### PR DESCRIPTION
 * Fix mismatch in C and SML types for some `_import`-ed runtime functions.
 * Use (default) `impure` attribute for many `_import`-ed runtime functions.