### PR TITLE
Correct target in generated $(MLTON_OUTPUT_SMLNJ_HEAP).d file

### DIFF
--- a/mlton/Makefile
+++ b/mlton/Makefile
@@ -218,7 +218,7 @@ $(MLTON_OUTPUT_SMLNJ_HEAP):
 $(MLTON_OUTPUT_SMLNJ_HEAP).d: $(shell $(FIND) ../lib/stubs -type f -name '*.cm') $(shell $(FIND) ../lib/mlyacc-lib -type f -name '*.cm') $(shell $(FIND) ../lib/mlton -type f -name '*.cm') $(shell $(FIND) . -type f -name '*.cm') $(MLTON_GEN_SOURCES)
 	@$(RM) $@
 	@touch $@
-	CM_VERBOSE=false $(SMLNJ_MAKEDEPEND) -DSMLNJ_PATCH_VERSION=$(SMLNJ_PATCH_VERSION) -n -f $@ mlton-smlnj.cm $@ || ($(RM) $@ ; exit 1)
+	CM_VERBOSE=false $(SMLNJ_MAKEDEPEND) -DSMLNJ_PATCH_VERSION=$(SMLNJ_PATCH_VERSION) -n -f $@ mlton-smlnj.cm $(MLTON_OUTPUT_SMLNJ_HEAP) || ($(RM) $@ ; exit 1)
 -include $(MLTON_OUTPUT_SMLNJ_HEAP).d
 endif
 


### PR DESCRIPTION
The `ml-makedepend` invocation should use `$(MLTON_OUTPUT_SMLNJ_HEAP)` as the target, rather than `$@` (which corresponds to `$(MLTON_OUTPUT_SMLNJ_HEAP).d`).