### PR TITLE
A handful of improvements related to cross compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,11 @@ runtime:
 	echo "GMP_INC_DIR=\"$(WITH_GMP_INC_DIR)\"" >> "$(LIB)/targets/$(TARGET)/vars"
 	echo "GMP_LIB_DIR=\"$(WITH_GMP_LIB_DIR)\"" >> "$(LIB)/targets/$(TARGET)/vars"
 
+.PHONY: install-runtime
+install-runtime:
+	$(MKDIR) "$(TLIB)/targets/$(TARGET)"
+	$(CP) "$(LIB)/targets/$(TARGET)" "$(TLIB)/targets/"
+
 .PHONY: script
 script:
 	$(SED) \

--- a/Makefile
+++ b/Makefile
@@ -154,15 +154,15 @@ runtime:
 		$(MKDIR) "$(INC)/$$d";					\
 		$(CP) "$(SRC)/runtime/$$d/"*.h "$(INC)/$$d";		\
 	done
+	echo "EXE=\"$(EXE)\""                       > "$(LIB)/targets/$(TARGET)/vars"
+	echo "CC=\"$(CC)\""                        >> "$(LIB)/targets/$(TARGET)/vars"
+	echo "GMP_INC_DIR=\"$(WITH_GMP_INC_DIR)\"" >> "$(LIB)/targets/$(TARGET)/vars"
+	echo "GMP_LIB_DIR=\"$(WITH_GMP_LIB_DIR)\"" >> "$(LIB)/targets/$(TARGET)/vars"
 
 .PHONY: script
 script:
 	$(SED) \
 		-e "s;^LIB_REL_BIN=.*;LIB_REL_BIN=\"$(LIB_REL_BIN)\";" \
-		-e "s;^EXE=.*;EXE=\"$(EXE)\";" \
-		-e "s;^CC=.*;CC=\"$(CC)\";" \
-		-e "s;^GMP_INC_DIR=.*;GMP_INC_DIR=\"$(WITH_GMP_INC_DIR)\";" \
-		-e "s;^GMP_LIB_DIR=.*;GMP_LIB_DIR=\"$(WITH_GMP_LIB_DIR)\";" \
 		-e 's/mlton-compile/$(MLTON_OUTPUT)/' \
 		-e "s;^    SMLNJ=.*;    SMLNJ=\"$(SMLNJ)\";" \
 		< "$(SRC)/bin/mlton-script" > "$(BIN)/$(MLTON)"

--- a/Makefile.binary
+++ b/Makefile.binary
@@ -65,14 +65,13 @@ install:
 
 .PHONY: update
 update:
-	$(CP) "$(SBIN)/mlton" "$(SBIN)/mlton.bak"
+	$(CP) "$(SLIB)/targets/self/vars" "$(SLIB)/targets/self/vars.bak"
 	$(SED) \
 		-e "s;^CC=.*;CC=\"$(CC)\";" \
 		-e "s;^GMP_INC_DIR=.*;GMP_INC_DIR=$(if $(WITH_GMP_INC_DIR),\"$(WITH_GMP_INC_DIR)\");" \
 		-e "s;^GMP_LIB_DIR=.*;GMP_LIB_DIR=$(if $(WITH_GMP_LIB_DIR),\"$(WITH_GMP_LIB_DIR)\");" \
-		< "$(SBIN)/mlton.bak" > "$(SBIN)/mlton"
-	chmod a+x "$(SBIN)/mlton"
-	$(RM) "$(SBIN)/mlton.bak"
+		< "$(SLIB)/targets/self/vars.bak" > "$(SLIB)/targets/self/vars"
+	$(RM) "$(SLIB)/targets/self/vars.bak"
 	$(CP) "$(SLIB)/targets/self/constants" "$(SLIB)/targets/self/constants.bak"
 	$(SED) \
 		-e "s;^default::pie=.*;default::pie=$(subst __pie__,0,$(shell echo "__pie__" | $(CC) -P -E -));" \

--- a/bin/mlton-script
+++ b/bin/mlton-script
@@ -5,20 +5,31 @@
 
 LIB_REL_BIN="../lib/mlton"
 
-EXE=
-
-CC="cc"
-
-# You may need to set 'GMP_INC_DIR' so the C compiler can find gmp.h.
-GMP_INC_DIR=
-# You may need to set 'GMP_LIB_DIR' so the C compiler can find libgmp.
-GMP_LIB_DIR=
-
-
 set -e
 
 dir=$(dirname "$0")
 lib=$(cd "$dir/$LIB_REL_BIN" && pwd)
+
+# Find if "-target" is set, to read cross-specific variables.
+# Default to "self".
+TARGET=self
+prev_arg=
+for arg in "$@"
+do
+    if [ "$prev_arg" = "-target" ]; then
+        TARGET="$arg"
+    fi
+    prev_arg="$arg"
+done
+
+TARGET_VARS="$lib/targets/$TARGET/vars"
+if [ ! -f "$TARGET_VARS" ]; then
+        echo "Unable to read $TARGET_VARS." >&2
+        exit 1
+fi
+. "$TARGET_VARS"
+
+
 
 
 doitMLton () {

--- a/bin/regression
+++ b/bin/regression
@@ -88,12 +88,12 @@ compFail () {
 "$mlton" -verbose 1 || (echo 'no mlton present' && exitFail=true)
 echo "flags = ${flags[*]}"
 
-TARGET_ARCH=$("$mlton" -show path-map | sed -n 's/TARGET_ARCH \(.*\)/\1/p')
-TARGET_OS=$("$mlton" -show path-map | sed -n 's/TARGET_OS \(.*\)/\1/p')
-OBJPTR_REP=$("$mlton" -show path-map | sed -n 's/OBJPTR_REP \(.*\)/\1/p')
+TARGET_ARCH=$("$mlton" "${flags[@]}" -show path-map | sed -n 's/TARGET_ARCH \(.*\)/\1/p')
+TARGET_OS=$("$mlton" "${flags[@]}" -show path-map | sed -n 's/TARGET_OS \(.*\)/\1/p')
+OBJPTR_REP=$("$mlton" "${flags[@]}" -show path-map | sed -n 's/OBJPTR_REP \(.*\)/\1/p')
 ALIGN=$(echo "${flags[@]}" | sed -n 's/.*-align \(.\).*/\1/p')
 if [ -z "$ALIGN" ]; then
-    ALIGN=$("$mlton" -z 2>&1 | sed -n 's/.*-align {\(.\).*/\1/p')
+    ALIGN=$("$mlton" "${flags[@]}" -z 2>&1 | sed -n 's/.*-align {\(.\).*/\1/p')
 fi
 
 cd "$src/regression"

--- a/runtime/basis/Real/IEEEReal-consts.c
+++ b/runtime/basis/Real/IEEEReal-consts.c
@@ -1,7 +1,27 @@
 #include "platform.h"
 
-const C_Int_t IEEEReal_RoundingMode_FE_TONEAREST = FE_TONEAREST;
-const C_Int_t IEEEReal_RoundingMode_FE_DOWNWARD = FE_DOWNWARD;
 const C_Int_t IEEEReal_RoundingMode_FE_NOSUPPORT = FE_NOSUPPORT;
+
+#ifdef FE_TONEAREST
+const C_Int_t IEEEReal_RoundingMode_FE_TONEAREST = FE_TONEAREST;
+#else
+const C_Int_t IEEEReal_RoundingMode_FE_TONEAREST = FE_NOSUPPORT;
+#endif
+
+#ifdef FE_DOWNWARD
+const C_Int_t IEEEReal_RoundingMode_FE_DOWNWARD = FE_DOWNWARD;
+#else
+const C_Int_t IEEEReal_RoundingMode_FE_DOWNWARD = FE_NOSUPPORT;
+#endif
+
+#ifdef FE_UPWARD
 const C_Int_t IEEEReal_RoundingMode_FE_UPWARD = FE_UPWARD;
+#else
+const C_Int_t IEEEReal_RoundingMode_FE_UPWARD = FE_NOSUPPORT;
+#endif
+
+#ifdef FE_TOWARDZERO
 const C_Int_t IEEEReal_RoundingMode_FE_TOWARDZERO = FE_TOWARDZERO;
+#else
+const C_Int_t IEEEReal_RoundingMode_FE_TOWARDZERO = FE_NOSUPPORT;
+#endif

--- a/runtime/gc/gc_state.h
+++ b/runtime/gc/gc_state.h
@@ -113,4 +113,4 @@ PRIVATE void GC_setGCSignalHandled (GC_state s, Bool_t b);
 PRIVATE Bool_t GC_getGCSignalPending (GC_state s);
 PRIVATE void GC_setGCSignalPending (GC_state s, Bool_t b);
 
-PRIVATE GC_state MLton_gcState ();
+PRIVATE GC_state MLton_gcState (void);

--- a/runtime/gc/init.c
+++ b/runtime/gc/init.c
@@ -342,7 +342,7 @@ int GC_init (GC_state s, int argc, char **argv) {
   s->saveWorldStatus = true;
 
   initIntInf (s);
-  initSignalStack (s);
+  initSignalStack ();
   worldFile = NULL;
 
   unless (isAligned (s->sysvals.pageSize, CARD_SIZE))

--- a/runtime/gc/profiling.h
+++ b/runtime/gc/profiling.h
@@ -107,7 +107,10 @@ PRIVATE GC_profileData profileMalloc (GC_state s);
 PRIVATE void profileWrite (GC_state s, GC_profileData p, const char* fileName);
 PRIVATE void profileFree (GC_state s, GC_profileData p);
 
+#if HAS_TIME_PROFILING
 static void GC_handleSigProf (int signum);
+#endif
+
 static void setProfTimer (suseconds_t usec);
 static void initProfilingTime (GC_state s);
 static void atexitForProfiling (void);

--- a/runtime/gc/profiling.h
+++ b/runtime/gc/profiling.h
@@ -107,7 +107,7 @@ PRIVATE GC_profileData profileMalloc (GC_state s);
 PRIVATE void profileWrite (GC_state s, GC_profileData p, const char* fileName);
 PRIVATE void profileFree (GC_state s, GC_profileData p);
 
-static void GC_handleSigProf ();
+static void GC_handleSigProf (int signum);
 static void setProfTimer (suseconds_t usec);
 static void initProfilingTime (GC_state s);
 static void atexitForProfiling (void);

--- a/runtime/gc/signals.c
+++ b/runtime/gc/signals.c
@@ -9,12 +9,12 @@
 
 #if not HAS_SIGALTSTACK
 
-void initSignalStack () {
+void initSignalStack (void) {
 }
 
 #else
 
-void initSignalStack () {
+void initSignalStack (void) {
   static stack_t altstack = { .ss_sp = NULL, .ss_size = 0, .ss_flags = 0 };
 
   if (! altstack.ss_sp) {
@@ -33,6 +33,6 @@ void initSignalStack () {
 
 #endif
 
-void GC_initSignalStack () {
+void GC_initSignalStack (void) {
   initSignalStack ();
 }

--- a/runtime/gc/signals.h
+++ b/runtime/gc/signals.h
@@ -32,8 +32,8 @@ struct GC_signalsInfo {
 
 #if (defined (MLTON_GC_INTERNAL_FUNCS))
 
-static void initSignalStack ();
+static void initSignalStack (void);
 
 #endif /* (defined (MLTON_GC_INTERNAL_FUNCS)) */
 
-void GC_initSignalStack ();
+void GC_initSignalStack (void);


### PR DESCRIPTION
This was split off of #550.

- Two of these fix some minor compiler warnings.
- One automates rounding mode detection (WASM only supports the 1 rounding mode, and it turns out POSIX already provides a mechanism to detect this).
- The last three commits make it easier to build and install multiple cross-compiler targets at the same time.