### PR TITLE
Add $(MLTON_GEN_SOURCES) as dependency of $(MLTON_OUTPUT_SMLNJ_HEAP).d

### DIFF
--- a/mlton/Makefile
+++ b/mlton/Makefile
@@ -215,7 +215,7 @@ $(MLTON_OUTPUT_SMLNJ_HEAP):
 		echo 'SMLofNJ.exportFn("$@",Main.main);'			\
 	) | CM_VERBOSE=false CONTROL_POLY_EQ_WARN=false "$(SMLNJ)" -DSMLNJ_PATCH_VERSION=$(SMLNJ_PATCH_VERSION)
 
-$(MLTON_OUTPUT_SMLNJ_HEAP).d: $(shell $(FIND) ../lib/stubs -type f -name '*.cm') $(shell $(FIND) ../lib/mlyacc-lib -type f -name '*.cm') $(shell $(FIND) ../lib/mlton -type f -name '*.cm') $(shell $(FIND) . -type f -name '*.cm')
+$(MLTON_OUTPUT_SMLNJ_HEAP).d: $(shell $(FIND) ../lib/stubs -type f -name '*.cm') $(shell $(FIND) ../lib/mlyacc-lib -type f -name '*.cm') $(shell $(FIND) ../lib/mlton -type f -name '*.cm') $(shell $(FIND) . -type f -name '*.cm') $(MLTON_GEN_SOURCES)
 	@$(RM) $@
 	@touch $@
 	CM_VERBOSE=false $(SMLNJ_MAKEDEPEND) -DSMLNJ_PATCH_VERSION=$(SMLNJ_PATCH_VERSION) -n -f $@ mlton-smlnj.cm $@ || ($(RM) $@ ; exit 1)


### PR DESCRIPTION
Closes MLton/mlton#519

SML/NJ CM, indirectly through the `ml-makedepend` tool, requires all source files mentioned in scanned `.cm` files to exist.  Ensure that the generated source files (e.g., `../lib/stubs/mlton-stubs/pre-mlton.sml`, `control/version.sml`, and `front-end/*`) exist before trying to generate $(MLTON_OUTPUT_SMLNJ_HEAP).d.