### PR TITLE
MinGW spawn prototypes update

### DIFF
--- a/runtime/basis/MLton/Process/spawne.c
+++ b/runtime/basis/MLton/Process/spawne.c
@@ -24,8 +24,8 @@ C_Errno_t(C_PId_t) MLton_Process_spawne (NullString8_t pNStr,
   eSaved = env[eLen - 1];
   env[eLen - 1] = NULL;
   res = spawnve (SPAWN_MODE, path, 
-                 (const char * const *)args,
-                 (const char * const *)env);
+                 (char * const *)args,
+                 (char * const *)env);
   /* spawnve failed */
   args[aLen - 1] = aSaved;
   env[eLen - 1] = eSaved;

--- a/runtime/basis/MLton/Process/spawnp.c
+++ b/runtime/basis/MLton/Process/spawnp.c
@@ -16,7 +16,7 @@ C_Errno_t(C_PId_t) MLton_Process_spawnp (NullString8_t pNStr,
   aSaved = args[aLen - 1];
   args[aLen - 1] = NULL;
   res = spawnvp (SPAWN_MODE, path, 
-                 (const char * const *)args);
+                 (char * const *)args);
   /* spawnvp failed */
   args[aLen - 1] = aSaved;
   return (C_Errno_t(C_PId_t))res;


### PR DESCRIPTION
Update pointer casts to match MinGW's prototypes for `spawn{p,ve}`