### PR TITLE
Fix `normalize_path` in `./bin/mlbdeps`

### DIFF
--- a/bin/mlbdeps
+++ b/bin/mlbdeps
@@ -11,6 +11,11 @@ function normalize_path () {
     local opath=""
     while [ "$opath" != "$path" ]; do
         opath="$path"
+        path="$(echo "$path" | ${SED} -e 's;^\./;;')"
+    done
+    local opath=""
+    while [ "$opath" != "$path" ]; do
+        opath="$path"
         path="$(echo "$path" | ${SED} -e 's;/\./;/;')"
     done
     opath=""


### PR DESCRIPTION
A path of the form `./../lib/stubs/mlkit/basis/sources.mlb` should not be
normalized to `lib/stubs/mlkit/basis/sources.mlb`.