### PR TITLE
Fix bug in X86GenerateTransfers introduced by 286a54cc0.

### DIFF
--- a/mlton/codegen/x86-codegen/x86-generate-transfers.fun
+++ b/mlton/codegen/x86-codegen/x86-generate-transfers.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2019-2022 Matthew Fluet.
+(* Copyright (C) 2009,2019-2023 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -1130,9 +1130,16 @@ struct
                                     size = #2 fptrArg}),
                                   args)
                               end
+                     val protoArgs =
+                        Vector.foldr
+                        (protoArgs, [], fn (protoArg, protoArgs) =>
+                         case protoArg of
+                            CType.Int64 => CType.Word32 :: CType.Word32 :: protoArgs
+                          | CType.Word64 => CType.Word32 :: CType.Word32 :: protoArgs
+                          | _ => protoArg :: protoArgs)
                      val (pushArgs, size_args)
                        = List.fold2
-                         (args, Vector.toList protoArgs, (AppendList.empty, 0),
+                         (args, protoArgs, (AppendList.empty, 0),
                           fn ((arg, size), protoArg, (assembly_args, size_args)) =>
                           let
                              val (assembly_arg, size_arg) =


### PR DESCRIPTION
Commit 286a54cc0 introduced a dependency on the declared prototype of a C function when generating the assembly for a C function call, in order to properly sign extend 8-bit and 16-bit arguments.

Early in the x86 codegen, Word64 values are converted into pairs of Word32 values, so a C function call with Word64 values will converted to a call with pairs of Word32 values for those arguments (increasing the number of arguments relative to the earlier IRs).  But, no such translation was made to the C function's prototype, which continued to use Int64 and Word64 types.  This lead to a `Fail: fold2` internal-compiler error due to the mismatch in the number of actual arguments and the number of prototype arguments.

A simple solution is to expand the Int64 and Word64 prototype arguments to pairs of Word32 arguments (signedness does not matter).