### PR TITLE
Remove unused `numHandlerUses` from SSA and SSA2 shrinker

### DIFF
--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2011,2017,2019 Matthew Fluet.
+(* Copyright (C) 2009,2011,2017,2019,2022 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -27,7 +27,6 @@ structure Array =
       open Array
 
       fun inc (a: int t, i: int): unit = update (a, i, 1 + sub (a, i))
-      fun dec (a: int t, i: int): unit = update (a, i, sub (a, i) - 1)
    end
 
 datatype z = datatype Exp.t
@@ -262,7 +261,6 @@ fun shrinkFunction {globals: Statement.t vector} =
          val inDegree = Array.array (numBlocks, 0)
          fun addLabelIndex i = Array.inc (inDegree, i)
          val isHeader = Array.array (numBlocks, false)
-         val numHandlerUses = Array.array (numBlocks, 0)
          fun layoutLabel (l: Label.t): Layout.t =
             let
                val i = labelIndex l
@@ -382,10 +380,6 @@ fun shrinkFunction {globals: Statement.t vector} =
                 | Call {args, return, ...} =>
                      let
                         val () = incVars args
-                        val () =
-                           Return.foreachHandler
-                           (return, fn l =>
-                            Array.inc (numHandlerUses, labelIndex l))
                         val () = Return.foreachLabel (return, incLabel)
                      in
                         normal ()
@@ -631,21 +625,9 @@ fun shrinkFunction {globals: Statement.t vector} =
                      in
                         case LabelMeaning.aux m of
                            Block =>
-                              let
-                                 val t = Block.transfer (Vector.sub (blocks, i))
-                                 val () = Transfer.foreachLabel (t, deleteLabel)
-                                 val () =
-                                    case t of
-                                       Transfer.Call {return, ...} =>
-                                          Return.foreachHandler
-                                          (return, fn l =>
-                                           Array.dec (numHandlerUses,
-                                                      (LabelMeaning.blockIndex
-                                                       (labelMeaning l))))
-                                     | _ => ()
-                              in
-                                 ()
-                              end
+                              Transfer.foreachLabel
+                              (Block.transfer (Vector.sub (blocks, i)),
+                               deleteLabel)
                          | Bug => ()
                          | Case {cases, default, ...} =>
                               (Cases.foreach (cases, deleteLabel)


### PR DESCRIPTION
The `numHandlerUses` was a vestige of HandlerPush/HandlerPop expressions in the
SSA IR, removed by b7a169a3a.