### PR TITLE
Fix bug in heap translation

### DIFF
--- a/runtime/gc/translate.c
+++ b/runtime/gc/translate.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010,2019-2020 Matthew Fluet.
+/* Copyright (C) 2010,2019-2020,2024 Matthew Fluet.
  * Copyright (C) 1999-2007 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -26,7 +26,7 @@ void translateFun (__attribute__((unused)) GC_state s, objptr *opp, void *env) {
   to = translateState->to;
   p = objptrToPointer (*opp, from);
   if ((from <= p) and
-      (p < from + translateState->size)) {
+      (p <= from + translateState->size)) {
     p = (p - from) + to;
     *opp = pointerToObjptr (p, to);
   }


### PR DESCRIPTION
It is valid for an object pointer to point to the "end" of the heap (`s->heap.start + s->heap.oldGenSize`) if it is a pointer to an object of zero size, such as a zero-length array/vector or a `unit array` or `unit ref`, in which case the object proper does not extend beyond the "end" of heap.

Closes MLton/mlton#560