### PR TITLE
Replace broken link to 'Asynchronous Exceptions in Haskell' paper

### DIFF
--- a/doc/guide/src/References.adoc
+++ b/doc/guide/src/References.adoc
@@ -482,7 +482,7 @@ ____
 == M
 
  * [[MarlowEtAl01]]
- http://community.haskell.org/~simonmar/papers/async.pdf[Asynchronous Exceptions in Haskell].
+ https://simonmar.github.io/bib/papers/async.pdf[Asynchronous Exceptions in Haskell].
  Simon Marlow, Simon Peyton Jones, Andy Moran and John Reppy.
  <<#PLDI>> 2001.
 +


### PR DESCRIPTION
The previous link returned a 404. 
https://community.haskell.org/~simonmar/papers/async.pdf

The new link is hosted on GitHub pages, apparently by one of the authors. 
https://simonmar.github.io/bib/papers/async.pdf