### PR TITLE
Fix bug in `ConstantPropagation` with vector literals.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,8 +9,10 @@ Here are the changes from version 20210117 to YYYYMMDD.
 === Details
 
 * 2021-12-17
+  ** Fix bug in `ConstantPropagation` with vector literals.  Thanks to
+  Ram Raghunathan for the bug report.
   ** Fix mismatch in C and SML types for some `_import`-ed runtime
-     functions.
+  functions.
 
 * 2021-10-21
   ** Migrate website sources from http://asciidoc.org/[AsciiDoc] to

--- a/mlton/ssa/constant-propagation.fun
+++ b/mlton/ssa/constant-propagation.fun
@@ -1374,7 +1374,7 @@ fun transform (program: Program.t): Program.t =
                 | Prim.Vector_sub => sequenceSub vectorSequence
                 | Prim.Vector_vector =>
                      let
-                        val sequence = Sequence.make (args, Type.deArray resultType)
+                        val sequence = Sequence.make (args, Type.deVector resultType)
                      in
                         new (Vector {sequence = sequence}, resultType)
                      end


### PR DESCRIPTION
Closes MLton/mlton#462