### PR TITLE
Fix comment in Makefile and CrossCompiling.adoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ endif
 
 ######################################################################
 
-# remote-bootstrap and remote-add-cross-target
+# remote-bootstrap and remote-add-cross
 
 # The `remote-bootstrap` goal automates the process of bootstraping MLton on a
 # remote machine that doesn't have a suitable pre-compiled `mlton` binary.  It
@@ -496,7 +496,7 @@ endif
 #  * build MLton on the remote machine from clean sources using the boot package
 #  * receive the built binary release from the remote machine
 #
-# The `remote-add-cross-target` goal automates the process of adding a cross
+# The `remote-add-cross` goal automates the process of adding a cross
 # compiler target.  It works as follows:
 #  * send the current sources to a remote machine (using ssh)
 #  * build the MLton runtime system on the remote machine

--- a/doc/guide/src/CrossCompiling.adoc
+++ b/doc/guide/src/CrossCompiling.adoc
@@ -16,8 +16,8 @@ MLton is running on and the _target_ as the machine that MLton is
 compiling for.
 
 To build the MLton runtime system for the target, use the
-`remote-add-cross-target` goal of the root `Makefile`; see comments in
-the root `Makefile`.  The `remote-add-cross-target` goal uses `ssh` to
+`remote-add-cross` goal of the root `Makefile`; see comments in
+the root `Makefile`.  The `remote-add-cross` goal uses `ssh` to
 build the runtime system on a remote machine.  Building the runtime
 system requires compiling and executing programs that determine
 characteristics of the platform, which is why it isn't currently
@@ -27,7 +27,7 @@ cross-compiler toolchain.
 Here is an example adding a `sparc-sun-solaris` cross-compile target
 using the remote machine `blade`:
 ----
-% make CROSS_TARGET=sparc-sun-solaris REMOTE_MACHINE=blade remote-add-cross-target
+% make CROSS_TARGET=sparc-sun-solaris REMOTE_MACHINE=blade remote-add-cross
 ----
 
 Once you have both the MLton runtime system and a cross-compiler


### PR DESCRIPTION
There is no such target called `remote-add-cross-target`.
```console
$ make REMOTE_MACHINE=host remote-add-cross-target
make: *** No rule to make target 'remote-add-cross-target'.  Stop.
```
