### PR TITLE
Fix bug in `SplitTypes` SSA optimization

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,12 +1,16 @@
 = CHANGELOG
 
+* 2025-12-15
+  ** Fix bug in `SplitTypes` SSA optimization.  Thanks to David Wang
+  for the bug report.
+
 * 2025-10-29
   ** Fix bug in `DeepFlatten` SSA2 optimization.  Thanks to Tom
-     Schollenberger (tommyscholly) for the bug report.
+  Schollenberger (tommyscholly) for the bug report.
 
 * 2025-10-04
   ** Fix bug in `Useless` SSA optimization.  Thanks to Humza Shahid
-     (hummy123) for the bug report.
+  (hummy123) for the bug report.
 
 * 2025-06-23
   ** Add (expert) `-profile-tail-call-opt {always|self-only|never}`

--- a/mlton/ssa/split-types.fun
+++ b/mlton/ssa/split-types.fun
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Jason Carr
+(* Copyright (C) 2018 Jason Carr, 2025 Matthew Fluet.
  *
  * MLton is released under a HPND-style license.
  * See the file MLton-LICENSE for details.
@@ -166,6 +166,12 @@ fun transform (program as Program.T {datatypes, globals, functions, main}) =
                in
                   primBoolInfo
                end
+            fun copyPrim args =
+               let
+                  val _ = TypeInfo.coerce (Vector.sub (args, 2), Vector.sub (args, 0))
+               in
+                  TypeInfo.fromType Type.unit
+               end
             fun default () =
               if case Type.dest resultType of
                       Type.Datatype tycon => Tycon.equals (tycon, primBoolTycon)
@@ -182,6 +188,8 @@ fun transform (program as Program.T {datatypes, globals, functions, main}) =
                   in
                      (ty, TypeInfo.Array)
                   end
+               | Prim.Array_copyArray => copyPrim args
+               | Prim.Array_copyVector => copyPrim args
                | Prim.Array_sub => derefPrim args
                | Prim.Array_toArray => Vector.sub (args, 0)
                | Prim.Array_toVector => Vector.sub (args, 0)


### PR DESCRIPTION
The `Array_copy{Array,Vector}` primitives correspond to a `memcpy` of elements from one sequence to another and require the element types to be the same.  `SplitTypes` was not unifying the `TypeInfo` of the elements of the source and destination sequences, allowing their types to be split, leading to an internal SSA IR type checking error.

Thanks to David Wang for the bug report.