### PR TITLE
mlton-script: OpenBSD link-opt for no xonly text

### DIFF
--- a/bin/mlton-script
+++ b/bin/mlton-script
@@ -121,6 +121,7 @@ for arg in "$@"; do
                -target-link-opt mingw                                   \
                        '-lws2_32 -lkernel32 -lpsapi -lnetapi32 -lwinmm' \
                -target-link-opt mingw '-Wl,--enable-stdcall-fixup'      \
+               -target-link-opt openbsd '-Wl,--no-execute-only'         \
                -target-link-opt solaris '-lnsl -lsocket -lrt'           \
                -target-link-opt x86 '-m32'                              \
                -profile-exclude '\$\(SML_LIB\)'


### PR DESCRIPTION
Add a `-target-link-opt` for OpenBSD that disables "xonly" text.

OpenBSD's linker, by default, makes a program's text segment executable-only ("xonly"): that is, executable but not readable. However, MLton needs to be able to read the text segment when mapping return addresses to stack frame indices, possibly among other things.  This causes programs compiled with MLton's native code generator to fault and die with `SIGSEGV`.

However, the default "xonly" behavior can be disabled with a linker option (`--no-execute-only`), so we can turn it off with a `-target-link-opt` specific to OpenBSD in `mlton-script`. Binaries built in this configuration run as expected.

Fixes #538