### PR TITLE
Fix bug in `DeepFlatten`, failing to unify elements of `Array_copy{Array,Vector}` args

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 = CHANGELOG
 
+* 2025-10-29
+  ** Fix bug in `DeepFlatten` SSA2 optimization.  Thanks to Tom
+     Schollenberger (tommyscholly) for the bug report.
+
 * 2025-10-04
   ** Fix bug in `Useless` SSA optimization.  Thanks to Humza Shahid
      (hummy123) for the bug report.


### PR DESCRIPTION
The `DeepFlatten` pass failed to unify the flattening of elements of sequences used as arguments of `Array_copy{Array,Vector}`.  Because `Array_copy{Array,Vector}` is compiled to a `memmove`, the elements of the src and dst sequences must share the same representation.

Thanks to Tom Schollenberger (@tommyscholly) for the bug report.