### PR TITLE
Use "fixed" `structure Real64` with recent versions of SML/NJ

### DIFF
--- a/lib/stubs/smlnj/basis/sources.cm
+++ b/lib/stubs/smlnj/basis/sources.cm
@@ -85,9 +85,7 @@ real.0.sml
 real.1.sml
 #endif
 ../../common/basis/real32-via-real.sml
-#if SMLNJ_VERSION < 110 orelse (SMLNJ_VERSION = 110 andalso SMLNJ_MINOR_VERSION < 99) orelse (SMLNJ_VERSION = 110 andalso SMLNJ_MINOR_VERSION = 99 andalso SMLNJ_PATCH_VERSION < 3)
 ../../common/basis/real64-via-real.sml
-#endif
 
 #if SMLNJ_VERSION < 110 orelse (SMLNJ_VERSION = 110 andalso SMLNJ_MINOR_VERSION < 91)
 ../../common/basis/pack-word64-dummy.sml


### PR DESCRIPTION
Closes MLton/mlton#523

Although SML/NJ 110.99.3 fixed some issues with `structure Real{,64}` failing to match the SML Basis Library specification, it did not implement `Real.fmt StringCvt.EXACT`.  So, a "fixed" version of `structure Real64` needs to be exported (rather than exposing the version of `structure Real64` from `$/basis.cm`) and it is simplest to revert back to `structure Real64 = Real` (where `structure Real = FixReal(struct open Pervasive.Real end)`).