### PR TITLE
Switch from `macos-latest` to `macos-13`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         cc: ["gcc", "clang"]
         codegen: ["amd64", "c", "llvm"]
         exclude:


### PR DESCRIPTION
`macos-latest` has switched to `macos-14` (`arm64`), which will be nice to use, but will require some additional updates.