### PR TITLE
Introduce options to control profiling-specific optimizations

### DIFF
--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -440,6 +440,8 @@ signature CONTROL_FLAGS =
 
       val profileInclExcl: (Regexp.Compiled.t * bool) list ref
 
+      val profileIntroLoopsOpt: bool ref
+
       val profileRaise: bool ref
 
       val profileStack: bool ref

--- a/mlton/control/control-flags.sig
+++ b/mlton/control/control-flags.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012,2014-2017,2019-2021 Matthew Fluet.
+(* Copyright (C) 2009-2012,2014-2017,2019-2021,2025 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -443,6 +443,8 @@ signature CONTROL_FLAGS =
       val profileRaise: bool ref
 
       val profileStack: bool ref
+
+      val profileTailCallOpt: bool ref
 
       val profileVal: bool ref
 

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1487,6 +1487,10 @@ val profileInclExcl =
                         (Layout.tuple2 (Regexp.Compiled.layout, 
                                         Bool.layout)))}
 
+val profileIntroLoopsOpt = control {name = "perform intro loops optimization when profiling",
+                                    default = true,
+                                    toString = Bool.toString}
+
 val profileRaise = control {name = "profile raise",
                             default = false,
                             toString = Bool.toString}

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009-2012,2014-2017,2019-2021 Matthew Fluet.
+(* Copyright (C) 2009-2012,2014-2017,2019-2021,2025 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -1494,6 +1494,10 @@ val profileRaise = control {name = "profile raise",
 val profileStack = control {name = "profile stack",
                             default = false,
                             toString = Bool.toString}
+
+val profileTailCallOpt = control {name = "optimize tail calls when profiling",
+                                  default = true,
+                                  toString = Bool.toString}
 
 val profileVal = control {name = "profile val",
                           default = false,

--- a/mlton/control/control-flags.sml
+++ b/mlton/control/control-flags.sml
@@ -1495,7 +1495,7 @@ val profileStack = control {name = "profile stack",
                             default = false,
                             toString = Bool.toString}
 
-val profileTailCallOpt = control {name = "optimize tail calls when profiling",
+val profileTailCallOpt = control {name = "perform tail call optimization when profiling",
                                   default = true,
                                   toString = Bool.toString}
 

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -807,7 +807,7 @@ fun makeOptions {usage} =
         boolRef profileRaise),
        (Normal, "profile-stack", " {false|true}", "profile the stack",
         boolRef profileStack),
-       (Expert, "profile-tail-call-opt", " {true|false}", "optimize tail calls when profiling",
+       (Expert, "profile-tail-call-opt", " {true|false}", "perform tail call optimization when profiling",
         boolRef profileTailCallOpt),
        (Normal, "profile-val", " {false|true}",
         "profile val bindings in addition to functions",

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2010-2011,2013-2022,2024 Matthew Fluet.
+(* Copyright (C) 2010-2011,2013-2022,2024-2025 Matthew Fluet.
  * Copyright (C) 1999-2009 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -807,6 +807,8 @@ fun makeOptions {usage} =
         boolRef profileRaise),
        (Normal, "profile-stack", " {false|true}", "profile the stack",
         boolRef profileStack),
+       (Expert, "profile-tail-call-opt", " {true|false}", "optimize tail calls when profiling",
+        boolRef profileTailCallOpt),
        (Normal, "profile-val", " {false|true}",
         "profile val bindings in addition to functions",
         boolRef profileVal),

--- a/mlton/main/main.fun
+++ b/mlton/main/main.fun
@@ -802,6 +802,8 @@ fun makeOptions {usage} =
                             in List.push (profileInclExcl, (re, true))
                             end
            | NONE => usage (concat ["invalid -profile-include flag: ", s])))),
+       (Expert, "profile-intro-loops-opt", " {true|false}", "perform intro loops optimization when profiling",
+        boolRef profileIntroLoopsOpt),
        (Expert, "profile-raise", " {false|true}",
         "profile raises in addition to functions",
         boolRef profileRaise),

--- a/mlton/ssa/introduce-loops.fun
+++ b/mlton/ssa/introduce-loops.fun
@@ -1,4 +1,5 @@
-(* Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
+(* Copyright (C) 2025 Matthew Fluet.
+ * Copyright (C) 1999-2005, 2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
  *
@@ -16,25 +17,75 @@ open S
 datatype z = datatype Exp.t
 datatype z = datatype Transfer.t
 
-structure Return =
+structure LabelInfo =
    struct
-      open Return
-
-      fun isTail (z: t): bool =
-         case z of
-            Dead => false
-          | NonTail _ => false
-          | Tail => true
+      datatype t =
+         Block
+       | RaiseEta
+       | ReturnEta of {profileStmts: Statement.t vector}
    end
 
 fun transform (Program.T {datatypes, globals, functions, main}) =
    let
+      val shrink = shrinkFunction {globals = globals}
+
       val functions =
          List.revMap
          (functions, fn f =>
           let
              val {args, blocks, mayInline, name, raises, returns, start} =
                 Function.dest f
+             val {get = labelInfo, set = setLabelInfo, ...} =
+                Property.getSetOnce
+                (Label.plist, Property.initConst LabelInfo.Block)
+             val _ =
+                Vector.foreach
+                (blocks, fn Block.T {label, args = formals, statements, transfer} =>
+                 let
+                    fun rr (actuals, make) =
+                       if Vector.length formals = Vector.length actuals
+                          andalso
+                          Vector.forall2
+                          (formals, actuals, fn ((formal, _), actual) =>
+                           Var.equals (formal, actual))
+                          andalso
+                          Vector.forall (statements, Statement.isProfile)
+                          then setLabelInfo (label, make {profileStmts = statements})
+                       else ()
+                 in
+                    case transfer of
+                       Transfer.Raise actuals =>
+                          rr (actuals, fn _ => LabelInfo.RaiseEta)
+                     | Transfer.Return actuals =>
+                          rr (actuals, LabelInfo.ReturnEta)
+                     | _ => ()
+                 end)
+
+             fun returnIsTail return =
+                let
+                   fun maybe profileStmts =
+                      if Vector.isEmpty profileStmts
+                         orelse !Control.profileIntroLoopsOpt
+                         then SOME {profileStmts = profileStmts}
+                      else NONE
+                in
+                   case return of
+                      Return.Dead => NONE
+                    | Return.NonTail {cont, handler} =>
+                         (case labelInfo cont of
+                             LabelInfo.ReturnEta {profileStmts} =>
+                                (case handler of
+                                    Handler.Caller => maybe profileStmts
+                                  | Handler.Dead => maybe profileStmts
+                                  | Handler.Handle handler =>
+                                       (case labelInfo handler of
+                                           LabelInfo.RaiseEta =>
+                                              maybe profileStmts
+                                         | _ => NONE))
+                           | _ => NONE)
+                    | Return.Tail => SOME {profileStmts = Vector.new0 ()}
+                end
+
              val tailCallsItself = ref false
              val _ =
                 Vector.foreach
@@ -42,7 +93,7 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                  case transfer of
                     Call {func, return, ...} =>
                        if Func.equals (name, func)
-                          andalso Return.isTail return
+                          andalso Option.isSome (returnIsTail return)
                           then tailCallsItself := true
                        else ()
                   | _ => ())
@@ -65,15 +116,19 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                             (blocks,
                              fn Block.T {label, args, statements, transfer} =>
                              let
-                                val transfer =
+                                val (statements, transfer) =
                                    case transfer of
                                       Call {func, args, return} =>
-                                         if Func.equals (name, func)
-                                            andalso Return.isTail return
-                                            then Goto {dst = loopName, 
-                                                       args = args}
-                                         else transfer
-                                    | _ => transfer
+                                         (case (Func.equals (name, func),
+                                                returnIsTail return) of
+                                             (true, SOME {profileStmts}) =>
+                                                (if Vector.isEmpty profileStmts
+                                                    then statements
+                                                 else Vector.concat [statements, profileStmts],
+                                                 Goto {dst = loopName,
+                                                       args = args})
+                                           | _ => (statements, transfer))
+                                    | _ => (statements, transfer)
                              in
                                 Block.T {label = label,
                                          args = args,
@@ -102,13 +157,14 @@ fun transform (Program.T {datatypes, globals, functions, main}) =
                       end
                 else (args, start, blocks)
           in
-             Function.new {args = args,
-                           blocks = blocks,
-                           mayInline = mayInline,
-                           name = name,
-                           raises = raises,
-                           returns = returns,
-                           start = start}
+             (shrink o Function.new)
+             {args = args,
+              blocks = blocks,
+              mayInline = mayInline,
+              name = name,
+              raises = raises,
+              returns = returns,
+              start = start}
           end)
    in
       Program.T {datatypes = datatypes,

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -12,22 +12,6 @@ struct
 
 open S
 
-structure Exp =
-   struct
-      open Exp
-
-      val isProfile =
-         fn Profile _ => true
-          | _ => false
-   end
-
-structure Statement =
-   struct
-      open Statement
-
-      fun isProfile (T {exp, ...}) = Exp.isProfile exp
-   end
-
 structure Array =
    struct
       open Array

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -787,6 +787,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                                     end
                                  fun tail profileStatements =
                                     (deleteLabelMeaning contMeaning
+                                     ; Handler.foreachLabel (handler, deleteLabel)
                                      ; (profileStatements, Return.Tail))
                                  fun cont (handler, handlerProfileStatements) =
                                     case LabelMeaning.aux contMeaning of

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -813,7 +813,8 @@ fun shrinkFunction {globals: Statement.t vector} =
                                            | LabelMeaning.Raise {args, profileStmts} =>
                                                 if isEta (handlerMeaning, args)
                                                    then cont (if List.isEmpty profileStmts
-                                                                 then Handler.Caller
+                                                                 then (deleteLabel l
+                                                                       ; Handler.Caller)
                                                                  else handler,
                                                               SOME profileStmts)
                                                 else nonTail handler

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -328,36 +328,10 @@ fun shrinkFunction {globals: Statement.t vector} =
                fun rr (xs: Var.t vector, make) =
                   let
                      val _ = incVars xs
-(*
-                     val n = Vector.length statements
-                     fun loop (i, ac) =
-                        if i = n
-                           then
-                              if 0 = Vector.length xs
-                                 orelse 0 < Vector.length args
-                                 then doit (make {args = extract xs,
-                                                  profileStmts = rev ac})
-                              else normal ()
-                        else
-                           let
-                              val Statement.T {exp, ty, ...} =
-                                 Vector.sub (statements, i)
-                           in
-                              if Exp.isProfile exp
-                                 then loop (i + 1,
-                                            Statement.T {exp = exp,
-                                                         ty = ty,
-                                                         var = NONE} :: ac)
-                              else normal ()
-                           end
-                  in
-                     loop (0, [])
-                  end
-*)
                   in
                      if Vector.forall (statements, Statement.isProfile)
-                        andalso (0 = Vector.length xs
-                                 orelse 0 < Vector.length args)
+                        (* andalso (Vector.isEmpty xs *)
+                        (*          orelse not (Vector.isEmpty args)) *)
                         then doit (make {args = extract xs,
                                          profileStmts = profileStmts ()})
                      else normal ()

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2011,2017,2019,2022 Matthew Fluet.
+(* Copyright (C) 2009,2011,2017,2019,2022,2025 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -321,8 +321,10 @@ fun shrinkFunction {globals: Statement.t vector} =
                fun normal () = doit LabelMeaning.Block
                fun canMove () =
                   Vector.toListMap
-                  (statements, fn Statement.T {exp, ty, ...} =>
-                   Statement.T {exp = exp, ty = ty, var = NONE})
+                  (statements, fn Statement.T {exp, ...} =>
+                   if Exp.isProfile exp
+                      then Statement.T {exp = exp, ty = Type.unit, var = NONE}
+                   else Error.bug "Ssa.Shrink.computeMeaning.canMove: not Exp.isProfile")
                fun rr (xs: Var.t vector, make) =
                   let
                      val _ = incVars xs

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -767,35 +767,35 @@ fun shrinkFunction {globals: Statement.t vector} =
                                     (ps,
                                      fn (i, Position.Formal i') => i = i'
                                       | _ => false)
-                                 val m = labelMeaning cont
+                                 val contMeaning = labelMeaning cont
                                  fun nonTail handler =
                                     let
-                                       val _ = forceMeaningBlock m
+                                       val _ = forceMeaningBlock contMeaning
                                        val handler =
                                           Handler.map
                                           (handler, fn l =>
                                            let
-                                              val m = labelMeaning l
-                                              val _ = forceMeaningBlock m
+                                              val handlerMeaning = labelMeaning l
+                                              val _ = forceMeaningBlock handlerMeaning
                                            in
-                                              meaningLabel m
+                                              meaningLabel handlerMeaning
                                            end)
                                     in
                                        ([],
-                                        Return.NonTail {cont = meaningLabel m,
+                                        Return.NonTail {cont = meaningLabel contMeaning,
                                                         handler = handler})
                                     end
-                                 fun tail statements =
-                                    (deleteLabelMeaning m
-                                     ; (statements, Return.Tail))
-                                 fun cont (handler, handlerEta) =
-                                    case LabelMeaning.aux m of
+                                 fun tail profileStatements =
+                                    (deleteLabelMeaning contMeaning
+                                     ; (profileStatements, Return.Tail))
+                                 fun cont (handler, handlerProfileStatements) =
+                                    case LabelMeaning.aux contMeaning of
                                        LabelMeaning.Bug =>
-                                          (case handlerEta of
+                                          (case handlerProfileStatements of
                                               NONE => nonTail handler
                                             | SOME profileStmts => tail profileStmts)
                                      | LabelMeaning.Return {args, profileStmts} =>
-                                          if isEta (m, args)
+                                          if isEta (contMeaning, args)
                                              then tail profileStmts
                                           else nonTail handler
                                      | _ => nonTail handler
@@ -805,12 +805,12 @@ fun shrinkFunction {globals: Statement.t vector} =
                                   | Handler.Dead => cont (handler, NONE)
                                   | Handler.Handle l =>
                                        let
-                                          val m = labelMeaning l
+                                          val handlerMeaning = labelMeaning l
                                        in
-                                          case LabelMeaning.aux m of
+                                          case LabelMeaning.aux handlerMeaning of
                                              LabelMeaning.Bug => cont (handler, NONE)
                                            | LabelMeaning.Raise {args, profileStmts} =>
-                                                if isEta (m, args)
+                                                if isEta (handlerMeaning, args)
                                                    then cont (if List.isEmpty profileStmts
                                                                  then Handler.Caller
                                                                  else handler,

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -794,9 +794,15 @@ fun shrinkFunction {globals: Statement.t vector} =
                                        LabelMeaning.Bug =>
                                           (case handlerProfileStatements of
                                               NONE => nonTail handler
-                                            | SOME profileStmts => tail profileStmts)
+                                            | SOME profileStmts =>
+                                                 if List.isEmpty profileStmts
+                                                    orelse !Control.profileTailCallOpt
+                                                    then tail profileStmts
+                                                 else nonTail handler)
                                      | LabelMeaning.Return {args, profileStmts} =>
                                           if isEta (contMeaning, args)
+                                             andalso (List.isEmpty profileStmts
+                                                      orelse !Control.profileTailCallOpt)
                                              then tail profileStmts
                                           else nonTail handler
                                      | _ => nonTail handler

--- a/mlton/ssa/shrink.fun
+++ b/mlton/ssa/shrink.fun
@@ -303,17 +303,25 @@ fun shrinkFunction {globals: Statement.t vector} =
                val _ =
                   Vector.foreach
                   (statements, fn s => Exp.foreachVar (Statement.exp s, incVar))
-               fun extract (actuals: Var.t vector): Positions.t =
-                  let
-                     val {get: Var.t -> Position.t, set, destroy} =
-                        Property.destGetSetOnce
-                        (Var.plist, Property.initFun Position.Free)
-                     val _ = Vector.foreachi (args, fn (i, (x, _)) =>
-                                              set (x, Position.Formal i))
-                     val ps = Vector.map (actuals, get)
-                     val _ = destroy ()
-                  in ps
-                  end
+               local
+                  fun mk (f: (Var.t -> Position.t) -> 'a) : 'a =
+                     let
+                        val {get: Var.t -> Position.t, set, destroy} =
+                           Property.destGetSetOnce
+                           (Var.plist, Property.initFun Position.Free)
+                        val _ = Vector.foreachi (args, fn (i, (x, _)) =>
+                                                 set (x, Position.Formal i))
+                        val res = f get
+                        val _ = destroy ()
+                     in
+                        res
+                     end
+               in
+                  fun extractOne (var: Var.t): Position.t =
+                     mk (fn get => get var)
+                  fun extract (vars: Var.t vector): Positions.t =
+                     mk (fn get => Vector.map (vars, get))
+               end
                fun doit aux =
                   LabelMeaning.T {aux = aux,
                                   blockIndex = i,
@@ -391,12 +399,12 @@ fun shrinkFunction {globals: Statement.t vector} =
                               then m (* It's an eta. *)
                            else
                            let
-                              val ps = extract actuals
+                              val actuals = extract actuals
                               val n =
                                  Vector.fold (args, 0, fn ((x, _), n) =>
                                               n + numVarOccurrences x)
                               val n' =
-                                 Vector.fold (ps, 0, fn (p, n) =>
+                                 Vector.fold (actuals, 0, fn (p, n) =>
                                               case p of
                                                  Position.Formal _ => n + 1
                                                | _ => n)
@@ -407,23 +415,18 @@ fun shrinkFunction {globals: Statement.t vector} =
                                        ; normal ())
                               else
                                  let
-                                    fun extract (ps': Positions.t)
-                                       : Positions.t =
-                                       Vector.map
-                                       (ps', fn p =>
-                                        let
-                                           datatype z = datatype Position.t
-                                        in
-                                           case p of
-                                              Free x => Free x
-                                            | Formal i => Vector.sub (ps, i)
-                                        end)
+                                    fun updateOne (p: Position.t) : Position.t =
+                                       case p of
+                                          Position.Free x => extractOne x
+                                        | Position.Formal i => Vector.sub (actuals, i)
+                                    fun update (ps: Positions.t) : Positions.t =
+                                       Vector.map (ps, updateOne)
                                     val profileStmts' = profileStmts ()
                                     val a =
                                        case LabelMeaning.aux m of
                                           Block =>
                                              Goto {dst = m,
-                                                   args = ps,
+                                                   args = actuals,
                                                    profileStmts = profileStmts'}
                                         | Bug =>
                                              if (case returns of
@@ -434,21 +437,21 @@ fun shrinkFunction {globals: Statement.t vector} =
                                                         Type.equals (t, t')))
                                                 then Bug
                                              else Goto {dst = m,
-                                                        args = ps,
+                                                        args = actuals,
                                                         profileStmts = profileStmts'}
                                         | Case _ => 
                                              Goto {dst = m,
-                                                   args = ps,
+                                                   args = actuals,
                                                    profileStmts = profileStmts'}
                                         | Goto {dst, args, profileStmts} =>
                                              Goto {dst = dst,
-                                                   args = extract args,
+                                                   args = update args,
                                                    profileStmts = profileStmts' @ profileStmts}
                                         | Raise {args, profileStmts} =>
-                                             Raise {args = extract args,
+                                             Raise {args = update args,
                                                     profileStmts = profileStmts' @ profileStmts}
                                         | Return {args, profileStmts} =>
-                                             Return {args = extract args,
+                                             Return {args = update args,
                                                      profileStmts = profileStmts' @ profileStmts}
                                  in
                                     doit a

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -805,9 +805,15 @@ fun shrinkFunction {globals: Statement.t vector} =
                                        LabelMeaning.Bug =>
                                           (case handlerProfileStatements of
                                               NONE => nonTail handler
-                                            | SOME profileStmts => tail profileStmts)
+                                            | SOME profileStmts =>
+                                                 if List.isEmpty profileStmts
+                                                    orelse !Control.profileTailCallOpt
+                                                    then tail profileStmts
+                                                 else nonTail handler)
                                      | LabelMeaning.Return {args, profileStmts} =>
                                           if isEta (contMeaning, args)
+                                             andalso (List.isEmpty profileStmts
+                                                      orelse !Control.profileTailCallOpt)
                                              then tail profileStmts
                                           else nonTail handler
                                      | _ => nonTail handler

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -824,7 +824,8 @@ fun shrinkFunction {globals: Statement.t vector} =
                                            | LabelMeaning.Raise {args, profileStmts} =>
                                                 if isEta (handlerMeaning, args)
                                                    then cont (if List.isEmpty profileStmts
-                                                                 then Handler.Caller
+                                                                 then (deleteLabel l
+                                                                       ; Handler.Caller)
                                                                  else handler,
                                                               SOME profileStmts)
                                                 else nonTail handler

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -778,35 +778,35 @@ fun shrinkFunction {globals: Statement.t vector} =
                                     (ps,
                                      fn (i, Position.Formal i') => i = i'
                                       | _ => false)
-                                 val m = labelMeaning cont
+                                 val contMeaning = labelMeaning cont
                                  fun nonTail handler =
                                     let
-                                       val () = forceMeaningBlock m
+                                       val () = forceMeaningBlock contMeaning
                                        val handler =
                                           Handler.map
                                           (handler, fn l =>
                                            let
-                                              val m = labelMeaning l
-                                              val () = forceMeaningBlock m
+                                              val handlerMeaning = labelMeaning l
+                                              val () = forceMeaningBlock handlerMeaning
                                            in
-                                              meaningLabel m
+                                              meaningLabel handlerMeaning
                                            end)
                                     in
                                        ([],
-                                        Return.NonTail {cont = meaningLabel m,
+                                        Return.NonTail {cont = meaningLabel contMeaning,
                                                         handler = handler})
                                     end
-                                 fun tail statements =
-                                    (deleteLabelMeaning m
-                                     ; (statements, Return.Tail))
-                                 fun cont (handler, handlerEta) =
-                                    case LabelMeaning.aux m of
+                                 fun tail profileStatements =
+                                    (deleteLabelMeaning contMeaning
+                                     ; (profileStatements, Return.Tail))
+                                 fun cont (handler, handlerProfileStatements) =
+                                    case LabelMeaning.aux contMeaning of
                                        LabelMeaning.Bug =>
-                                          (case handlerEta of
+                                          (case handlerProfileStatements of
                                               NONE => nonTail handler
                                             | SOME profileStmts => tail profileStmts)
                                      | LabelMeaning.Return {args, profileStmts} =>
-                                          if isEta (m, args)
+                                          if isEta (contMeaning, args)
                                              then tail profileStmts
                                           else nonTail handler
                                      | _ => nonTail handler
@@ -816,12 +816,12 @@ fun shrinkFunction {globals: Statement.t vector} =
                                   | Handler.Dead => cont (handler, NONE)
                                   | Handler.Handle l =>
                                        let
-                                          val m = labelMeaning l
+                                          val handlerMeaning = labelMeaning l
                                        in
-                                          case LabelMeaning.aux m of
+                                          case LabelMeaning.aux handlerMeaning of
                                              LabelMeaning.Bug => cont (handler, NONE)
                                            | LabelMeaning.Raise {args, profileStmts} =>
-                                                if isEta (m, args)
+                                                if isEta (handlerMeaning, args)
                                                    then cont (if List.isEmpty profileStmts
                                                                  then Handler.Caller
                                                                  else handler,

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2011,2017,2019,2022 Matthew Fluet.
+(* Copyright (C) 2009,2011,2017,2019,2022,2025 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -331,7 +331,11 @@ fun shrinkFunction {globals: Statement.t vector} =
                                   label = Block.label (Vector.sub (blocks, i))}
                fun normal () = doit LabelMeaning.Block
                fun canMove () =
-                  Vector.toList statements
+                  Vector.toListMap
+                  (statements, fn stmt =>
+                   if Statement.isProfile stmt
+                      then stmt
+                   else Error.bug "Ssa2.Shrink.computeMeaning.canMove: not Statement.isProfile")
                fun rr (xs: Var.t vector, make) =
                   let
                      val () = incVars xs

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -339,32 +339,10 @@ fun shrinkFunction {globals: Statement.t vector} =
                fun rr (xs: Var.t vector, make) =
                   let
                      val () = incVars xs
-(*
-                     val n = Vector.length statements
-                     fun loop (i, ac) =
-                        if i = n
-                           then
-                              if 0 = Vector.length xs
-                                 orelse 0 < Vector.length args
-                                 then doit (make {args = extract xs,
-                                                  profileStmts = rev ac})
-                              else normal ()
-                        else
-                           let
-                              val s = Vector.sub (statements, i)
-                           in
-                              if Statement.isProfile s
-                                 then loop (i + 1, s :: ac)
-                              else normal ()
-                           end
-                  in
-                     loop (0, [])
-                  end
-*)
                   in
                      if Vector.forall (statements, Statement.isProfile)
-                        andalso (0 = Vector.length xs
-                                 orelse 0 < Vector.length args)
+                        (* andalso (Vector.isEmpty xs *)
+                        (*          orelse not (Vector.isEmpty args)) *)
                         then doit (make {args = extract xs,
                                          profileStmts = profileStmts ()})
                      else normal ()

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -798,6 +798,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                                     end
                                  fun tail profileStatements =
                                     (deleteLabelMeaning contMeaning
+                                     ; Handler.foreachLabel (handler, deleteLabel)
                                      ; (profileStatements, Return.Tail))
                                  fun cont (handler, handlerProfileStatements) =
                                     case LabelMeaning.aux contMeaning of

--- a/mlton/ssa/shrink2.fun
+++ b/mlton/ssa/shrink2.fun
@@ -130,16 +130,16 @@ structure LabelMeaning =
       and aux =
          Block
        | Bug
-       | Case of {canMove: Statement.t list,
-                  cases: (Con.t, Label.t) Cases.t,
-                  default: Label.t option}
-       | Goto of {canMove: Statement.t list,
-                  dst: t,
-                  args: Positions.t}
+       | Case of {cases: (Con.t, Label.t) Cases.t,
+                  default: Label.t option,
+                  profileStmts: Statement.t list}
+       | Goto of {dst: t,
+                  args: Positions.t,
+                  profileStmts: Statement.t list}
        | Raise of {args: Positions.t,
-                   canMove: Statement.t list}
+                   profileStmts: Statement.t list}
        | Return of {args: Positions.t,
-                    canMove: Statement.t list}
+                    profileStmts: Statement.t list}
 
       local
          fun make f (T r) = f r
@@ -330,12 +330,12 @@ fun shrinkFunction {globals: Statement.t vector} =
                                   blockIndex = i,
                                   label = Block.label (Vector.sub (blocks, i))}
                fun normal () = doit LabelMeaning.Block
-               fun canMove () =
+               fun profileStmts () =
                   Vector.toListMap
                   (statements, fn stmt =>
                    if Statement.isProfile stmt
                       then stmt
-                   else Error.bug "Ssa2.Shrink.computeMeaning.canMove: not Statement.isProfile")
+                   else Error.bug "Ssa2.Shrink.computeMeaning.profileStmts: not Statement.isProfile")
                fun rr (xs: Var.t vector, make) =
                   let
                      val () = incVars xs
@@ -347,7 +347,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                               if 0 = Vector.length xs
                                  orelse 0 < Vector.length args
                                  then doit (make {args = extract xs,
-                                                  canMove = rev ac})
+                                                  profileStmts = rev ac})
                               else normal ()
                         else
                            let
@@ -366,7 +366,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                         andalso (0 = Vector.length xs
                                  orelse 0 < Vector.length args)
                         then doit (make {args = extract xs,
-                                         canMove = canMove ()})
+                                         profileStmts = profileStmts ()})
                      else normal ()
                   end
             in
@@ -400,9 +400,9 @@ fun shrinkFunction {globals: Statement.t vector} =
                            andalso 1 = numVarOccurrences test
                            andalso Var.equals (test, #1 (Vector.first args))
                            then
-                              doit (LabelMeaning.Case {canMove = canMove (),
-                                                       cases = cases,
-                                                       default = default})
+                              doit (LabelMeaning.Case {cases = cases,
+                                                       default = default,
+                                                       profileStmts = profileStmts ()})
                         else
                            normal ()
                      end
@@ -451,13 +451,13 @@ fun shrinkFunction {globals: Statement.t vector} =
                                               Free x => Free x
                                             | Formal i => Vector.sub (ps, i)
                                         end)
-                                    val canMove' = canMove ()
+                                    val profileStmts' = profileStmts ()
                                     val a =
                                        case LabelMeaning.aux m of
                                           Block =>
-                                             Goto {canMove = canMove',
-                                                   dst = m,
-                                                   args = ps}
+                                             Goto {dst = m,
+                                                   args = ps,
+                                                   profileStmts = profileStmts'}
                                         | Bug =>
                                              if (case returns of
                                                     NONE => true
@@ -466,23 +466,23 @@ fun shrinkFunction {globals: Statement.t vector} =
                                                        (ts, args, fn (t, (_, t')) =>
                                                         Type.equals (t, t')))
                                                 then Bug
-                                             else Goto {canMove = canMove',
-                                                        dst = m,
-                                                        args = ps}
+                                             else Goto {dst = m,
+                                                        args = ps,
+                                                        profileStmts = profileStmts'}
                                        | Case _ =>
-                                             Goto {canMove = canMove',
-                                                   dst = m,
-                                                   args = ps}
-                                        | Goto {canMove, dst, args} =>
-                                             Goto {canMove = canMove' @ canMove,
+                                             Goto {dst = m,
+                                                   args = ps,
+                                                   profileStmts = profileStmts'}
+                                        | Goto {dst, args, profileStmts} =>
+                                             Goto {profileStmts = profileStmts' @ profileStmts,
                                                    dst = dst,
                                                    args = extract args}
-                                        | Raise {args, canMove} =>
+                                        | Raise {args, profileStmts} =>
                                              Raise {args = extract args,
-                                                    canMove = canMove' @ canMove}
-                                        | Return {args, canMove} =>
+                                                    profileStmts = profileStmts' @ profileStmts}
+                                        | Return {args, profileStmts} =>
                                              Return {args = extract args,
-                                                     canMove = canMove' @ canMove}
+                                                     profileStmts = profileStmts' @ profileStmts}
                                  in
                                     doit a
                                  end
@@ -705,12 +705,11 @@ fun shrinkFunction {globals: Statement.t vector} =
          val traceSimplifyCase =
             Trace.trace
             ("Ssa2.Shrink2.simplifyCase",
-             fn {canMove, cases, default, test, ...} =>
-             Layout.record [("canMove", List.layout Statement.layout canMove),
-                            ("cantSimplify", Layout.str "fn () => ..."),
+             fn {cases, default, profileStmts, test, ...} =>
+             Layout.record [("cantSimplify", Layout.str "fn () => ..."),
                             ("gone", Layout.str "fn () => ..."),
-                            ("test", VarInfo.layout test),
-                            ("cases/default",
+                            ("profileStmts", List.layout Statement.layout profileStmts),
+                            ("test/cases/default",
                              (Transfer.layout o Transfer.Case)
                              {cases = cases,
                               default = default,
@@ -740,16 +739,16 @@ fun shrinkFunction {globals: Statement.t vector} =
                                 | Position.Free x => x)
                    val (statements, transfer) =
                       let
-                         fun rr ({args, canMove}, make) =
-                            (canMove, make (Vector.map (args, use o extract)))
+                         fun rr ({args, profileStmts}, make) =
+                            (profileStmts, make (Vector.map (args, use o extract)))
                          datatype z = datatype LabelMeaning.aux
                       in
                          case aux of
                             Block => simplifyBlock ([], block)
                           | Bug => ([], Transfer.Bug)
                           | Case _ => simplifyBlock ([], block)
-                          | Goto {canMove, dst, args} =>
-                               gotoMeaning (canMove,
+                          | Goto {dst, args, profileStmts} =>
+                               gotoMeaning (profileStmts,
                                             dst,
                                             Vector.map (args, extract))
                           | Raise z => rr (z, Transfer.Raise)
@@ -767,12 +766,12 @@ fun shrinkFunction {globals: Statement.t vector} =
                 end) arg
          and simplifyBlock arg : Statement.t list * Transfer.t =
             traceSimplifyBlock
-            (fn (canMoveIn, Block.T {statements, transfer, ...}) =>
+            (fn (profileStmtsIn, Block.T {statements, transfer, ...}) =>
             let
                val f = evalStatements statements
                val (ss, transfer) = simplifyTransfer transfer
             in
-               (canMoveIn @ (f ss), transfer)
+               (profileStmtsIn @ (f ss), transfer)
             end) arg
          and evalStatements (ss: Statement.t vector)
             : Statement.t list -> Statement.t list =
@@ -827,10 +826,10 @@ fun shrinkFunction {globals: Statement.t vector} =
                                        LabelMeaning.Bug =>
                                           (case handlerEta of
                                               NONE => nonTail handler
-                                            | SOME canMove => tail canMove)
-                                     | LabelMeaning.Return {args, canMove} =>
+                                            | SOME profileStmts => tail profileStmts)
+                                     | LabelMeaning.Return {args, profileStmts} =>
                                           if isEta (m, args)
-                                             then tail canMove
+                                             then tail profileStmts
                                           else nonTail handler
                                      | _ => nonTail handler
                               in
@@ -843,12 +842,12 @@ fun shrinkFunction {globals: Statement.t vector} =
                                        in
                                           case LabelMeaning.aux m of
                                              LabelMeaning.Bug => cont (handler, NONE)
-                                           | LabelMeaning.Raise {args, canMove} =>
+                                           | LabelMeaning.Raise {args, profileStmts} =>
                                                 if isEta (m, args)
-                                                   then cont (if List.isEmpty canMove
+                                                   then cont (if List.isEmpty profileStmts
                                                                  then Handler.Caller
                                                                  else handler,
-                                                              SOME canMove)
+                                                              SOME profileStmts)
                                                 else nonTail handler
                                            | _ => nonTail handler
                                        end
@@ -870,12 +869,12 @@ fun shrinkFunction {globals: Statement.t vector} =
                                 default = Option.map (default, simplifyLabel)})
                    in
                       simplifyCase
-                      {canMove = [],
-                       cantSimplify = cantSimplify,
+                      {cantSimplify = cantSimplify,
                        cases = cases,
                        default = default,
                        gone = fn () => (Cases.foreach (cases, deleteLabel)
                                         ; Option.app (default, deleteLabel)),
+                       profileStmts = [],
                        test = test}
                    end
               | Goto {dst, args} => goto (dst, varInfos args)
@@ -888,8 +887,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                    ) arg
          and simplifyCase arg : Statement.t list * Transfer.t =
             traceSimplifyCase
-            (fn {canMove, cantSimplify,
-                 cases, default, gone, test: VarInfo.t} =>
+            (fn {cantSimplify, cases, default, gone, profileStmts, test: VarInfo.t} =>
             let
                (* tryToEliminate makes sure that the destination meaning
                 * hasn't already been simplified.  If it has, then we can't
@@ -906,7 +904,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                            val () = addLabelIndex i
                            val () = gone ()
                         in
-                           gotoMeaning (canMove, m, Vector.new0 ())
+                           gotoMeaning (profileStmts, m, Vector.new0 ())
                         end
                   end
             in
@@ -942,7 +940,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                                        val () = addLabelMeaning m
                                        val () = gone ()
                                     in
-                                       gotoMeaning (canMove, m, args)
+                                       gotoMeaning (profileStmts, m, args)
                                     end
                                  fun loop k =
                                     if k = n
@@ -993,7 +991,7 @@ fun shrinkFunction {globals: Statement.t vector} =
             gotoMeaning ([], labelMeaning dst, args)
          and gotoMeaning arg : Statement.t list * Transfer.t =
             traceGotoMeaning
-            (fn (canMoveIn,
+            (fn (profileStmtsIn,
                  m as LabelMeaning.T {aux, blockIndex = i, ...},
                  args: VarInfo.t vector) =>
              let
@@ -1010,13 +1008,13 @@ fun shrinkFunction {globals: Statement.t vector} =
                                (Block.args b, args, fn ((x, _), vi) =>
                                 setVarInfo (x, vi))
                          in
-                            simplifyBlock (canMoveIn, b)
+                            simplifyBlock (profileStmtsIn, b)
                          end
                    else
                       let
                          val () = forceMeaningBlock m
                       in
-                         (canMoveIn,
+                         (profileStmtsIn,
                           Goto {dst = Block.label (Vector.sub (blocks, i)),
                                 args = uses args})
                       end
@@ -1024,22 +1022,22 @@ fun shrinkFunction {globals: Statement.t vector} =
                    case p of
                       Position.Formal n => Vector.sub (args, n)
                     | Position.Free x => varInfo x
-                fun rr ({args, canMove}, make) =
-                   (canMoveIn @ canMove,
+                fun rr ({args, profileStmts}, make) =
+                   (profileStmtsIn @ profileStmts,
                     make (Vector.map (args, use o extract)))
                 datatype z = datatype LabelMeaning.aux
              in
                 case aux of
                    Block => normal ()
-                 | Bug => ((*canMoveIn*)[], Transfer.Bug)
-                 | Case {canMove, cases, default} =>
-                      simplifyCase {canMove = canMoveIn @ canMove,
-                                    cantSimplify = normal,
+                 | Bug => ((*profileStmtsIn*)[], Transfer.Bug)
+                 | Case {profileStmts, cases, default} =>
+                      simplifyCase {cantSimplify = normal,
                                     cases = cases,
                                     default = default,
                                     gone = fn () => deleteLabelMeaning m,
+                                    profileStmts = profileStmtsIn @ profileStmts,
                                     test = Vector.first args}
-                 | Goto {canMove, dst, args} =>
+                 | Goto {dst, args, profileStmts} =>
                       if Array.sub (isHeader, i)
                          orelse Array.sub (isBlock, i)
                          then normal ()
@@ -1052,7 +1050,7 @@ fun shrinkFunction {globals: Statement.t vector} =
                                   then addLabelMeaning dst
                                else ()
                          in
-                            gotoMeaning (canMoveIn @ canMove,
+                            gotoMeaning (profileStmtsIn @ profileStmts,
                                          dst,
                                          Vector.map (args, extract))
                          end

--- a/mlton/ssa/ssa-tree.fun
+++ b/mlton/ssa/ssa-tree.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2014,2017-2020,2024 Matthew Fluet.
+(* Copyright (C) 2009,2014,2017-2020,2024-2025 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -442,6 +442,10 @@ structure Exp =
       end
 
       val hash = Trace.trace ("SsaTree.Exp.hash", layout, Word.layout) hash
+
+      val isProfile =
+         fn Profile _ => true
+          | _ => false
    end
 datatype z = datatype Exp.t
 
@@ -543,6 +547,8 @@ structure Statement =
          in
             global
          end
+
+      fun isProfile (T {exp, ...}) = Exp.isProfile exp
    end
 
 structure Transfer =

--- a/mlton/ssa/ssa-tree.sig
+++ b/mlton/ssa/ssa-tree.sig
@@ -1,4 +1,4 @@
-(* Copyright (C) 2009,2017,2019 Matthew Fluet.
+(* Copyright (C) 2009,2017,2019,2025 Matthew Fluet.
  * Copyright (C) 1999-2008 Henry Cejtin, Matthew Fluet, Suresh
  *    Jagannathan, and Stephen Weeks.
  * Copyright (C) 1997-2000 NEC Research Institute.
@@ -87,6 +87,7 @@ signature SSA_TREE =
             val equals: t * t -> bool
             val foreachVar: t * (Var.t -> unit) -> unit
             val hash: t -> Word.t
+            val isProfile: t -> bool
             val layout: t -> Layout.t
             val maySideEffect: t -> bool
             val replaceVar: t * (Var.t -> Var.t) -> t
@@ -102,6 +103,7 @@ signature SSA_TREE =
 
             val clear: t -> unit (* clear the var *)
             val exp: t -> Exp.t
+            val isProfile: t -> bool
             val layout: t -> Layout.t
             val profile: ProfileExp.t -> t
             val var: t -> Var.t option


### PR DESCRIPTION
Add `-profile-tail-call-opt {true|false}` expert compile-time option.  The `-profile-tail-call-opt {true|false}` controls whether or not the SSA{,2} shrinker optimizes tail calls in the presence of profiling.

Add `-profile-tail-call-opt {true|false}` expert compile-time option.  The `-profile-intro-loops-opt {true|false}` controls whether or not the SSA IntroduceLoops optimization applies in presence of profiling and `-profile-tail-call-opt false`, when the SSA{,2} shrinker does not optimize tail calls in the presence of profiling.  In particular, when `-profile-tail-call-opt false` but `-profile-intro-loops-opt true`, then IntroduceLoops will recognize self non-tail calls with eta return and handler continuations as tail calls.

`-profile-tail-call-opt false` and `-profile-intro-loops-opt false` is expected to have a significant performance penalty, but can improve the accuracy of exception history.  It likely worsens the accuracy of time profiling, since the profiled program (without tail call and introduce loops optimizations) will be significantly different from the non-profiled program (with tail call and introduce loops optimizations).

`-profile-tail-call-opt false` and `-profile-intro-loops-opt true` is expected to recover some of the performance penalty, at the expense of less accurate exception history; the exception history will have only one entry for the recursive function, even if the exception is raised by a deeply nested recursive (tail) call.

Profiling results:
```
config command                                                                                                                                                                                       
C02    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen amd64                                                                          
C03    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen amd64 -profile drop -profile-tail-call-opt true -profile-intro-loops-opt true  
C04    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen amd64 -profile drop -profile-tail-call-opt false -profile-intro-loops-opt true 
C05    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen amd64 -profile drop -profile-tail-call-opt false -profile-intro-loops-opt false
C08    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen c                                                                              
C09    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen c -profile drop -profile-tail-call-opt true -profile-intro-loops-opt true      
C10    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen c -profile drop -profile-tail-call-opt false -profile-intro-loops-opt true     
C11    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen c -profile drop -profile-tail-call-opt false -profile-intro-loops-opt false    
C14    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen llvm                                                                           
C15    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen llvm -profile drop -profile-tail-call-opt true -profile-intro-loops-opt true   
C16    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen llvm -profile drop -profile-tail-call-opt false -profile-intro-loops-opt true  
C17    /home/mtf/devel/mlton/builds/gc0622b9f4/bin/mlton @MLton max-heap 4G -- -runtime max-heap -runtime 4G -codegen llvm -profile drop -profile-tail-call-opt false -profile-intro-loops-opt false 

task_clock ratio_means.fieller@0.95 (2-level)
program           `C03/C02` `C04/C02` `C05/C02` `C09/C08` `C10/C08` `C11/C08` `C15/C14` `C16/C14` `C17/C14`
barnes-hut           1.107     1.055     1.214     1.131     0.9522    1.264     0.9007    0.9306    0.9785
boyer                1.053     1.372     1.339     1.233     1.429     1.340     1.113     1.314     1.128 
checksum             1.026     1.032    10.34      1.102     1.099    18.20      1.029     1.163    18.62  
count-graphs         1.036     1.117     2.023     1.120     1.260     2.044     1.033     1.133     1.942 
DLXSimulator         1.050     1.042     2.450     1.020     1.039     2.519     1.130     0.9209    2.201 
fft                  1.038     1.076     1.692     0.9071    0.8427    1.476     1.101     1.114     1.682 
fib                  1.183     1.209     1.273     1.143     1.174     1.128     1.299     1.231     1.288 
flat-array           1.010     0.9847    3.701     0.9900    0.9762    3.655     1.212     1.262     3.145 
hamlet               1.035     1.022     1.210     1.047     1.029     1.414     1.040     1.097     1.281 
imp-for              1.072     1.034     5.059     1.023     1.044     6.872 
knuth-bendix         1.231     1.346     1.387     1.151     1.382     1.302     1.220     1.571     1.382 
lexgen               1.090     1.034     1.647     1.066     1.043     1.602     1.088     0.9897    1.535 
life                 0.9971    0.9810    2.423     0.9802    1.045     2.443     0.9818    0.9713    2.124 
logic                1.002     1.512     1.517     0.9268    1.533     1.747     1.063     1.631     1.986 
mandelbrot           0.9804    0.9926    1.754     0.9579    1.072     2.830     1.150     1.097     3.716 
matrix-multiply      0.9985    1.209     3.598     0.9716    1.096     6.408     0.9968    0.9880    8.000 
md5                  0.9943    0.9730    1.050     1.081     1.130     1.102     1.021     1.030     1.057 
merge                0.9251    1.146     1.262     0.9866    0.9012    1.009     0.9017    0.8910    1.075 
mlyacc               1.029     1.053     1.011     0.9717    1.020     1.025     1.050     1.033     1.072 
model-elimination    1.147     1.055     1.638     1.075     1.059     1.911     1.058     1.003     1.971 
mpuz                 1.059     1.077     3.122     1.020     1.094     3.827     0.9822    1.024     4.534 
nucleic              1.033     1.128     1.140     1.047     0.9743    1.053     0.9830    1.057     1.174 
peek                 1.059     1.026     3.912     1.010     1.066     7.083     0.9948    1.001     8.791 
pidigits             0.9842    0.9689    1.124     1.098     0.9231    1.125     1.110     0.9834    1.116 
ratio-regions        0.9516    1.087     6.217     1.118     1.059     7.095     1.020     0.9765    6.952 
ray                  1.067     1.077     1.242     0.9726    1.001     1.078     0.9786    1.001     1.146 
raytrace             0.9722    1.040     1.306     1.010     1.142     1.384     1.109     1.240     1.581 
simple               1.353     1.144     1.566     1.170     0.9980    1.103     1.122     0.9829    1.294 
smith-normal-form    0.9465    0.9540    0.9851    1.026     0.9895    0.9820    0.8872    0.9533    1.039 
string-concat        0.9844    0.9919    8.312     1.024     1.193     7.942     0.9610    0.9303    9.124 
tailmerge            1.051     1.003     1.980     1.044     0.9581    1.729     1.073     0.9661    1.723 
tak                  1.304     1.382     1.691     1.159     1.110     1.591     1.088     1.023     1.306 
tensor               0.9748    0.9561    2.294     1.143     1.190     3.024 
tsp                  1.056     1.036     1.217     0.9907    1.016     1.523     1.002     1.033     1.597 
tyan                 1.201     1.161     1.533     1.010     1.026     1.253     1.003     1.083     1.537 
vector-rev           1.042     1.131     9.978     0.8691    0.9528   11.91      1.016     0.9505   13.12  
vector32-concat      0.8325    0.9266    6.271     1.096     1.078     7.314     0.8915    0.9622    9.874 
vector64-concat      0.9219    1.081     5.738     0.9804    0.9389    3.569     0.8714    0.8335    5.495 
vliw                 1.132     1.055     1.460     0.8508    1.159     1.796     1.019     1.109     2.006 
wc-input1            1.016     1.032    11.17      0.8939    0.9587   11.11      0.9507    1.012    11.02  
wc-scanStream        1.005     1.121    18.73      0.9619    1.026    11.54      0.9254    0.9501   16.69  
zebra                1.082     1.059     2.532     1.082     1.091     3.880     1.044     1.003     4.285 
zern                 0.9558    1.008     1.755     1.062     1.033     1.952     0.9511    1.015     2.039 
MIN                  0.8325    0.9266    0.9851    0.8508    0.8427    0.9820    0.8714    0.8335    0.9785
GMEAN                1.042     1.080     2.334     1.032     1.065     2.474     1.029     1.050     2.555 
MAX                  1.353     1.512    18.73      1.233     1.533    18.20      1.299     1.631    18.62  
```

For the benchmarks that run in all configurations (see below), `-profile-tail-call-opt false -profile-intro-loops-opt false` introduces considerable overhead, while `-profile-tail-call-opt false -profile-intro-loops-opt true` is not significantly worse than `-profile-tail-call-opt true`.

With `-profile-tail-call-opt false -profile-intro-loops-opt false`, `even-odd`, `output1`, `psdes-random`, `reduce`, `tailfib` terminate with `Out of memory with max heap size 4Gb`, due to tail-recursive functions that are normally turned into loops being executed as non-tail-recursive functions with explosive stack growth.

Interestingly, with `-profile-tail-call-opt false -profile-intro-loops-opt true`, `even-odd` also terminates with `Out of memory with max heap size 4Gb`.

With `-codegen llvm`, `imp-for` and `tensor` (with `-profile-tail-call-opt true` or `-profile-tail-call-opt false -profile-intro-loops-opt true`), LLVM is able to completely optimize away the inner loops, leading to run times of 0 (and meaningless run time ratios).

It may be worth considering making `-profile-tail-call-opt false -profile-intro-loops-opt true` the default when `-const 'Exn.keepHistory true'` is used in order to improve the accuracy of exception history.  However, the fact that one benchmark (`even-odd`) exhausts heap with explosive stack growth is worrisome.

See MLton/mlton#609.