### PR TITLE
Fix `Date.localOffset` for time zones east of prime meridian

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ Here are the changes from version 20210117 to YYYYMMDD.
 
 === Details
 
+* 2023-0-728
+  ** Fix bug in `Date.localOffset` for time zones east of prime meridian.
+  Thanks to Arata Mizuki (minoki) for the bug report and suggested fix.
+
 * 2023-05-29
   ** Fix bugs in `WORD.scan` when `0` is followed by `w` or `x` or
   `wx` but not by more digits.  Thanks to Arata Mizuki (minoki) for

--- a/basis-library/system/date.sml
+++ b/basis-library/system/date.sml
@@ -300,7 +300,7 @@ structure Date :> DATE =
             else Time.fromSeconds clock
         end
 
-    fun localOffset () = Time.fromSeconds (localoffset () mod 86400)
+    fun localOffset () = Time.fromSeconds (Int.rem (localoffset (), 86400))
 
     local
        val isFormatChar =

--- a/basis-library/system/date.sml
+++ b/basis-library/system/date.sml
@@ -102,7 +102,7 @@ structure Date :> DATE =
     fun mktime_ (t: tmoz): C_Time.t = C_Errno.check (setTmBuf t; Prim.mkTime ())
 
     (* The offset to add to local time to get UTC: positive West of UTC *)
-    val localoffset: int = C_Double.round (Prim.localOffset ())
+    fun localoffset () : int = C_Double.round (Prim.localOffset ())
 
     val toweekday: int -> weekday =
        fn 0 => Sun | 1 => Mon | 2 => Tue | 3 => Wed
@@ -293,14 +293,14 @@ structure Date :> DATE =
            val secoffset = 
               case offset of
                  NONE      => 0
-               | SOME secs => localoffset + secs
+               | SOME secs => localoffset () + secs
             val clock = C_Time.toInt (mktime_ (dateToTmoz date)) - secoffset
         in
             if clock < 0 then raise Date
             else Time.fromSeconds clock
         end
 
-    fun localOffset () = Time.fromSeconds (localoffset mod 86400)
+    fun localOffset () = Time.fromSeconds (localoffset () mod 86400)
 
     local
        val isFormatChar =

--- a/regression/date-localOffset.ok
+++ b/regression/date-localOffset.ok
@@ -1,0 +1,3 @@
+TZ = UTC+4 :: Date.localOffset () = 14400.000
+TZ = UTC+0 :: Date.localOffset () = 0.000
+TZ = UTC-4 :: Date.localOffset () = ~14400.000

--- a/regression/date-localOffset.sml
+++ b/regression/date-localOffset.sml
@@ -1,0 +1,12 @@
+fun doit tz =
+   let
+      val () = MLton.ProcEnv.setenv {name = "TZ", value = tz}
+      val lo = Date.localOffset ()
+   in
+      app print
+      ["TZ = ", tz, " :: Date.localOffset () = ", Time.toString lo, "\n"]
+   end
+
+val () = doit "UTC+4"
+val () = doit "UTC+0"
+val () = doit "UTC-4"


### PR DESCRIPTION
Fix bug in `Date.localOffset` for time zones east of prime meridian.

Closes MLton/mlton#499.