### PR TITLE
LLVM opaque pointers

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ Here are the changes from version 20210117 to YYYYMMDD.
 
 === Details
 
+* 2024-08-09
+  ** Update the LLVM codegen to generate LLVM IR using opaque
+  pointers; using the LLVM codegen requires LLVM 15 (or higher).
+
 * 2024-05-22
   ** Optimize representation of sequences in `Useless` SSA
   optimization.

--- a/doc/guide/src/LLVMCodegen.adoc
+++ b/doc/guide/src/LLVMCodegen.adoc
@@ -31,6 +31,10 @@ As of 20230522, MLton requires LLVM 14, as it invokes `opt` using the
 https://releases.llvm.org/14.0.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir:["new
 pass manager"].
 
+As of 20240809, MLton requires LLVM 15, as it generates LLVM IR using
+https://releases.llvm.org/15.0.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir:["opaque
+pointers"].
+
 == Implementation
 
 * https://github.com/MLton/mlton/blob/master/mlton/codegen/llvm-codegen/llvm-codegen.sig[`llvm-codegen.sig`]


### PR DESCRIPTION
Update the LLVM codegen to generate LLVM IR using opaque pointers; using the LLVM codegen requires LLVM 15 (or higher).
