### PR TITLE
Fix `RegisterAllocation.toAddressMemLoc:disp` internal compiler error

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,9 +8,16 @@ Here are the changes from version 20210117 to YYYYMMDD.
 
 === Details
 
-* 2023-0-728
-  ** Fix bug in `Date.localOffset` for time zones east of prime meridian.
-  Thanks to Arata Mizuki (minoki) for the bug report and suggested fix.
+* 2023-08-31
+  ** Fix bug in x86 and amd64 native codegens leading to an internal
+  compiler error
+  (`Fail: amd64AllocateRegisters.RegisterAllocation.toAddressMemLoc:disp`).
+  Thanks to Darin Minamoto (DarinM223) for the bug report.
+
+* 2023-07-28
+  ** Fix bug in `Date.localOffset` for time zones east of prime
+  meridian.  Thanks to Arata Mizuki (minoki) for the bug report and
+  suggested fix.
 
 * 2023-05-29
   ** Fix bugs in `WORD.scan` when `0` is followed by `w` or `x` or

--- a/mlton/codegen/amd64-codegen/amd64-allocate-registers.fun
+++ b/mlton/codegen/amd64-codegen/amd64-allocate-registers.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010,2020 Matthew Fluet.
+(* Copyright (C) 2010,2020,2023 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -3775,6 +3775,8 @@ struct
                              Immediate.labelPlusWord (l1, w2)
                         | (Immediate.LabelPlusWord (l1, w1), Immediate.Word w2) => 
                              Immediate.labelPlusWord (l1, WordX.add (w1, w2))
+                        | (Immediate.Word w1, Immediate.Word w2) =>
+                             Immediate.word (WordX.add (w1, w2))
                         | _ => Error.bug "amd64AllocateRegisters.RegisterAllocation.toAddressMemLoc:disp")
               
               (* The base register gets supplied by three distinct cases:

--- a/mlton/codegen/x86-codegen/x86-allocate-registers.fun
+++ b/mlton/codegen/x86-codegen/x86-allocate-registers.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010,2020 Matthew Fluet.
+(* Copyright (C) 2010,2020,2023 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -3501,6 +3501,8 @@ struct
                              Immediate.labelPlusWord (mungeLabel l1, w2)
                         | (Immediate.LabelPlusWord (l1, w1), Immediate.Word w2) => 
                              Immediate.labelPlusWord (mungeLabel l1, WordX.add (w1, w2))
+                        | (Immediate.Word w1, Immediate.Word w2) =>
+                             Immediate.word (WordX.add (w1, w2))
                         | _ => Error.bug "x86AllocateRegisters.RegisterAllocation.toAddressMemLoc:disp")
 
               val {register = register_base,


### PR DESCRIPTION
Fix bug in x86 and amd64 native codegens leading to an internal compiler error
(`Fail: amd64AllocateRegisters.RegisterAllocation.toAddressMemLoc:disp`).

Thanks to Darin Minamoto (DarinM223) for the bug report.

Closes MLton/mlton#509