### PR TITLE
Calling convention fix for amd64 and llvm codegens

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,10 +8,13 @@ Here are the changes from version 20210117 to YYYYMMDD.
 
 === Details
 
-* 2022-02020
+* 2022-03-16
+  ** Fix (latent) bug with amd64 and LLVM codegens calling C functions with
+  signed 8-bit and 16-bit arguments.
+
+* 2022-02-20
   ** Fix bug with `-profile time` leading to a segmentation fault.
   Thanks to Byron Zhong for the bug report.
-
 
 * 2022-01-11
   ** Accept a non-semicolon terminated final expression in the syntax

--- a/doc/guide/src/Bugs20210117.adoc
+++ b/doc/guide/src/Bugs20210117.adoc
@@ -3,6 +3,11 @@
 Here are the known bugs in <<Release20210117#,MLton 20210117>>, listed
 in reverse chronological order of date reported.
 
+* [[bug02]]
+Bug with amd64 and LLVM codegens calling C functions with signed 8-bit and 16-bit arguments.
++
+Fixed by commits https://github.com/MLton/mlton/commit/286a54cc0[`286a54cc0`] and https://github.com/MLton/mlton/commit/c4502bdfb[`c4502bdfb`].
+
 * [[bug01]]
 Bug with `-profile time` leading to a segmentation fault.
 +

--- a/mlton/atoms/c-type.fun
+++ b/mlton/atoms/c-type.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2014,2019-2020 Matthew Fluet.
+(* Copyright (C) 2014,2019-2020,2022 Matthew Fluet.
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -169,5 +169,13 @@ val objptrHeader =
 val bool = word (WordSize.bool, {signed = true})
 val compareRes = word (WordSize.compareRes, {signed = true})
 val shiftArg = word (WordSize.shiftArg, {signed = false})
+
+fun isSignedInt t =
+   case t of
+      Int8 => true
+    | Int16 => true
+    | Int32 => true
+    | Int64 => true
+    | _ => false
 
 end

--- a/mlton/atoms/c-type.sig
+++ b/mlton/atoms/c-type.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2014,2019 Matthew Fluet.
+(* Copyright (C) 2014,2019,2022 Matthew Fluet.
  * Copyright (C) 2004-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  *
@@ -38,6 +38,7 @@ signature C_TYPE =
       val csize: unit -> t
       val compareRes: t
       val equals: t * t -> bool
+      val isSignedInt: t -> bool
       val objptrHeader: unit -> t
       val memo: (t -> 'a) -> t -> 'a
       (* name: I{8,16,32,64} R{32,64} W{8,16,32,64} *)


### PR DESCRIPTION
The amd64 and LLVM codegens were not sign extending 8-bit and 16-bit arguments according to the declared C prototype when calling a C function.  While this does not seem to be required by the x86-64 SysV ABI, it is assumed by clang, which could lead to incorrect behavior when SML code called a C function compiled by clang.
